### PR TITLE
Use real PNG logo and fix command-palette close bug

### DIFF
--- a/design/app.js
+++ b/design/app.js
@@ -793,9 +793,15 @@ function renderPalette(query) {
 
 function bindPalette() {
   $("#open-palette").addEventListener("click", openPalette);
+  $("#palette-close").addEventListener("click", closePalette);
   const input = $("#palette-input");
   input.addEventListener("input", () => { paletteFocus = 0; renderPalette(input.value); });
   input.addEventListener("keydown", (e) => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      closePalette();
+      return;
+    }
     const visible = $$("#palette-list .palette-item");
     if (e.key === "ArrowDown") {
       e.preventDefault();
@@ -817,9 +823,9 @@ function bindPalette() {
       }
     }
   });
-  // click outside closes
+  // click on the backdrop (anywhere outside the card) closes
   $("#palette").addEventListener("click", (e) => {
-    if (e.target === $("#palette")) closePalette();
+    if (!e.target.closest(".palette-card")) closePalette();
   });
 }
 

--- a/design/index.html
+++ b/design/index.html
@@ -8,30 +8,14 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="/static/style.css">
-  <link rel="icon" href="data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><circle cx='16' cy='16' r='14' fill='%232D7FF9'/><text x='16' y='22' text-anchor='middle' font-size='18' fill='white' font-family='-apple-system'>O</text></svg>">
+  <link rel="icon" href="/static/OrcaRouter%20Lite.png">
 </head>
 <body>
   <!-- ─────────────────────── Auth gate ─────────────────────── -->
   <div id="auth-gate" class="auth-gate">
     <div class="auth-card">
       <div class="auth-brand">
-        <span class="brand-logo" aria-hidden="true">
-          <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <linearGradient id="orcaG" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="#5BA8FF"/>
-                <stop offset="100%" stop-color="#1B5FCC"/>
-              </linearGradient>
-            </defs>
-            <path d="M14 22 C 14 14, 24 8, 36 10 C 48 12, 56 22, 54 34 C 52 46, 40 52, 30 50 C 22 48, 18 42, 16 38 L 8 42 L 12 32 L 8 24 Z" fill="url(#orcaG)"/>
-            <path d="M30 28 C 30 24, 36 22, 42 24 C 48 26, 50 32, 48 38 C 46 44, 38 46, 32 44 C 28 42, 28 36, 30 28 Z" fill="white"/>
-            <circle cx="38" cy="26" r="2" fill="#0A0F1C"/>
-          </svg>
-        </span>
-        <div class="brand-wordmark">
-          <span class="brand-orca">Orca</span><span class="brand-router">Router</span>
-          <span class="brand-pill">Lite</span>
-        </div>
+        <img class="brand-logo-img" src="/static/OrcaRouter%20Lite.png" alt="OrcaRouter Lite">
       </div>
       <p class="auth-tagline">Open Source. Single Tenant.</p>
 
@@ -85,23 +69,7 @@
   <div id="app-shell" class="app-shell" hidden>
     <aside class="sidebar">
       <div class="sidebar-brand">
-        <span class="brand-logo brand-logo-sm" aria-hidden="true">
-          <svg viewBox="0 0 64 64" xmlns="http://www.w3.org/2000/svg">
-            <defs>
-              <linearGradient id="orcaG2" x1="0" y1="0" x2="1" y2="1">
-                <stop offset="0%" stop-color="#5BA8FF"/>
-                <stop offset="100%" stop-color="#1B5FCC"/>
-              </linearGradient>
-            </defs>
-            <path d="M14 22 C 14 14, 24 8, 36 10 C 48 12, 56 22, 54 34 C 52 46, 40 52, 30 50 C 22 48, 18 42, 16 38 L 8 42 L 12 32 L 8 24 Z" fill="url(#orcaG2)"/>
-            <path d="M30 28 C 30 24, 36 22, 42 24 C 48 26, 50 32, 48 38 C 46 44, 38 46, 32 44 C 28 42, 28 36, 30 28 Z" fill="white"/>
-            <circle cx="38" cy="26" r="2" fill="#0A0F1C"/>
-          </svg>
-        </span>
-        <div class="brand-wordmark brand-wordmark-sm">
-          <span class="brand-orca">Orca</span><span class="brand-router">Router</span>
-          <span class="brand-pill">Lite</span>
-        </div>
+        <img class="brand-logo-img brand-logo-img-sm" src="/static/OrcaRouter%20Lite.png" alt="OrcaRouter Lite">
       </div>
 
       <nav class="sidebar-nav" id="tabs">
@@ -585,7 +553,9 @@
       <div class="palette-input-wrap">
         <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
         <input id="palette-input" placeholder="Jump to a tab, copy your base URL, open docs…" autocomplete="off" spellcheck="false">
-        <kbd>esc</kbd>
+        <button type="button" class="icon-btn" id="palette-close" aria-label="Close (Esc)" title="Close (Esc)">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+        </button>
       </div>
       <ul class="palette-list" id="palette-list"></ul>
     </div>

--- a/design/style.css
+++ b/design/style.css
@@ -68,6 +68,11 @@
   *, *::before, *::after { animation-duration: 0.01ms !important; transition-duration: 0.01ms !important; }
 }
 
+/* The HTML `hidden` attribute must always win over component display rules
+   (e.g. `.palette { display: grid }`), otherwise toggling `el.hidden = true`
+   from JS becomes a no-op and overlays can't be closed. */
+[hidden] { display: none !important; }
+
 /* -------------------------- reset / base ---------------------------------- */
 *, *::before, *::after { box-sizing: border-box; }
 html, body { height: 100%; }
@@ -109,6 +114,19 @@ code {
 }
 
 /* -------------------------- Brand wordmark -------------------------------- */
+.brand-logo-img {
+  display: block;
+  height: 44px;
+  width: auto;
+  max-width: 100%;
+  filter: drop-shadow(0 4px 14px var(--brand-glow));
+  object-fit: contain;
+  user-select: none;
+  -webkit-user-drag: none;
+}
+.brand-logo-img-sm { height: 32px; }
+
+/* Legacy SVG-based wordmark — kept for any future use */
 .brand-logo {
   display: inline-flex;
   width: 40px;


### PR DESCRIPTION
## Summary

Two follow-up fixes on the redesigned dashboard from #7:

### 1. Command palette wouldn't close

Setting `el.hidden = true` from `closePalette()` was a visual no-op. Author rules like `.palette { display: grid }` have the same selector specificity as the user-agent's `[hidden] { display: none }`, and **author rules win the cascade** — so the `hidden` attribute was being ignored. Same latent bug existed for `.app-shell`, `.auth-gate`, and `.drawer`.

**Fix:** one guard rule near the top of `design/style.css`:

```css
[hidden] { display: none !important; }
```

The HTML `hidden` attribute now always wins regardless of component display rules.

Belt-and-suspenders for the close UX:
- Explicit **X close button** in the palette header (visible, discoverable).
- **Escape** handled directly inside the palette input (was relying on document-level bubbling).
- Click-outside check now uses `closest(".palette-card")` so any backdrop click closes.

### 2. Use the real PNG logo

The previous redesign used a hand-rolled inline SVG approximation of the orca whale. Replace it with the actual brand asset at `design/OrcaRouter Lite.png` (already served at `/static/OrcaRouter%20Lite.png`) in:

- the auth-gate header,
- the sidebar header,
- the favicon.

The PNG includes the dual-tone "Orca**Router** Lite" wordmark, so the separate inline text spans are removed.

## Test plan

- [x] `pytest -q` — 100/100 still pass (no Python changes)
- [x] `node --check design/app.js` — clean
- [x] `curl /static/OrcaRouter%20Lite.png` returns `200 image/png` (836 KB)
- [x] HTML references the PNG path in 3 places (auth-gate, sidebar, favicon)
- [ ] Manual: open dashboard, press `Cmd+K`, verify Esc / X / backdrop-click all close the palette
- [ ] Manual: hard-refresh, confirm the orca PNG renders in auth-gate and sidebar

https://claude.ai/code/session_01Pyum331JqLEKo6fUgWYaoZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pyum331JqLEKo6fUgWYaoZ)_