### PR TITLE
Initialize app instance at module level

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -145,3 +145,6 @@ def create_app() -> FastAPI:
             return RedirectResponse("/health")
 
     return app
+
+
+app = create_app()


### PR DESCRIPTION
## Summary
Added module-level instantiation of the FastAPI application to make the app instance directly importable and usable.

## Key Changes
- Added `app = create_app()` at the end of `app/main.py` to create and export the application instance at module load time

## Implementation Details
Previously, the `create_app()` factory function was defined but not instantiated at the module level. This change ensures that the app instance is created when the module is imported, making it available for:
- Direct import statements (e.g., `from app.main import app`)
- ASGI server configuration (e.g., `uvicorn app.main:app`)
- Simplified application startup patterns

https://claude.ai/code/session_01FQHjk4z8GZ8nyrXMLhtvGa