### PR TITLE
Create /data with orca ownership for SQLite volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,9 @@ COPY packages/ packages/
 COPY design/ design/
 COPY scripts/ scripts/
 
-RUN useradd -m orca && chown -R orca:orca /app
+RUN useradd -m orca \
+    && mkdir -p /data \
+    && chown -R orca:orca /app /data
 USER orca
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- Create `/data` in the runtime image and chown it to `orca` before the `USER orca` switch, so the named SQLite volume mount is writable by the non-root container user.

## Why
After PR #3 fixed the ASGI loader, the next boot failure was:

```
sqlite3.OperationalError: unable to open database file
database_url=sqlite+aiosqlite:////data/orca.db
```

`docker-compose.yml` mounts the named volume `lite-data` at `/data`, but `/data` didn't exist in the image. Docker created the missing mount point as `root:root`, and the container running as `orca` (`Dockerfile:23-24`) couldn't write `orca.db`. Creating `/data` in the image with `orca` ownership lets Docker propagate that ownership to the volume on first mount.

## Test plan
- [ ] `docker compose down -v` (drops any pre-existing root-owned volume)
- [ ] `docker compose up --build`
- [ ] Logs show `✓ orcarouter-lite ready. API key: sk-orca-...` and `Uvicorn running on http://0.0.0.0:8000`
- [ ] `curl -i http://localhost:8000/health` → `200 OK`
- [ ] `http://localhost:8000/` renders the dashboard SPA

https://claude.ai/code/session_01FQHjk4z8GZ8nyrXMLhtvGa

---
_Generated by [Claude Code](https://claude.ai/code/session_01FQHjk4z8GZ8nyrXMLhtvGa)_