### PR TITLE
Update README with OrcaRouter-Lite repository and deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ OrcaRouter Lite is the open-source single-workspace edition of [OrcaRouter](http
 ## 60-second quickstart
 
 ```bash
-git clone https://github.com/Continuum-AI-Corp/OrcaRouter.git
-cd OrcaRouter/orcarouter-lite
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
 cp .env.example .env
 # add at least one: OPENAI_API_KEY=sk-...  (or ORCAROUTER_API_KEY=...)
 
@@ -150,7 +150,7 @@ for chunk in client.chat.completions.create(
 |---|---|
 | Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
 | Fly.io | `fly launch --dockerfile Dockerfile` |
-| Render | Connect repo, root dir = `orcarouter-lite` |
+| Render | Connect repo, root dir = `.` |
 | Bare Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (image coming soon) |
 
 ## What's in the box


### PR DESCRIPTION
## Summary
Updated README documentation to reflect the standalone OrcaRouter-Lite repository structure and corrected deployment instructions.

## Key Changes
- Updated git clone URL from `OrcaRouter` to `OrcaRouter-Lite` repository
- Simplified quickstart directory navigation from `OrcaRouter/orcarouter-lite` to `OrcaRouter-Lite`
- Corrected Render deployment root directory from `orcarouter-lite` to `.` to match the new repository structure

## Details
These changes align the documentation with the fact that OrcaRouter-Lite is now a standalone repository rather than a subdirectory within the main OrcaRouter project. The deployment instructions have been updated accordingly to reflect the new directory structure.

https://claude.ai/code/session_01K9V6oHwAEfL4DPRZYkaRwK