### PR TITLE
Add strategy-aware model selection and routing configuration

### DIFF
--- a/app/auto_routing.py
+++ b/app/auto_routing.py
@@ -1,14 +1,16 @@
-"""`model="auto"` — pick the cheapest catalog model that meets the request's
-capability requirements AND has a deployable provider configured.
+"""`model="auto"` — pick a catalog model that meets the request's capability
+requirements AND has a deployable provider configured. Selection rule depends
+on the active routing strategy.
 
 Two pure functions:
   - `required_capabilities(body)`  → set of {"tools", "vision", "json_mode"}
-  - `choose_auto_model(needs, deployable, candidates)` → model_id | None
+  - `choose_auto_model(needs, deployable, candidates, strategy, preferred_models)`
+    → model_id | None
 
 The chat handler resolves `model="auto"` by:
   1. computing needs = required_capabilities(request_body)
   2. computing deployable = {dep.model_name for dep in active_deployments}
-  3. calling choose_auto_model(needs, deployable, CATALOG)
+  3. calling choose_auto_model(...)
   4. swapping the resolved id into the request before calling the router
 
 Adapted from `apps/api/routes/chat.py:_required_capabilities` /
@@ -32,6 +34,25 @@ _CAP_FIELD = {
 # as `apps/api/router_cache.py:_provider_order_key`.
 _INPUT_WEIGHT = 0.3
 _OUTPUT_WEIGHT = 0.7
+
+
+# Map our user-facing strategy names to litellm.Router's `routing_strategy`.
+# `balanced` and `quality` use litellm's default (simple-shuffle, weighted by
+# RPM/TPM) — strategy intent is realised in `choose_auto_model` for `quality`,
+# and is a no-op for `balanced`. `None` means "don't pass routing_strategy".
+STRATEGY_TO_LITELLM: dict[str, str | None] = {
+    "balanced": None,
+    "cheapest": "cost-based-routing",
+    "fastest": "latency-based-routing",
+    "quality": None,
+}
+
+
+def litellm_routing_strategy(strategy: str | None) -> str | None:
+    """Return the litellm `routing_strategy` for a UI strategy, or None."""
+    if not strategy:
+        return None
+    return STRATEGY_TO_LITELLM.get(strategy)
 
 
 def _has_vision_content(messages: list[dict]) -> bool:
@@ -89,8 +110,21 @@ def choose_auto_model(
     needs: set[str],
     deployable: set[str],
     candidates: Iterable[CatalogModel],
+    strategy: str | None = None,
+    preferred_models: list[str] | None = None,
 ) -> str | None:
-    """Return the cheapest deployable model matching all `needs`, or None.
+    """Return a deployable model matching all `needs`, or None.
+
+    Selection rule by strategy:
+      - `quality`: highest blended cost (proxy for "biggest/most-capable")
+      - everything else (`cheapest` / `balanced` / `fastest` / None): lowest
+        blended cost. `fastest` shares the cheapest-capable rule because the
+        catalog has no per-model latency data; ordering across deployments of
+        the same model is handled by litellm's `latency-based-routing`.
+
+    If `preferred_models` is non-empty AND at least one entry is deployable
+    + capability-matching, the eligible set is restricted to that list. This
+    lets users pin a quality tier without giving up auto resolution.
 
     Excludes models with zero blended cost — those are unpriced entries in
     litellm's catalogue, not actually free, and routing to them would skew
@@ -102,7 +136,15 @@ def choose_auto_model(
         and _model_meets(m, needs)
         and _blended_cost(m) > 0
     ]
+    if preferred_models:
+        preferred_set = set(preferred_models)
+        narrowed = [m for m in eligible if m.id in preferred_set]
+        if narrowed:
+            eligible = narrowed
     if not eligible:
         return None
-    eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+    if strategy == "quality":
+        eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
+    else:
+        eligible.sort(key=lambda m: (_blended_cost(m), m.id))
     return eligible[0].id

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -103,8 +103,11 @@ async def get_router(session) -> object:
 
         from sqlalchemy import select
 
+        from app.auto_routing import litellm_routing_strategy
         from app.config import get_settings
+        from app.seed import DEFAULT_WORKSPACE_ID
         from packages.db.models.provider_key import ProviderKey
+        from packages.db.models.routing_config import RoutingConfig
         from packages.litellm_adapter.client import OrcaLiteLLMClient
 
         settings = get_settings()
@@ -119,7 +122,25 @@ async def get_router(session) -> object:
             settings=settings,
         )
 
-        _cached_client = OrcaLiteLLMClient(deployments=deployments)
+        routing_row = (
+            await session.execute(
+                select(RoutingConfig).where(
+                    RoutingConfig.workspace_id == DEFAULT_WORKSPACE_ID,
+                    RoutingConfig.is_deleted == 0,
+                )
+            )
+        ).scalar_one_or_none()
+        strategy = routing_row.strategy if routing_row else "balanced"
+        preferred_models = (
+            list(routing_row.preferred_models or []) if routing_row else []
+        )
+
+        _cached_client = OrcaLiteLLMClient(
+            deployments=deployments,
+            strategy=strategy,
+            preferred_models=preferred_models,
+            litellm_routing_strategy=litellm_routing_strategy(strategy),
+        )
         return _cached_client
 
 

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -46,6 +46,7 @@ async def _build_log_row(
     status_code: int,
     error_type: str | None,
     started_perf: float,
+    strategy: str,
 ) -> RequestLog:
     latency_ms = int((time.perf_counter() - started_perf) * 1000)
     meta = response.get("_orca_meta", {})
@@ -57,7 +58,7 @@ async def _build_log_row(
         model_requested=body.model,
         model_resolved=response.get("model", body.model),
         provider=meta.get("provider", "unknown"),
-        routing_strategy="balanced",
+        routing_strategy=strategy,
         input_tokens=usage.get("prompt_tokens", 0),
         output_tokens=usage.get("completion_tokens", 0),
         cost_microcents=0,
@@ -82,6 +83,10 @@ async def chat_completions(
         )
 
     client = await router_cache.get_router(db)
+    raw_strategy = getattr(client, "strategy", None)
+    strategy = raw_strategy if isinstance(raw_strategy, str) and raw_strategy else "balanced"
+    raw_preferred = getattr(client, "preferred_models", None)
+    preferred_models = raw_preferred if isinstance(raw_preferred, list) else []
 
     # Resolve `model="auto"` BEFORE building the request kwargs so the router
     # sees a real model. Capability requirements come from the request body
@@ -104,7 +109,11 @@ async def chat_completions(
                 ),
             )
         chosen = choose_auto_model(
-            needs=needs, deployable=deployable, candidates=CATALOG,
+            needs=needs,
+            deployable=deployable,
+            candidates=CATALOG,
+            strategy=strategy,
+            preferred_models=preferred_models,
         )
         if chosen is None:
             raise HTTPException(
@@ -152,6 +161,7 @@ async def chat_completions(
                 "_orca_meta": {"provider": "cache", "latency_ms": 0},
             },
             status_code=200, error_type=None, started_perf=started_perf,
+            strategy=strategy,
         )
         log.cost_microcents = 0
         db.add(log)
@@ -165,6 +175,7 @@ async def chat_completions(
                 "x-orca-cache": "HIT",
                 "x-orca-resolved-model": resolved_model,
                 "x-orca-requested-model": requested_model,
+                "x-orca-routing-strategy": strategy,
             },
         )
 
@@ -223,6 +234,7 @@ async def chat_completions(
                     body=body, kc=kc, response=synthetic,
                     status_code=status_code, error_type=error_type,
                     started_perf=started_perf,
+                    strategy=strategy,
                 )
                 db.add(log)
                 try:
@@ -238,6 +250,7 @@ async def chat_completions(
                 "X-Accel-Buffering": "no",
                 "x-orca-resolved-model": resolved_model,
                 "x-orca-requested-model": requested_model,
+                "x-orca-routing-strategy": strategy,
             },
         )
 
@@ -259,6 +272,7 @@ async def chat_completions(
             body=body, kc=kc, response=response if isinstance(response, dict) else {},
             status_code=status_code, error_type=error_type,
             started_perf=started_perf,
+            strategy=strategy,
         )
         db.add(log)
         try:
@@ -282,6 +296,7 @@ async def chat_completions(
             "x-orca-cache": cache_status,
             "x-orca-resolved-model": resolved_model,
             "x-orca-requested-model": requested_model,
+            "x-orca-routing-strategy": strategy,
         },
     )
 

--- a/design/index.html
+++ b/design/index.html
@@ -55,14 +55,35 @@
 
     <section id="panel-routing" class="panel">
       <h2>Routing strategy</h2>
+      <p class="muted">
+        Controls two things: which model <code>model="auto"</code> resolves to,
+        and how LiteLLM Router picks between deployments that serve the same
+        model (e.g. local OpenAI key + hosted upstream).
+      </p>
       <select id="routing-strategy">
-        <option value="balanced">balanced</option>
-        <option value="cheapest">cheapest</option>
-        <option value="fastest">fastest</option>
-        <option value="quality">quality</option>
+        <option value="balanced">balanced — simple-shuffle across deployments; cheapest-capable for auto</option>
+        <option value="cheapest">cheapest — cost-based-routing; cheapest-capable for auto</option>
+        <option value="fastest">fastest — latency-based-routing; cheapest-capable for auto</option>
+        <option value="quality">quality — simple-shuffle; most-expensive-capable for auto (proxy for biggest)</option>
       </select>
       <button id="routing-save">Save</button>
       <p id="routing-status"></p>
+      <details class="routing-help">
+        <summary>How each strategy maps to LiteLLM</summary>
+        <table>
+          <thead><tr><th>Strategy</th><th>litellm routing_strategy</th><th>model="auto" picks</th></tr></thead>
+          <tbody>
+            <tr><td>balanced</td><td><code>simple-shuffle</code> (default, RPM/TPM weighted)</td><td>cheapest capable</td></tr>
+            <tr><td>cheapest</td><td><code>cost-based-routing</code></td><td>cheapest capable</td></tr>
+            <tr><td>fastest</td><td><code>latency-based-routing</code></td><td>cheapest capable</td></tr>
+            <tr><td>quality</td><td><code>simple-shuffle</code></td><td>most expensive capable</td></tr>
+          </tbody>
+        </table>
+        <p class="muted">
+          The strategy in effect is echoed back on every response as the
+          <code>x-orca-routing-strategy</code> header.
+        </p>
+      </details>
     </section>
 
     <section id="panel-analytics" class="panel">

--- a/design/style.css
+++ b/design/style.css
@@ -86,3 +86,9 @@ code { background: var(--bg); padding: 2px 6px; border-radius: 4px; }
   display: none;
 }
 #new-key-display.shown { display: block; }
+
+p.muted { color: var(--muted); font-size: 13px; margin-top: 0; }
+details.routing-help { margin-top: 16px; color: var(--muted); font-size: 13px; }
+details.routing-help summary { cursor: pointer; }
+details.routing-help table { margin-top: 8px; }
+details.routing-help td, details.routing-help th { font-size: 12px; }

--- a/packages/litellm_adapter/client.py
+++ b/packages/litellm_adapter/client.py
@@ -37,7 +37,19 @@ def _translate_error(exc: Exception) -> UpstreamProviderError:
 class OrcaLiteLLMClient:
     """Wraps a litellm.Router, routes by `model` alias, returns a dict."""
 
-    def __init__(self, deployments: list[ProviderDeployment]):
+    def __init__(
+        self,
+        deployments: list[ProviderDeployment],
+        *,
+        strategy: str | None = None,
+        preferred_models: list[str] | None = None,
+        litellm_routing_strategy: str | None = None,
+    ):
+        # Stash routing config on the instance so chat.py can read it without
+        # re-querying the DB on every request.
+        self.strategy = strategy or "balanced"
+        self.preferred_models = list(preferred_models or [])
+
         # litellm-suppress-debug
         import litellm
         from litellm import Router
@@ -67,11 +79,15 @@ class OrcaLiteLLMClient:
             self._deployments = []
             return
 
-        self._router = Router(
-            model_list=model_list,
-            num_retries=2,
-            timeout=30.0,
-        )
+        router_kwargs: dict = {
+            "model_list": model_list,
+            "num_retries": 2,
+            "timeout": 30.0,
+        }
+        if litellm_routing_strategy:
+            router_kwargs["routing_strategy"] = litellm_routing_strategy
+
+        self._router = Router(**router_kwargs)
         self._deployments = deployments
 
     async def acompletion(self, **kwargs) -> dict:

--- a/tests/integration/test_auto_model.py
+++ b/tests/integration/test_auto_model.py
@@ -141,6 +141,39 @@ async def test_auto_response_reports_resolved_model_to_caller(auto_client):
     assert r.headers.get("x-orca-resolved-model") == captured["model"]
 
 
+async def test_auto_with_quality_strategy_picks_different_model_than_cheapest(auto_client, monkeypatch):
+    """`quality` flips the auto resolver from cheapest- to most-expensive-capable."""
+    client, captured = auto_client
+
+    from app import router_cache
+
+    # The fixture installs a fresh AsyncMock as the router; pin strategy on it.
+    fake_router = await router_cache.get_router(None)  # returns the mocked fake
+    fake_router.strategy = "cheapest"
+    fake_router.preferred_models = []
+
+    r1 = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r1.status_code == 200
+    cheapest_pick = captured["model"]
+    assert r1.headers.get("x-orca-routing-strategy") == "cheapest"
+
+    fake_router.strategy = "quality"
+
+    r2 = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r2.status_code == 200
+    quality_pick = captured["model"]
+    assert r2.headers.get("x-orca-routing-strategy") == "quality"
+
+    # cheapest and quality should pick different ends of the OpenAI catalog.
+    assert cheapest_pick != quality_pick
+
+
 async def test_auto_returns_422_when_no_capable_model_is_deployable(tmp_sqlite_url, monkeypatch):
     """If no provider keys cover the required capabilities, surface a clear 422."""
     monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)

--- a/tests/integration/test_chat_completion.py
+++ b/tests/integration/test_chat_completion.py
@@ -153,3 +153,31 @@ async def test_chat_completion_validation_error_for_empty_messages(chat_client):
     )
     assert r.status_code == 422
     assert r.json()["error"]["type"] == "validation_error"
+
+
+async def test_chat_completion_logs_active_strategy(chat_client):
+    """RequestLog.routing_strategy reflects the configured strategy, not a
+    hardcoded value, and the same strategy is echoed in the response header."""
+    client, fake = chat_client
+    # Bolt the strategy onto the mock so chat.py reads it like a real client.
+    fake.strategy = "cheapest"
+    fake.preferred_models = []
+
+    r = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+        },
+    )
+    assert r.status_code == 200
+    assert r.headers.get("x-orca-routing-strategy") == "cheapest"
+
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        log = (await s.execute(select(RequestLog))).scalars().one()
+    assert log.routing_strategy == "cheapest"

--- a/tests/integration/test_misc_routes.py
+++ b/tests/integration/test_misc_routes.py
@@ -126,3 +126,18 @@ async def test_put_routing_rejects_unknown_strategy(lite_client):
     client, _ = lite_client
     r = await client.put("/v1/routing", json={"strategy": "magic-sauce"})
     assert r.status_code == 422
+
+
+async def test_put_routing_invalidates_cached_router(lite_client, monkeypatch):
+    """Changing the strategy must drop the cached client so the next request
+    rebuilds it with the new `routing_strategy`."""
+    client, _ = lite_client
+    from app import router_cache
+
+    sentinel = object()
+    router_cache._cached_client = sentinel
+    assert router_cache._cached_client is sentinel
+
+    r = await client.put("/v1/routing", json={"strategy": "cheapest"})
+    assert r.status_code == 200
+    assert router_cache._cached_client is None

--- a/tests/unit/test_auto_routing.py
+++ b/tests/unit/test_auto_routing.py
@@ -146,3 +146,98 @@ def test_choose_model_uses_blended_input_plus_output_cost():
         needs=set(), deployable={"a", "b"}, candidates=candidates
     )
     assert chosen == "a"
+
+
+# ── strategy-aware selection ────────────────────────────────────────────
+
+def test_choose_model_quality_strategy_picks_most_expensive():
+    """`quality` is the inverse of `cheapest` — biggest as a proxy for best."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("medium", "openai", "openai/", True, False, False, 1e-6, 3e-6),
+        CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap", "medium", "expensive"},
+        candidates=candidates,
+        strategy="quality",
+    )
+    assert chosen == "expensive"
+
+
+def test_choose_model_cheapest_strategy_matches_default():
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap", "expensive"},
+        candidates=candidates,
+        strategy="cheapest",
+    )
+    assert chosen == "cheap"
+
+
+def test_choose_model_preferred_models_narrows_eligible_set():
+    """When `preferred_models` is set and any are eligible, restrict to them."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap-not-preferred", "openai", "openai/", True, False, False, 1e-8, 1e-8),
+        CatalogModel("preferred-mid", "openai", "openai/", True, False, False, 1e-6, 3e-6),
+        CatalogModel("preferred-big", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap-not-preferred", "preferred-mid", "preferred-big"},
+        candidates=candidates,
+        strategy="cheapest",
+        preferred_models=["preferred-mid", "preferred-big"],
+    )
+    assert chosen == "preferred-mid"  # cheapest within the preferred set
+
+
+def test_choose_model_preferred_models_falls_back_when_none_eligible():
+    """If preferred_models has no eligible entries, ignore the filter."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap"},
+        candidates=candidates,
+        preferred_models=["does-not-exist", "neither-does-this"],
+    )
+    assert chosen == "cheap"
+
+
+# ── litellm strategy mapping ────────────────────────────────────────────
+
+def test_litellm_routing_strategy_maps_known_values():
+    from app.auto_routing import litellm_routing_strategy
+
+    assert litellm_routing_strategy("cheapest") == "cost-based-routing"
+    assert litellm_routing_strategy("fastest") == "latency-based-routing"
+    # `balanced` and `quality` use litellm's default (no override)
+    assert litellm_routing_strategy("balanced") is None
+    assert litellm_routing_strategy("quality") is None
+
+
+def test_litellm_routing_strategy_returns_none_for_unknown_or_empty():
+    from app.auto_routing import litellm_routing_strategy
+
+    assert litellm_routing_strategy(None) is None
+    assert litellm_routing_strategy("") is None
+    assert litellm_routing_strategy("not-a-real-strategy") is None


### PR DESCRIPTION
## Summary
This PR extends the auto-routing system to support multiple selection strategies and adds routing configuration persistence. The `model="auto"` resolver now respects user-configured strategies (cheapest, fastest, quality, balanced) and preferred model lists, while the litellm Router is configured with the appropriate `routing_strategy` parameter.

## Key Changes

- **Strategy-aware auto model selection**: `choose_auto_model()` now accepts `strategy` and `preferred_models` parameters
  - `quality` strategy picks the most expensive capable model (proxy for capability)
  - Other strategies pick the cheapest capable model
  - `preferred_models` list narrows the eligible set when any preferred models are deployable and capable
  - Falls back to full eligible set if no preferred models match

- **litellm routing strategy mapping**: New `litellm_routing_strategy()` function maps UI strategies to litellm Router parameters
  - `cheapest` → `cost-based-routing`
  - `fastest` → `latency-based-routing`
  - `balanced` and `quality` → `None` (use litellm defaults)

- **Router client configuration**: `OrcaLiteLLMClient` now stores and passes routing configuration
  - Accepts `strategy`, `preferred_models`, and `litellm_routing_strategy` parameters
  - Stashes strategy and preferred_models on instance for chat handler access
  - Passes `routing_strategy` to litellm Router constructor when provided

- **Chat handler integration**: Routes now read strategy from the cached router client
  - Passes strategy and preferred_models to `choose_auto_model()`
  - Logs active strategy to RequestLog
  - Echoes strategy back in `x-orca-routing-strategy` response header

- **Router cache updates**: `get_router()` now queries RoutingConfig from database
  - Reads strategy and preferred_models from persistent config
  - Passes them to OrcaLiteLLMClient constructor
  - Cache invalidation on routing config changes

- **UI improvements**: Enhanced routing strategy panel with detailed explanations
  - Added help table mapping strategies to litellm behavior and auto selection rules
  - Clarified that strategy affects both auto resolution and deployment selection

## Testing
- Unit tests for strategy-aware selection (quality, cheapest, preferred models)
- Unit tests for litellm strategy mapping
- Integration tests verifying quality strategy picks different models than cheapest
- Integration tests confirming strategy is logged and echoed in responses
- Integration test for cache invalidation on routing config changes

https://claude.ai/code/session_014Pvw2X2yHRXdbQxUx45a2u