### PR TITLE
Add hosted fallback status & unreachable models dashboard UI

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -50,9 +50,16 @@ class Settings(BaseSettings):
     together_api_key: str | None = None
     fireworks_api_key: str | None = None
 
-    # ── Hosted-as-upstream (managed safety net) ──
+    # ── Hosted-as-upstream (standard fallback) ──
+    # When configured (env or via dashboard), every catalog model gets an extra
+    # deployment routed through hosted — so requests for a model the user has
+    # no local key for still succeed. Free $5 trial credit available via the
+    # signup URL surfaced in the Lite dashboard's "Hosted fallback" card.
     orcarouter_api_key: str | None = None
     orcarouter_base_url: str = "https://api.orcarouter.ai/v1"
+    orcarouter_signup_url: str = (
+        "https://www.orcarouter.ai/signup?ref=lite-dashboard&trial=5usd"
+    )
 
     # ── Body limit (for image / file attachments) ──
     max_body_bytes: int = 100 * 1024 * 1024

--- a/app/main.py
+++ b/app/main.py
@@ -117,7 +117,7 @@ def create_app() -> FastAPI:
 
     app.add_middleware(AuthMiddleware)
 
-    from app.routes import analytics, chat, health, keys, models, providers, routing
+    from app.routes import analytics, chat, health, hosted, keys, models, providers, routing
 
     app.include_router(health.router)
     app.include_router(providers.router)
@@ -126,6 +126,7 @@ def create_app() -> FastAPI:
     app.include_router(models.router)
     app.include_router(keys.router)
     app.include_router(routing.router)
+    app.include_router(hosted.router)
 
     # ── Static SPA (provider keys, routing, analytics, keys) ──
     import os

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -93,16 +93,40 @@ def hosted_key_source(
 ) -> str | None:
     """Return where the hosted upstream key came from, or None if unconfigured.
 
-    Mirrors the precedence used by `build_deployments`: a DB row beats env.
-    Used by `/v1/hosted` to tell the dashboard whether to show the CTA or
-    the "active" pill.
+    Mirrors the precedence used by `build_deployments`: a DB row beats env,
+    BUT only if the row's encrypted_key actually decrypts. A row whose
+    ciphertext is corrupt (post-rotation, DB tampering) is silently dropped
+    by `build_deployments`, so reporting it as "configured" here would tell
+    the dashboard "Active" while requests still 503 on hosted models.
     """
-    for row in db_keys:
-        if row.provider == HOSTED_PROVIDER_NAME and row.is_enabled and not row.is_deleted:
-            return "dashboard"
+    if HOSTED_PROVIDER_NAME in usable_providers_from_db(db_keys):
+        return "dashboard"
     if env_key:
         return "env"
     return None
+
+
+def usable_providers_from_db(db_keys: list["ProviderKey"]) -> set[str]:
+    """Set of provider names whose DB-stored key actually decrypts.
+
+    Single source of truth for "is this provider deployable from a DB row?"
+    Used by `hosted_key_source` and `/v1/analytics/unreachable` so the
+    dashboard's "configured providers" view stays in lockstep with what
+    `build_deployments` will actually wire up. Without this, an
+    undecryptable row (after `CREDENTIAL_ENCRYPTION_KEY` rotation) would
+    falsely suppress models from the unreachable list while the router
+    can't reach them either.
+    """
+    out: set[str] = set()
+    for row in db_keys:
+        if not row.is_enabled or row.is_deleted:
+            continue
+        try:
+            decrypt_credential(row.encrypted_key)
+        except Exception:
+            continue
+        out.add(row.provider)
+    return out
 
 
 # ── Cached router instance ────────────────────────────────────────────────

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -36,7 +36,7 @@ def build_deployments(
     Precedence:
       1. DB provider keys (UI-edited, authoritative; encrypted at rest)
       2. Env vars for providers not present in DB
-      3. Hosted-as-upstream (one entry per known model) when ORCAROUTER_API_KEY set
+      3. Hosted-as-upstream (one entry per catalog model) — DB key > env key
     """
     deployments: list[ProviderDeployment] = []
     db_provider_keys: dict[str, str] = {}
@@ -49,7 +49,9 @@ def build_deployments(
         except Exception:
             continue
 
-    # Step 1+2: provider keys (DB > env)
+    # Step 1+2: provider keys (DB > env). The hosted "orcarouter" provider
+    # has no rows in `models_for_provider`, so it's silently skipped here and
+    # picked up in step 3.
     for provider, models in (
         (p, models_for_provider(p)) for p in {*db_provider_keys, *env_keys}
     ):
@@ -66,20 +68,41 @@ def build_deployments(
                 )
             )
 
-    # Step 3: hosted-as-upstream
-    if settings.orcarouter_api_key:
+    # Step 3: hosted-as-upstream. DB-stored "orcarouter" key (set via the
+    # dashboard's Hosted fallback CTA) overrides the env key, mirroring step
+    # 1+2 precedence. Either source enables every catalog model as a hosted
+    # deployment so the long tail of providers never errors with "no key."
+    hosted_key = db_provider_keys.get(HOSTED_PROVIDER_NAME) or settings.orcarouter_api_key
+    if hosted_key:
         for model_id in all_model_ids():
             deployments.append(
                 ProviderDeployment(
                     model_name=model_id,
                     litellm_model=f"openai/{model_id}",
-                    api_key=settings.orcarouter_api_key,
+                    api_key=hosted_key,
                     api_base=settings.orcarouter_base_url,
                     provider=HOSTED_PROVIDER_NAME,
                 )
             )
 
     return deployments
+
+
+def hosted_key_source(
+    *, env_key: str | None, db_keys: list["ProviderKey"]
+) -> str | None:
+    """Return where the hosted upstream key came from, or None if unconfigured.
+
+    Mirrors the precedence used by `build_deployments`: a DB row beats env.
+    Used by `/v1/hosted` to tell the dashboard whether to show the CTA or
+    the "active" pill.
+    """
+    for row in db_keys:
+        if row.provider == HOSTED_PROVIDER_NAME and row.is_enabled and not row.is_deleted:
+            return "dashboard"
+    if env_key:
+        return "env"
+    return None
 
 
 # ── Cached router instance ────────────────────────────────────────────────

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.config import get_settings
 from app.deps import get_db, get_key_context
-from app.router_cache import HOSTED_PROVIDER_NAME, hosted_key_source
+from app.router_cache import HOSTED_PROVIDER_NAME, hosted_key_source, usable_providers_from_db
 from packages.auth.types import KeyContext
 from packages.db.models.provider_key import ProviderKey
 from packages.db.models.request_log import RequestLog
@@ -314,10 +314,13 @@ async def unreachable_models(
         env_key=settings.orcarouter_api_key,
         db_keys=list(rows),
     )
-    configured_providers: set[str] = set()
-    for r in rows:
-        if r.is_enabled and r.provider != HOSTED_PROVIDER_NAME:
-            configured_providers.add(r.provider)
+    # Filter DB-set providers through the same decrypt check build_deployments
+    # uses, so a corrupt encrypted_key doesn't falsely suppress models from
+    # the unreachable list while the router still can't reach them.
+    configured_providers: set[str] = {
+        p for p in usable_providers_from_db(list(rows))
+        if p != HOSTED_PROVIDER_NAME
+    }
     for provider, key in settings.env_provider_keys().items():
         if key:
             configured_providers.add(provider)

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -221,22 +221,34 @@ async def savings_vs_baseline(
 
 def _hosted_auto_savings(rows, catalog: list, catalog_by_id: dict) -> dict:
     """For each request, find the cheapest catalog model that meets the
-    resolved model's capability set, and sum what it would have cost.
+    resolved model's capability set, scoring on the row's ACTUAL token
+    counts.
 
-    Excludes rows whose resolved model isn't in the catalog (can't compare
-    capabilities) and zero-priced catalog entries (likely placeholders).
-    Savings are computed against the actual spend on COMPARABLE rows only —
-    summing non-catalog spend into the baseline would falsely inflate the
+    Cost minimization is per-row, not per-model: an input-heavy request
+    and an output-heavy request with the same `model_resolved` may pick
+    different counterfactual models, since the cheapest model depends on
+    the actual token mix. A fixed input/output blended weight (as used
+    in `auto_routing.choose_auto_model`, which has to decide BEFORE the
+    request runs) under-reports savings here, where we already know
+    exact tokens for every row.
+
+    Excludes rows whose resolved model isn't in the catalog (can't
+    compare capabilities) and zero-priced catalog entries (likely
+    placeholders). Savings are computed against the actual spend on
+    COMPARABLE rows only — non-catalog spend would falsely inflate the
     saved figure shown on the dashboard.
     """
-    cheapest_cache: dict[str, object | None] = {}
+    # Cache the eligible candidate list per resolved model — capability
+    # filtering is the same across rows, only the cost minimization
+    # depends on per-row tokens.
+    candidates_cache: dict[str, list | None] = {}
 
-    def _cheapest_for(actual_id: str):
-        if actual_id in cheapest_cache:
-            return cheapest_cache[actual_id]
+    def _candidates_for(actual_id: str) -> list | None:
+        if actual_id in candidates_cache:
+            return candidates_cache[actual_id]
         actual = catalog_by_id.get(actual_id)
         if actual is None:
-            cheapest_cache[actual_id] = None
+            candidates_cache[actual_id] = None
             return None
         eligible = [
             m for m in catalog
@@ -245,29 +257,24 @@ def _hosted_auto_savings(rows, catalog: list, catalog_by_id: dict) -> dict:
             and (not actual.supports_json_mode or m.supports_json_mode)
             and (m.input_cost_per_token + m.output_cost_per_token) > 0
         ]
-        if not eligible:
-            cheapest_cache[actual_id] = None
-            return None
-        # Same blended cost weighting used by app.auto_routing.choose_auto_model.
-        chosen = min(
-            eligible,
-            key=lambda m: 0.3 * m.input_cost_per_token + 0.7 * m.output_cost_per_token,
-        )
-        cheapest_cache[actual_id] = chosen
-        return chosen
+        candidates_cache[actual_id] = eligible if eligible else None
+        return candidates_cache[actual_id]
 
     hosted_microcents = 0
     actual_comparable_microcents = 0
     counted = 0
     for i, o, c, model_resolved in rows:
-        cheapest = _cheapest_for(model_resolved)
-        if cheapest is None:
+        candidates = _candidates_for(model_resolved)
+        if not candidates:
             continue
-        actual_comparable_microcents += int(c or 0)
-        hosted_microcents += int(
-            (i or 0) * cheapest.input_cost_per_token * 1_000_000
-            + (o or 0) * cheapest.output_cost_per_token * 1_000_000
+        i_v = i or 0
+        o_v = o or 0
+        cheapest_usd = min(
+            i_v * m.input_cost_per_token + o_v * m.output_cost_per_token
+            for m in candidates
         )
+        hosted_microcents += int(cheapest_usd * 1_000_000)
+        actual_comparable_microcents += int(c or 0)
         counted += 1
 
     saved = max(0, actual_comparable_microcents - hosted_microcents)

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -1,4 +1,4 @@
-"""Analytics routes — recent requests, spend by model, latency by provider."""
+"""Analytics routes — recent requests, spend, latency, savings, unreachable models."""
 
 from __future__ import annotations
 
@@ -8,11 +8,39 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.config import get_settings
 from app.deps import get_db, get_key_context
+from app.router_cache import HOSTED_PROVIDER_NAME, hosted_key_source
 from packages.auth.types import KeyContext
+from packages.db.models.provider_key import ProviderKey
 from packages.db.models.request_log import RequestLog
 
 router = APIRouter(prefix="/v1/analytics", tags=["analytics"])
+
+# Curated "promote me" list for the unreachable-models tile. The full catalog
+# is 100+ models; surfacing all of them buries the conversion message. These
+# are the flagship/popular IDs developers actually wish they had keys for.
+# Order matters — first one in this list that's unreachable is shown first.
+_PROMOTED_MODEL_IDS: tuple[str, ...] = (
+    "claude-3-5-sonnet-latest",
+    "claude-3-5-haiku-latest",
+    "claude-3-opus-latest",
+    "gpt-4o",
+    "gpt-4o-mini",
+    "o1",
+    "o1-mini",
+    "o3-mini",
+    "gemini-1.5-pro",
+    "gemini-1.5-flash",
+    "gemini-2.0-flash",
+    "deepseek-chat",
+    "deepseek-reasoner",
+    "mistral-large-latest",
+    "command-r-plus",
+    "llama-3.1-405b-instruct",
+    "llama-3.3-70b-versatile",
+    "grok-2-latest",
+)
 
 
 def _percentile(values: list[int], pct: float) -> int:
@@ -126,10 +154,15 @@ async def savings_vs_baseline(
     """What would these requests have cost on `baseline` instead?
 
     Powers the dashboard's "you saved $X by routing" tile. The baseline
-    must be a known catalog model (default: gpt-4o, the typical "I'd
-    just use GPT-4o" comparison).
+    must be a known catalog model (default: gpt-4o).
+
+    Also returns a `hosted_auto` row: per-request, what would the cheapest
+    catalog model with the *same capability set* as the resolved model have
+    cost? That's the upper bound on additional savings the hosted-auto
+    router could unlock by reaching models the user has no local key for.
+    Conservative — assumes the resolved model's capabilities are required.
     """
-    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+    from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
 
     baseline_model = CATALOG_BY_ID.get(baseline)
     if baseline_model is None:
@@ -145,6 +178,7 @@ async def savings_vs_baseline(
                 RequestLog.input_tokens,
                 RequestLog.output_tokens,
                 RequestLog.cost_microcents,
+                RequestLog.model_resolved,
             )
             .where(
                 RequestLog.is_deleted == 0,
@@ -154,7 +188,7 @@ async def savings_vs_baseline(
         )
     ).all()
 
-    actual_microcents = sum(int(c or 0) for _i, _o, c in rows)
+    actual_microcents = sum(int(c or 0) for _i, _o, c, _m in rows)
     # Per-token pricing in litellm is USD/token; convert to microcents
     # (1 USD = 1,000,000 microcents).
     baseline_microcents = sum(
@@ -162,7 +196,7 @@ async def savings_vs_baseline(
             (i or 0) * baseline_model.input_cost_per_token * 1_000_000
             + (o or 0) * baseline_model.output_cost_per_token * 1_000_000
         )
-        for i, o, _c in rows
+        for i, o, _c, _m in rows
     )
     saved = max(0, baseline_microcents - actual_microcents)
     pct = (
@@ -171,6 +205,8 @@ async def savings_vs_baseline(
         else 0
     )
 
+    hosted_auto = _hosted_auto_savings(rows, actual_microcents, CATALOG, CATALOG_BY_ID)
+
     return {
         "baseline_model": baseline,
         "request_count": len(rows),
@@ -178,5 +214,137 @@ async def savings_vs_baseline(
         "baseline_microcents": baseline_microcents,
         "saved_microcents": saved,
         "savings_percent": pct,
+        "hosted_auto": hosted_auto,
         "days": days,
+    }
+
+
+def _hosted_auto_savings(
+    rows, actual_microcents: int, catalog: list, catalog_by_id: dict
+) -> dict:
+    """For each request, find the cheapest catalog model that meets the
+    resolved model's capability set, and sum what it would have cost.
+
+    Excludes rows whose resolved model isn't in the catalog (can't compare
+    capabilities) and zero-priced catalog entries (likely placeholders).
+    """
+    cheapest_cache: dict[str, object | None] = {}
+
+    def _cheapest_for(actual_id: str):
+        if actual_id in cheapest_cache:
+            return cheapest_cache[actual_id]
+        actual = catalog_by_id.get(actual_id)
+        if actual is None:
+            cheapest_cache[actual_id] = None
+            return None
+        eligible = [
+            m for m in catalog
+            if (not actual.supports_tools or m.supports_tools)
+            and (not actual.supports_vision or m.supports_vision)
+            and (not actual.supports_json_mode or m.supports_json_mode)
+            and (m.input_cost_per_token + m.output_cost_per_token) > 0
+        ]
+        if not eligible:
+            cheapest_cache[actual_id] = None
+            return None
+        # Same blended cost weighting used by app.auto_routing.choose_auto_model.
+        chosen = min(
+            eligible,
+            key=lambda m: 0.3 * m.input_cost_per_token + 0.7 * m.output_cost_per_token,
+        )
+        cheapest_cache[actual_id] = chosen
+        return chosen
+
+    hosted_microcents = 0
+    counted = 0
+    for i, o, _c, model_resolved in rows:
+        cheapest = _cheapest_for(model_resolved)
+        if cheapest is None:
+            continue
+        hosted_microcents += int(
+            (i or 0) * cheapest.input_cost_per_token * 1_000_000
+            + (o or 0) * cheapest.output_cost_per_token * 1_000_000
+        )
+        counted += 1
+
+    saved = max(0, actual_microcents - hosted_microcents)
+    pct = round(100 * saved / actual_microcents, 1) if actual_microcents else 0
+    return {
+        "actual_microcents": hosted_microcents,
+        "saved_microcents": saved,
+        "savings_percent": pct,
+        "comparable_request_count": counted,
+    }
+
+
+@router.get("/unreachable")
+async def unreachable_models(
+    limit: int = Query(10, ge=1, le=50),
+    _kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Flagship catalog models the user can't currently route to.
+
+    A model is "unreachable" when neither (a) the user has a provider key
+    for its provider, nor (b) hosted upstream is configured. Powers the
+    dashboard's conversion tile that nudges Lite users to enable hosted
+    fallback for free $5 credit.
+
+    Returns the curated list intersected with what's actually unreachable,
+    capped at `limit`. When hosted is configured, the list is empty —
+    everything in the catalog is reachable via hosted.
+    """
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+
+    settings = get_settings()
+    rows = (
+        await db.execute(
+            select(ProviderKey).where(ProviderKey.is_deleted == 0)
+        )
+    ).scalars().all()
+
+    hosted = hosted_key_source(
+        env_key=settings.orcarouter_api_key,
+        db_keys=list(rows),
+    )
+    configured_providers: set[str] = set()
+    for r in rows:
+        if r.is_enabled and r.provider != HOSTED_PROVIDER_NAME:
+            configured_providers.add(r.provider)
+    for provider, key in settings.env_provider_keys().items():
+        if key:
+            configured_providers.add(provider)
+
+    if hosted is not None:
+        return {
+            "hosted_configured": True,
+            "configured_providers": sorted(configured_providers),
+            "unreachable": [],
+        }
+
+    unreachable: list[dict] = []
+    for model_id in _PROMOTED_MODEL_IDS:
+        m = CATALOG_BY_ID.get(model_id)
+        if m is None:
+            continue
+        if m.provider in configured_providers:
+            continue
+        unreachable.append(
+            {
+                "id": m.id,
+                "provider": m.provider,
+                "input_cost_per_token": m.input_cost_per_token,
+                "output_cost_per_token": m.output_cost_per_token,
+                "supports_tools": m.supports_tools,
+                "supports_vision": m.supports_vision,
+                "supports_json_mode": m.supports_json_mode,
+            }
+        )
+        if len(unreachable) >= limit:
+            break
+
+    return {
+        "hosted_configured": False,
+        "configured_providers": sorted(configured_providers),
+        "unreachable": unreachable,
     }

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -205,7 +205,7 @@ async def savings_vs_baseline(
         else 0
     )
 
-    hosted_auto = _hosted_auto_savings(rows, actual_microcents, CATALOG, CATALOG_BY_ID)
+    hosted_auto = _hosted_auto_savings(rows, CATALOG, CATALOG_BY_ID)
 
     return {
         "baseline_model": baseline,
@@ -219,14 +219,15 @@ async def savings_vs_baseline(
     }
 
 
-def _hosted_auto_savings(
-    rows, actual_microcents: int, catalog: list, catalog_by_id: dict
-) -> dict:
+def _hosted_auto_savings(rows, catalog: list, catalog_by_id: dict) -> dict:
     """For each request, find the cheapest catalog model that meets the
     resolved model's capability set, and sum what it would have cost.
 
     Excludes rows whose resolved model isn't in the catalog (can't compare
     capabilities) and zero-priced catalog entries (likely placeholders).
+    Savings are computed against the actual spend on COMPARABLE rows only —
+    summing non-catalog spend into the baseline would falsely inflate the
+    saved figure shown on the dashboard.
     """
     cheapest_cache: dict[str, object | None] = {}
 
@@ -256,19 +257,25 @@ def _hosted_auto_savings(
         return chosen
 
     hosted_microcents = 0
+    actual_comparable_microcents = 0
     counted = 0
-    for i, o, _c, model_resolved in rows:
+    for i, o, c, model_resolved in rows:
         cheapest = _cheapest_for(model_resolved)
         if cheapest is None:
             continue
+        actual_comparable_microcents += int(c or 0)
         hosted_microcents += int(
             (i or 0) * cheapest.input_cost_per_token * 1_000_000
             + (o or 0) * cheapest.output_cost_per_token * 1_000_000
         )
         counted += 1
 
-    saved = max(0, actual_microcents - hosted_microcents)
-    pct = round(100 * saved / actual_microcents, 1) if actual_microcents else 0
+    saved = max(0, actual_comparable_microcents - hosted_microcents)
+    pct = (
+        round(100 * saved / actual_comparable_microcents, 1)
+        if actual_comparable_microcents
+        else 0
+    )
     return {
         "actual_microcents": hosted_microcents,
         "saved_microcents": saved,

--- a/app/routes/hosted.py
+++ b/app/routes/hosted.py
@@ -1,0 +1,50 @@
+"""Hosted-fallback status endpoint.
+
+Powers the dashboard's "Hosted fallback" card: tells the SPA whether
+hosted upstream is configured (env or DB), where the configuration came
+from, and the signup URL to send unconfigured users to for their free
+$5 trial credit.
+"""
+
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.config import get_settings
+from app.deps import get_db, get_key_context
+from app.router_cache import HOSTED_PROVIDER_NAME, hosted_key_source
+from packages.auth.types import KeyContext
+from packages.db.models.provider_key import ProviderKey
+
+router = APIRouter(prefix="/v1/hosted", tags=["hosted"])
+
+
+@router.get("")
+async def hosted_status(
+    _kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    settings = get_settings()
+    rows = (
+        await db.execute(
+            select(ProviderKey).where(
+                ProviderKey.provider == HOSTED_PROVIDER_NAME,
+                ProviderKey.is_deleted == 0,
+            )
+        )
+    ).scalars().all()
+
+    source = hosted_key_source(
+        env_key=settings.orcarouter_api_key,
+        db_keys=list(rows),
+    )
+
+    return {
+        "configured": source is not None,
+        "source": source,
+        "base_url": settings.orcarouter_base_url,
+        "signup_url": settings.orcarouter_signup_url,
+        "provider_name": HOSTED_PROVIDER_NAME,
+    }

--- a/app/routes/providers.py
+++ b/app/routes/providers.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app import router_cache
 from app.deps import get_db, get_key_context
 from packages.auth.encryption import encrypt_credential
 from packages.auth.types import KeyContext
@@ -87,6 +88,7 @@ async def set_provider_key(
         db.add(existing)
 
     await db.commit()
+    router_cache.invalidate_router()
 
     return ProviderKeyOut(
         provider=existing.provider,
@@ -115,4 +117,5 @@ async def delete_provider_key(
 
     row.is_deleted = 1
     await db.commit()
+    router_cache.invalidate_router()
     return Response(status_code=204)

--- a/design/app.js
+++ b/design/app.js
@@ -453,13 +453,19 @@ function renderHostedCard() {
     if (providersCard) providersCard.hidden = true;
 
     // Hosted-active state: source line + extra savings projection
-    const src = state.hosted.source === "env" ? "via environment variable" : "via dashboard";
+    const isEnv = state.hosted.source === "env";
     const ha = state.savings.hosted_auto;
     const haText = (ha && ha.saved_microcents > 0)
       ? `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of current spend) by routing through hosted-auto on the cheapest catalog model per request.`
       : `No request history yet — once traffic flows, this card will show how much routing through hosted-auto would save.`;
-    $("#hosted-active-meta").innerHTML = `Active ${src}. Every catalog model is reachable.`;
+    $("#hosted-active-meta").innerHTML = isEnv
+      ? `Active via environment variable (<code>ORCAROUTER_API_KEY</code>). Every catalog model is reachable. To disable, unset the env var and restart.`
+      : `Active via dashboard. Every catalog model is reachable.`;
     $("#hosted-savings").innerHTML = haText;
+    // The Remove button DELETEs the DB row; with no DB row (env-only) it
+    // would 404. Hide it and let the meta line explain how to disable.
+    const removeBtn = $("#hosted-remove-btn");
+    if (removeBtn) removeBtn.hidden = isEnv;
   } else {
     pill.textContent = "Not configured";
     pill.className = "pill muted";

--- a/design/app.js
+++ b/design/app.js
@@ -30,8 +30,10 @@ const state = {
   recent: [],
   spend: { total_microcents: 0, by_model: [] },
   latency: { by_provider: [] },
-  savings: { saved_microcents: 0, savings_percent: 0 },
+  savings: { saved_microcents: 0, savings_percent: 0, hosted_auto: null },
   models: [],
+  hosted: { configured: false, source: null, signup_url: "https://www.orcarouter.ai/signup?ref=lite-dashboard&trial=5usd", provider_name: "orcarouter" },
+  unreachable: { hosted_configured: false, unreachable: [] },
   windowDays: 7,
   lang: "python",
 };
@@ -157,6 +159,8 @@ function showShell() {
     loadAnalytics(),
     loadKeys(),
     loadModels(),
+    loadHosted(),
+    loadUnreachable(),
   ]).then(() => {
     renderProviders();
     renderRouting();
@@ -164,6 +168,8 @@ function showShell() {
     renderKeys();
     renderOverview();
     renderQuickstart();
+    renderHostedCard();
+    renderUnreachable();
     syncOnboarding();
   });
 }
@@ -188,9 +194,21 @@ function setTab(tab) {
   $("#page-sub").textContent = TAB_META[tab].sub;
   // refresh the tab's data so it's fresh-on-view
   if (tab === "analytics") loadAnalytics().then(renderAnalytics);
-  if (tab === "providers") loadProviders().then(renderProviders);
+  if (tab === "providers") {
+    Promise.all([loadProviders(), loadHosted(), loadUnreachable()]).then(() => {
+      renderProviders();
+      renderHostedCard();
+      renderUnreachable();
+    });
+  }
   if (tab === "keys")      loadKeys().then(renderKeys);
-  if (tab === "overview")  renderOverview();
+  if (tab === "overview")  {
+    Promise.all([loadHosted(), loadUnreachable()]).then(() => {
+      renderOverview();
+      renderHostedCard();
+      renderUnreachable();
+    });
+  }
 }
 
 function bindTabs() {
@@ -254,9 +272,11 @@ function renderProviders() {
         try {
           await api(`/v1/providers/${prov}`, { method: "DELETE" });
           toast(`Removed ${prov}`, "ok");
-          await loadProviders();
+          await Promise.all([loadProviders(), loadHosted(), loadUnreachable()]);
           renderProviders();
           renderQuickAdd();
+          renderHostedCard();
+          renderUnreachable();
           renderOverview();
           syncOnboarding();
         } catch (e) {
@@ -304,8 +324,10 @@ function bindProviderForm() {
       });
       $("#provider-key").value = "";
       toast(`Saved ${provider} key`, "ok");
-      await loadProviders();
+      await Promise.all([loadProviders(), loadHosted(), loadUnreachable()]);
       renderProviders();
+      renderHostedCard();
+      renderUnreachable();
       renderOverview();
       syncOnboarding();
     } catch (err) {
@@ -375,6 +397,147 @@ async function loadAnalytics() {
     if (savings) state.savings = savings;
   } catch (e) {
     toast(`Couldn't load analytics: ${e.message}`, "err");
+  }
+}
+
+/* ==========================================================================
+   HOSTED FALLBACK + UNREACHABLE MODELS
+   ========================================================================== */
+async function loadHosted() {
+  try {
+    state.hosted = await api(`/v1/hosted`);
+  } catch {
+    // Non-fatal — card just stays in unconfigured state.
+  }
+}
+
+async function loadUnreachable() {
+  try {
+    state.unreachable = await api(`/v1/analytics/unreachable?limit=8`);
+  } catch {
+    state.unreachable = { hosted_configured: false, unreachable: [] };
+  }
+}
+
+function fmtPerMtok(perToken) {
+  // litellm prices are USD per token; show as $/1M tokens.
+  const perMillion = (perToken || 0) * 1_000_000;
+  if (perMillion === 0) return "—";
+  if (perMillion < 1) return `$${perMillion.toFixed(2)}`;
+  return `$${perMillion.toFixed(2)}`;
+}
+
+function renderHostedCard() {
+  const card = $("#hosted-card");
+  if (!card) return;
+  card.hidden = false;
+
+  const pill = $("#hosted-status-pill");
+  const cta = $("#hosted-cta");
+  const active = $("#hosted-active");
+  const signupBtn = $("#hosted-signup-btn");
+  const providersPill = $("#providers-hosted-pill");
+  const providersSignup = $("#providers-hosted-signup");
+  const providersCard = $("#providers-hosted-card");
+
+  const url = state.hosted.signup_url || "https://www.orcarouter.ai/signup?ref=lite-dashboard&trial=5usd";
+  if (signupBtn) signupBtn.href = url;
+  if (providersSignup) providersSignup.href = url;
+
+  if (state.hosted.configured) {
+    pill.textContent = "Active";
+    pill.className = "pill ok";
+    cta.hidden = true;
+    active.hidden = false;
+    if (providersPill) { providersPill.textContent = "Active"; providersPill.className = "pill ok"; }
+    if (providersCard) providersCard.hidden = true;
+
+    // Hosted-active state: source line + extra savings projection
+    const src = state.hosted.source === "env" ? "via environment variable" : "via dashboard";
+    const ha = state.savings.hosted_auto;
+    const haText = (ha && ha.saved_microcents > 0)
+      ? `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of current spend) by routing through hosted-auto on the cheapest catalog model per request.`
+      : `No request history yet — once traffic flows, this card will show how much routing through hosted-auto would save.`;
+    $("#hosted-active-meta").innerHTML = `Active ${src}. Every catalog model is reachable.`;
+    $("#hosted-savings").innerHTML = haText;
+  } else {
+    pill.textContent = "Not configured";
+    pill.className = "pill muted";
+    cta.hidden = false;
+    active.hidden = true;
+    if (providersPill) { providersPill.textContent = "Not configured"; providersPill.className = "pill muted"; }
+    if (providersCard) providersCard.hidden = false;
+  }
+}
+
+function renderUnreachable() {
+  const wrap = $("#unreachable-list");
+  const grid = $("#unreachable-grid");
+  if (!wrap || !grid) return;
+  const list = state.unreachable.unreachable || [];
+  if (state.hosted.configured || list.length === 0) {
+    wrap.hidden = true;
+    return;
+  }
+  wrap.hidden = false;
+  grid.innerHTML = list.map((m) => {
+    const caps = [];
+    if (m.supports_tools) caps.push("tools");
+    if (m.supports_vision) caps.push("vision");
+    if (m.supports_json_mode) caps.push("json");
+    const capPills = caps.map((c) => `<span class="cap-pill">${c}</span>`).join("");
+    return `
+      <div class="unreachable-item" data-tooltip="Provider: ${escapeHtml(m.provider)} · ${fmtPerMtok(m.input_cost_per_token)}/$1M in · ${fmtPerMtok(m.output_cost_per_token)}/$1M out">
+        <div class="unreachable-id"><code>${escapeHtml(m.id)}</code></div>
+        <div class="unreachable-meta">
+          <span class="unreachable-provider">${escapeHtml(m.provider)}</span>
+          <span class="unreachable-price">${fmtPerMtok(m.input_cost_per_token)} / ${fmtPerMtok(m.output_cost_per_token)} per 1M</span>
+        </div>
+        <div class="unreachable-caps">${capPills}</div>
+      </div>`;
+  }).join("");
+}
+
+function bindHostedForm() {
+  const form = $("#hosted-key-form");
+  if (form) {
+    form.addEventListener("submit", async (e) => {
+      e.preventDefault();
+      const v = $("#hosted-key-input").value.trim();
+      if (!v) { toast("Paste your sk-orca-* key from orcarouter.ai", "err"); return; }
+      try {
+        await api(`/v1/providers/orcarouter`, {
+          method: "PUT",
+          body: JSON.stringify({ api_key: v }),
+        });
+        $("#hosted-key-input").value = "";
+        toast("Hosted fallback activated — every model is now reachable", "ok");
+        await Promise.all([loadHosted(), loadUnreachable(), loadProviders()]);
+        renderHostedCard();
+        renderUnreachable();
+        renderProviders();
+        renderOverview();
+      } catch (err) {
+        toast(err.message, "err");
+      }
+    });
+  }
+  const remove = $("#hosted-remove-btn");
+  if (remove) {
+    remove.addEventListener("click", async () => {
+      if (!confirm("Disable hosted fallback? Requests for models without a local key will start failing.")) return;
+      try {
+        await api(`/v1/providers/orcarouter`, { method: "DELETE" });
+        toast("Hosted fallback disabled", "info");
+        await Promise.all([loadHosted(), loadUnreachable(), loadProviders()]);
+        renderHostedCard();
+        renderUnreachable();
+        renderProviders();
+        renderOverview();
+      } catch (err) {
+        toast(err.message, "err");
+      }
+    });
   }
 }
 
@@ -564,8 +727,21 @@ function renderOverview() {
   $("#kpi-saved").textContent = fmtUsd(state.savings.saved_microcents || 0);
   $("#kpi-saved-sub").textContent =
     state.savings.savings_percent
-      ? `${state.savings.savings_percent}% smarter routing`
+      ? `vs always-GPT-4o (${state.savings.savings_percent}% off)`
       : "vs always-GPT-4o baseline";
+
+  // Second row: what hosted-auto could save on top of current routing.
+  const hostedAuto = state.savings.hosted_auto;
+  const haEl = $("#kpi-hosted-auto-value");
+  if (haEl) {
+    if (hostedAuto && hostedAuto.saved_microcents > 0) {
+      haEl.textContent = `+${fmtUsd(hostedAuto.saved_microcents)} (${hostedAuto.savings_percent}%)`;
+    } else if (hostedAuto && hostedAuto.comparable_request_count > 0) {
+      haEl.textContent = "already optimal";
+    } else {
+      haEl.textContent = "—";
+    }
+  }
 
   // True p50/p99 across raw request samples — averaging per-provider
   // percentiles is the "median of medians" trap. The /v1/analytics/latency
@@ -918,6 +1094,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   bindKeyboard();
   bindQuickstart();
   bindOnboarding();
+  bindHostedForm();
 
   // Probe existing key
   const ok = await checkAuth();

--- a/design/app.js
+++ b/design/app.js
@@ -462,7 +462,10 @@ function renderHostedCard() {
     if (!ha || ha.comparable_request_count === 0) {
       haText = `No comparable request history yet — once traffic flows, this card will show how much routing through hosted-auto would save.`;
     } else if (ha.saved_microcents > 0) {
-      haText = `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of current spend) by routing through hosted-auto on the cheapest catalog model per request.`;
+      // savings_percent is computed against comparable spend only (rows
+      // resolved to a catalog model), not total spend — keep the copy
+      // honest so non-catalog traffic doesn't make the figure misleading.
+      haText = `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of comparable-traffic spend) by routing through hosted-auto on the cheapest catalog model per request.`;
     } else {
       haText = `Already optimal — your current routing matches the cheapest hosted-auto pick on every comparable request.`;
     }

--- a/design/app.js
+++ b/design/app.js
@@ -452,12 +452,20 @@ function renderHostedCard() {
     if (providersPill) { providersPill.textContent = "Active"; providersPill.className = "pill ok"; }
     if (providersCard) providersCard.hidden = true;
 
-    // Hosted-active state: source line + extra savings projection
+    // Hosted-active state: source line + extra savings projection.
+    // Three branches: no comparable history yet, additional savings
+    // detected, or already optimal (history exists but routing matches
+    // the cheapest hosted-auto pick on every comparable request).
     const isEnv = state.hosted.source === "env";
     const ha = state.savings.hosted_auto;
-    const haText = (ha && ha.saved_microcents > 0)
-      ? `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of current spend) by routing through hosted-auto on the cheapest catalog model per request.`
-      : `No request history yet — once traffic flows, this card will show how much routing through hosted-auto would save.`;
+    let haText;
+    if (!ha || ha.comparable_request_count === 0) {
+      haText = `No comparable request history yet — once traffic flows, this card will show how much routing through hosted-auto would save.`;
+    } else if (ha.saved_microcents > 0) {
+      haText = `Up to <strong>${fmtUsd(ha.saved_microcents)}</strong> additional savings detected (${ha.savings_percent}% of current spend) by routing through hosted-auto on the cheapest catalog model per request.`;
+    } else {
+      haText = `Already optimal — your current routing matches the cheapest hosted-auto pick on every comparable request.`;
+    }
     $("#hosted-active-meta").innerHTML = isEnv
       ? `Active via environment variable (<code>ORCAROUTER_API_KEY</code>). Every catalog model is reachable. To disable, unset the env var and restart.`
       : `Active via dashboard. Every catalog model is reachable.`;

--- a/design/index.html
+++ b/design/index.html
@@ -149,13 +149,17 @@
               <div class="kpi-value" id="kpi-spend">$—</div>
               <div class="kpi-sub" id="kpi-spend-sub">across 0 requests</div>
             </article>
-            <article class="kpi-card kpi-card-accent" data-tooltip="Estimated savings vs baseline GPT-4o for the same traffic">
+            <article class="kpi-card kpi-card-accent" data-tooltip="Top: vs GPT-4o for the same traffic. Bottom: extra savings hosted-auto could unlock by reaching cheaper models you don't have keys for.">
               <div class="kpi-head">
-                <span class="kpi-label">Saved vs GPT-4o</span>
+                <span class="kpi-label">Routing savings</span>
                 <svg class="kpi-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
               </div>
               <div class="kpi-value" id="kpi-saved">$—</div>
-              <div class="kpi-sub" id="kpi-saved-sub">— smarter routing</div>
+              <div class="kpi-sub" id="kpi-saved-sub">vs always-GPT-4o</div>
+              <div class="kpi-extra" id="kpi-hosted-auto">
+                <span class="kpi-extra-label">vs hosted-auto</span>
+                <span class="kpi-extra-value" id="kpi-hosted-auto-value">+$—</span>
+              </div>
             </article>
             <article class="kpi-card" data-tooltip="True median latency across the most recent requests (raw samples, not averaged)">
               <div class="kpi-head">
@@ -212,6 +216,53 @@
             </article>
           </div>
 
+          <article class="card hosted-card" id="hosted-card" hidden>
+            <div class="hosted-card-head">
+              <div>
+                <h2 class="card-title">
+                  Hosted fallback
+                  <span class="pill" id="hosted-status-pill">Not configured</span>
+                </h2>
+                <p class="card-sub" id="hosted-card-sub">
+                  One key, every model. Standard fallback for any model you don't have a local key for.
+                  Free <strong>$5</strong> trial credit on sign-up — no credit card.
+                </p>
+              </div>
+            </div>
+
+            <!-- Unconfigured state -->
+            <div class="hosted-cta" id="hosted-cta" hidden>
+              <div class="hosted-cta-actions">
+                <a class="btn btn-primary" id="hosted-signup-btn" href="#" target="_blank" rel="noreferrer">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20M2 12h20"/></svg>
+                  Get free $5 credit on orcarouter.ai
+                </a>
+                <span class="hosted-step">Then paste the <code>sk-orca-*</code> key →</span>
+              </div>
+              <form id="hosted-key-form" class="inline-form hosted-paste">
+                <label class="field flex-grow">
+                  <span class="field-label">Hosted API key</span>
+                  <input id="hosted-key-input" type="password" placeholder="sk-orca-..." autocomplete="off" spellcheck="false">
+                </label>
+                <button type="submit" class="btn btn-primary">
+                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>
+                  Activate fallback
+                </button>
+              </form>
+              <div id="unreachable-list" class="unreachable-list" hidden>
+                <p class="hosted-meta">Models you can't reach today — hosted unlocks all of them:</p>
+                <div class="unreachable-grid" id="unreachable-grid"></div>
+              </div>
+            </div>
+
+            <!-- Configured state -->
+            <div class="hosted-active" id="hosted-active" hidden>
+              <p class="hosted-meta" id="hosted-active-meta">Active — every catalog model is reachable.</p>
+              <div class="hosted-savings" id="hosted-savings"></div>
+              <button class="btn btn-ghost btn-sm" id="hosted-remove-btn" data-tooltip="Disable hosted fallback">Remove key</button>
+            </div>
+          </article>
+
           <article class="card help-banner" id="getting-started">
             <div>
               <h3>New here? Get fully set up in 2 minutes</h3>
@@ -227,6 +278,23 @@
 
         <!-- ─────────────── Providers ─────────────── -->
         <section id="panel-providers" class="panel">
+          <article class="card hosted-card hosted-card-compact" id="providers-hosted-card" hidden>
+            <div class="hosted-card-head">
+              <div>
+                <h2 class="card-title">
+                  Hosted fallback
+                  <span class="pill" id="providers-hosted-pill">Not configured</span>
+                </h2>
+                <p class="card-sub">
+                  Cover the long tail without per-provider sign-ups. Free <strong>$5</strong> credit, billed at cost after.
+                </p>
+              </div>
+              <a class="btn btn-primary" id="providers-hosted-signup" href="#" target="_blank" rel="noreferrer">
+                Get free credit
+              </a>
+            </div>
+          </article>
+
           <article class="card">
             <header class="card-head">
               <div>

--- a/design/style.css
+++ b/design/style.css
@@ -512,12 +512,127 @@ code {
   color: var(--ink);
 }
 .kpi-sub { margin-top: 4px; font-size: 12.5px; color: var(--ink-3); }
+.kpi-extra {
+  margin-top: 10px;
+  padding-top: 8px;
+  border-top: 1px dashed var(--border);
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 11.5px;
+  color: var(--ink-3);
+}
+.kpi-extra-label { letter-spacing: 0.02em; }
+.kpi-extra-value {
+  font-weight: 600;
+  color: var(--brand-deep);
+  font-variant-numeric: tabular-nums;
+}
 .kpi-card-accent {
   background: linear-gradient(135deg, var(--brand-soft) 0%, white 60%);
   border-color: var(--brand-soft);
 }
 .kpi-card-accent .kpi-value { color: var(--brand-deep); }
 .kpi-card-accent .kpi-icon  { color: var(--brand); }
+
+/* ==========================================================================
+   HOSTED FALLBACK CARD
+   ========================================================================== */
+.hosted-card {
+  background: linear-gradient(135deg, var(--brand-soft) 0%, white 70%);
+  border-color: var(--brand-soft);
+}
+.hosted-card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--s-4);
+}
+.hosted-card-compact .hosted-card-head { align-items: center; }
+.hosted-cta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-4);
+  margin-top: var(--s-4);
+}
+.hosted-cta-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--s-3);
+  flex-wrap: wrap;
+}
+.hosted-step {
+  font-size: 12.5px;
+  color: var(--ink-3);
+}
+.hosted-step code {
+  font-size: 11.5px;
+  background: var(--surface-2);
+  padding: 1px 5px;
+  border-radius: 4px;
+}
+.hosted-paste { margin: 0; }
+.hosted-active {
+  margin-top: var(--s-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--s-3);
+}
+.hosted-meta { font-size: 13px; color: var(--ink-2); margin: 0; }
+.hosted-savings {
+  font-size: 13px;
+  color: var(--ink);
+  background: var(--surface-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+}
+
+/* ==========================================================================
+   UNREACHABLE MODELS GRID
+   ========================================================================== */
+.unreachable-list { margin-top: var(--s-3); }
+.unreachable-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--s-3);
+  margin-top: var(--s-2);
+}
+.unreachable-item {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  transition: border-color var(--d-fast) var(--ease), transform var(--d-fast) var(--ease);
+}
+.unreachable-item:hover {
+  border-color: var(--brand);
+  transform: translateY(-1px);
+}
+.unreachable-id { font-family: var(--font-mono); font-size: 12.5px; color: var(--ink); }
+.unreachable-meta {
+  display: flex;
+  justify-content: space-between;
+  font-size: 11.5px;
+  color: var(--ink-3);
+  font-variant-numeric: tabular-nums;
+}
+.unreachable-provider { text-transform: capitalize; }
+.unreachable-caps { display: flex; gap: 4px; flex-wrap: wrap; margin-top: 2px; }
+.cap-pill {
+  font-size: 10px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--ink-2);
+  background: var(--surface-2);
+  padding: 1px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+}
 
 /* ==========================================================================
    FORMS

--- a/tests/integration/test_hosted_status.py
+++ b/tests/integration/test_hosted_status.py
@@ -124,6 +124,119 @@ async def test_hosted_status_dashboard_overrides_env(tmp_sqlite_url, monkeypatch
     session_mod._session_factory = None
 
 
+async def test_hosted_status_reports_unconfigured_when_db_row_undecryptable(tmp_sqlite_url, monkeypatch):
+    """Codex P1: hosted_key_source previously trusted any enabled DB row,
+    but build_deployments only deploys hosted when the key actually
+    decrypts. Inject a corrupt encrypted_key directly and verify
+    /v1/hosted reports unconfigured (not 'Active' lying to the user)."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    # Insert a corrupt orcarouter row directly — bypasses the encryption
+    # path that PUT /v1/providers/orcarouter would use.
+    from packages.db.models.provider_key import ProviderKey
+    async with factory() as s:
+        s.add(ProviderKey(
+            provider="orcarouter",
+            encrypted_key=b"definitely-not-a-valid-aesgcm-blob",
+            key_prefix="sk-orca-...",
+            label="default",
+            is_enabled=True,
+        ))
+        await s.commit()
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.get("/v1/hosted")
+        body = r.json()
+        assert body["configured"] is False, (
+            "Undecryptable DB row must not flip /v1/hosted to configured — "
+            "the router can't actually use it"
+        )
+        assert body["source"] is None
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
+async def test_hosted_status_falls_back_to_env_when_db_row_undecryptable(tmp_sqlite_url, monkeypatch):
+    """If the dashboard-stored key is corrupt but ORCAROUTER_API_KEY is
+    set, /v1/hosted should report source=env — matching what
+    build_deployments will actually do."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-from-env-fallback")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from packages.db.models.provider_key import ProviderKey
+    async with factory() as s:
+        s.add(ProviderKey(
+            provider="orcarouter",
+            encrypted_key=b"corrupt",
+            key_prefix="sk-orca-...",
+            label="default",
+            is_enabled=True,
+        ))
+        await s.commit()
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.get("/v1/hosted")
+        body = r.json()
+        assert body["configured"] is True
+        assert body["source"] == "env"
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_hosted_status_requires_auth(tmp_sqlite_url, monkeypatch):
     """Anonymous clients must not be able to enumerate hosted state."""
     engine, factory, client = await _make_client(tmp_sqlite_url, monkeypatch)

--- a/tests/integration/test_hosted_status.py
+++ b/tests/integration/test_hosted_status.py
@@ -1,0 +1,136 @@
+"""Tests for GET /v1/hosted — the "Hosted fallback" status endpoint.
+
+The dashboard's hosted CTA card calls this on mount to decide whether to
+show the "Get free $5 credit" sign-up flow or the "Active" pill. If this
+endpoint lies about state, the conversion funnel breaks.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def _make_client(tmp_sqlite_url, monkeypatch, env_vars: dict | None = None):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    for k, v in (env_vars or {}).items():
+        monkeypatch.setenv(k, v)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+    return engine, factory, AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    )
+
+
+@pytest.fixture
+async def unconfigured_client(tmp_sqlite_url, monkeypatch):
+    engine, factory, client = await _make_client(tmp_sqlite_url, monkeypatch)
+    async with client as c:
+        yield c
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None
+
+
+@pytest.fixture
+async def env_configured_client(tmp_sqlite_url, monkeypatch):
+    engine, factory, client = await _make_client(
+        tmp_sqlite_url, monkeypatch,
+        {"ORCAROUTER_API_KEY": "sk-orca-from-env"},
+    )
+    async with client as c:
+        yield c
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None
+
+
+async def test_hosted_status_unconfigured_shows_signup_url(unconfigured_client):
+    r = await unconfigured_client.get("/v1/hosted")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["configured"] is False
+    assert body["source"] is None
+    assert body["base_url"] == "https://api.orcarouter.ai/v1"
+    # The sign-up URL is what the dashboard's "Get free $5 credit" button
+    # opens — must point at orcarouter.ai (not openrouter, not anything else).
+    assert "orcarouter.ai" in body["signup_url"]
+    assert body["provider_name"] == "orcarouter"
+
+
+async def test_hosted_status_env_configured_reports_env_source(env_configured_client):
+    r = await env_configured_client.get("/v1/hosted")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["configured"] is True
+    assert body["source"] == "env"
+
+
+async def test_hosted_status_dashboard_configured_reports_dashboard_source(unconfigured_client):
+    """Pasting the key via PUT /v1/providers/orcarouter must flip the status
+    to configured + source=dashboard, not env."""
+    put = await unconfigured_client.put(
+        "/v1/providers/orcarouter",
+        json={"api_key": "sk-orca-from-dashboard"},
+    )
+    assert put.status_code == 200, put.text
+
+    r = await unconfigured_client.get("/v1/hosted")
+    body = r.json()
+    assert body["configured"] is True
+    assert body["source"] == "dashboard"
+
+
+async def test_hosted_status_dashboard_overrides_env(tmp_sqlite_url, monkeypatch):
+    """When both env + DB are set, the source reports 'dashboard'
+    (matches the precedence in build_deployments)."""
+    engine, factory, client = await _make_client(
+        tmp_sqlite_url, monkeypatch,
+        {"ORCAROUTER_API_KEY": "sk-orca-from-env"},
+    )
+    async with client as c:
+        await c.put(
+            "/v1/providers/orcarouter",
+            json={"api_key": "sk-orca-from-dashboard"},
+        )
+        r = await c.get("/v1/hosted")
+        body = r.json()
+        assert body["configured"] is True
+        assert body["source"] == "dashboard"
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None
+
+
+async def test_hosted_status_requires_auth(tmp_sqlite_url, monkeypatch):
+    """Anonymous clients must not be able to enumerate hosted state."""
+    engine, factory, client = await _make_client(tmp_sqlite_url, monkeypatch)
+    async with client as c:
+        c.headers.pop("Authorization", None)
+        r = await c.get("/v1/hosted")
+        assert r.status_code == 401
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None

--- a/tests/integration/test_savings.py
+++ b/tests/integration/test_savings.py
@@ -122,6 +122,80 @@ async def test_savings_endpoint_excludes_failed_requests(savings_client):
     assert body["request_count"] == 2  # the 503 row excluded
 
 
+async def test_savings_response_includes_hosted_auto_block(savings_client):
+    """The savings tile in the dashboard renders TWO rows:
+      1. vs always-GPT-4o (existing)
+      2. vs hosted-auto (the cheapest catalog model with the same caps)
+
+    Backend must surface both so the SPA doesn't have to compute the
+    second one client-side from the catalog."""
+    r = await savings_client.get("/v1/analytics/savings?days=30")
+    body = r.json()
+    assert "hosted_auto" in body
+    ha = body["hosted_auto"]
+    for field in (
+        "actual_microcents",
+        "saved_microcents",
+        "savings_percent",
+        "comparable_request_count",
+    ):
+        assert field in ha
+
+
+async def test_hosted_auto_never_more_expensive_than_actual(savings_client):
+    """The hosted-auto comparison picks the cheapest model meeting the
+    resolved model's capabilities, so it can't cost MORE than what was
+    actually spent — at worst, it picks the same model and saves $0."""
+    r = await savings_client.get("/v1/analytics/savings?days=30")
+    body = r.json()
+    ha = body["hosted_auto"]
+    assert ha["actual_microcents"] <= body["actual_microcents"]
+    assert ha["saved_microcents"] >= 0
+
+
+async def test_hosted_auto_zero_when_no_history(tmp_sqlite_url, monkeypatch):
+    """Empty request log → hosted_auto returns zeros, not nulls/errors."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.get("/v1/analytics/savings?days=30")
+    body = r.json()
+    assert body["hosted_auto"]["actual_microcents"] == 0
+    assert body["hosted_auto"]["saved_microcents"] == 0
+    assert body["hosted_auto"]["savings_percent"] == 0
+    assert body["hosted_auto"]["comparable_request_count"] == 0
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_savings_endpoint_handles_empty_history(tmp_sqlite_url, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
     from app import config as cfg

--- a/tests/integration/test_savings.py
+++ b/tests/integration/test_savings.py
@@ -122,6 +122,93 @@ async def test_savings_endpoint_excludes_failed_requests(savings_client):
     assert body["request_count"] == 2  # the 503 row excluded
 
 
+async def test_hosted_auto_excludes_non_catalog_row_costs_from_savings(tmp_sqlite_url, monkeypatch):
+    """Regression: requests resolved to a model not in the catalog can't be
+    compared against hosted-auto, so they were skipped in the hosted_microcents
+    sum — but their cost was still in actual_microcents. That inflated the
+    saved figure (Codex P1 review on PR #9). The savings denominator must be
+    the actual spend on COMPARABLE rows only."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    # 1 catalog row with tiny cost + 1 non-catalog row with huge cost.
+    # The non-catalog row's cost MUST NOT show up as hosted-auto savings.
+    from packages.db.models.request_log import RequestLog
+    catalog_cost = int((1000 * 1.5e-7 + 500 * 6e-7) * 1_000_000)  # ~$0.00045
+    huge_non_catalog_cost = 999_000_000  # $999 — would dwarf savings if leaked
+
+    rows = [
+        RequestLog(
+            workspace_id="default", api_key_id=str(uuid.uuid4()),
+            trace_id=str(uuid.uuid4()),
+            model_requested="auto", model_resolved="gpt-4o-mini",
+            provider="openai", routing_strategy="balanced",
+            input_tokens=1000, output_tokens=500,
+            cost_microcents=catalog_cost,
+            latency_ms=100, status_code=200,
+        ),
+        RequestLog(
+            workspace_id="default", api_key_id=str(uuid.uuid4()),
+            trace_id=str(uuid.uuid4()),
+            model_requested="auto",
+            model_resolved="some-private-fine-tune-not-in-catalog",
+            provider="openai", routing_strategy="balanced",
+            input_tokens=10_000, output_tokens=10_000,
+            cost_microcents=huge_non_catalog_cost,
+            latency_ms=300, status_code=200,
+        ),
+    ]
+    async with factory() as s:
+        for r in rows:
+            s.add(r)
+        await s.commit()
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.get("/v1/analytics/savings?days=30")
+    body = r.json()
+    ha = body["hosted_auto"]
+
+    # Only 1 row was comparable.
+    assert ha["comparable_request_count"] == 1
+    # Hard upper bound: hosted-auto savings can never exceed the actual spend
+    # on comparable rows. The non-catalog $999 row must not leak in.
+    assert ha["saved_microcents"] <= catalog_cost, (
+        f"saved={ha['saved_microcents']} > comparable actual={catalog_cost} — "
+        "non-catalog row cost leaked into the savings figure"
+    )
+    # Percent must also be relative to comparable spend, never the inflated total.
+    assert ha["savings_percent"] <= 100
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_savings_response_includes_hosted_auto_block(savings_client):
     """The savings tile in the dashboard renders TWO rows:
       1. vs always-GPT-4o (existing)

--- a/tests/integration/test_unreachable.py
+++ b/tests/integration/test_unreachable.py
@@ -1,0 +1,142 @@
+"""Tests for GET /v1/analytics/unreachable — the "Models you can't reach" tile.
+
+Drives the dashboard's conversion message: "look what you're missing without
+hosted." When hosted is configured, the list must clear to zero (otherwise
+the tile would lie about coverage).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+async def _client(tmp_sqlite_url, monkeypatch, env_vars: dict | None = None):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    for k, v in (env_vars or {}).items():
+        monkeypatch.setenv(k, v)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+    return engine, AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    )
+
+
+@pytest.fixture
+async def fresh_client(tmp_sqlite_url, monkeypatch):
+    engine, client = await _client(tmp_sqlite_url, monkeypatch)
+    async with client as c:
+        yield c
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None
+
+
+async def test_unreachable_with_no_keys_lists_flagship_models(fresh_client):
+    """A bare-bones Lite install with no provider keys can't reach any
+    flagship model — the endpoint should return a non-empty list to power
+    the conversion CTA."""
+    r = await fresh_client.get("/v1/analytics/unreachable")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["hosted_configured"] is False
+    assert body["configured_providers"] == []
+    assert len(body["unreachable"]) >= 1
+    # Each entry must carry the fields the SPA renders (provider, prices,
+    # capability flags) — otherwise the tile breaks.
+    sample = body["unreachable"][0]
+    for field in (
+        "id", "provider",
+        "input_cost_per_token", "output_cost_per_token",
+        "supports_tools", "supports_vision", "supports_json_mode",
+    ):
+        assert field in sample
+
+
+async def test_unreachable_excludes_models_for_configured_providers(fresh_client):
+    """Once anthropic key is set, no anthropic models appear in unreachable."""
+    await fresh_client.put(
+        "/v1/providers/anthropic",
+        json={"api_key": "sk-ant-test"},
+    )
+    r = await fresh_client.get("/v1/analytics/unreachable")
+    body = r.json()
+    assert "anthropic" in body["configured_providers"]
+    providers_in_list = {m["provider"] for m in body["unreachable"]}
+    assert "anthropic" not in providers_in_list
+
+
+async def test_unreachable_clears_when_hosted_enabled(fresh_client):
+    """Hosted reaches every catalog model, so the unreachable list must be
+    empty — otherwise the dashboard would falsely tell active hosted users
+    they're missing models they actually have access to."""
+    await fresh_client.put(
+        "/v1/providers/orcarouter",
+        json={"api_key": "sk-orca-test"},
+    )
+    r = await fresh_client.get("/v1/analytics/unreachable")
+    body = r.json()
+    assert body["hosted_configured"] is True
+    assert body["unreachable"] == []
+
+
+async def test_unreachable_clears_when_hosted_via_env(tmp_sqlite_url, monkeypatch):
+    """Env-configured hosted should clear the list just like dashboard does."""
+    engine, client = await _client(
+        tmp_sqlite_url, monkeypatch,
+        {"ORCAROUTER_API_KEY": "sk-orca-env"},
+    )
+    async with client as c:
+        r = await c.get("/v1/analytics/unreachable")
+        body = r.json()
+        assert body["hosted_configured"] is True
+        assert body["unreachable"] == []
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None
+
+
+async def test_unreachable_respects_limit(fresh_client):
+    r = await fresh_client.get("/v1/analytics/unreachable?limit=3")
+    body = r.json()
+    assert len(body["unreachable"]) <= 3
+
+
+async def test_unreachable_counts_env_provider_keys(tmp_sqlite_url, monkeypatch):
+    """Env-set OPENAI_API_KEY counts as 'configured' — a Docker user with
+    only env vars shouldn't see openai models in the unreachable tile."""
+    engine, client = await _client(
+        tmp_sqlite_url, monkeypatch,
+        {"OPENAI_API_KEY": "sk-test-env"},
+    )
+    async with client as c:
+        r = await c.get("/v1/analytics/unreachable")
+        body = r.json()
+        assert "openai" in body["configured_providers"]
+        providers_in_list = {m["provider"] for m in body["unreachable"]}
+        assert "openai" not in providers_in_list
+    await engine.dispose()
+    from packages.db import session as session_mod
+    session_mod._session_factory = None

--- a/tests/integration/test_unreachable.py
+++ b/tests/integration/test_unreachable.py
@@ -124,6 +124,66 @@ async def test_unreachable_respects_limit(fresh_client):
     assert len(body["unreachable"]) <= 3
 
 
+async def test_unreachable_excludes_undecryptable_provider_keys(tmp_sqlite_url, monkeypatch):
+    """Codex P2: an enabled DB row with a corrupt encrypted_key isn't
+    actually deployable (build_deployments drops it). The unreachable
+    endpoint must not silently treat that provider as 'covered' — those
+    models really are unreachable until the key is fixed."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    # Inject a corrupt anthropic row — would falsely suppress claude-* from
+    # the unreachable list if the endpoint trusts is_enabled blindly.
+    from packages.db.models.provider_key import ProviderKey
+    async with factory() as s:
+        s.add(ProviderKey(
+            provider="anthropic",
+            encrypted_key=b"corrupt-not-valid-aesgcm",
+            key_prefix="sk-ant-...",
+            label="default",
+            is_enabled=True,
+        ))
+        await s.commit()
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.get("/v1/analytics/unreachable")
+        body = r.json()
+        assert "anthropic" not in body["configured_providers"], (
+            "An undecryptable DB row must not be reported as a configured "
+            "provider — build_deployments can't deploy it"
+        )
+        providers_in_list = {m["provider"] for m in body["unreachable"]}
+        assert "anthropic" in providers_in_list
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_unreachable_counts_env_provider_keys(tmp_sqlite_url, monkeypatch):
     """Env-set OPENAI_API_KEY counts as 'configured' — a Docker user with
     only env vars shouldn't see openai models in the unreachable tile."""

--- a/tests/unit/test_hosted_auto.py
+++ b/tests/unit/test_hosted_auto.py
@@ -1,0 +1,118 @@
+"""Unit tests for `_hosted_auto_savings` — the hosted-auto comparison
+that powers the second row of the savings KPI in the dashboard.
+
+These tests bypass the analytics fixture and call the function directly
+with a synthetic catalog so we can pin behavior on edge cases (token-mix
+asymmetry, zero-priced models) without depending on whatever litellm
+ships in `model_cost`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class _StubModel:
+    """Subset of CatalogModel that `_hosted_auto_savings` consumes."""
+    id: str
+    supports_tools: bool = False
+    supports_vision: bool = False
+    supports_json_mode: bool = False
+    input_cost_per_token: float = 0.0
+    output_cost_per_token: float = 0.0
+
+
+def _build(catalog: list) -> tuple[list, dict]:
+    return catalog, {m.id: m for m in catalog}
+
+
+def test_hosted_auto_picks_cheapest_for_each_row_actual_tokens():
+    """Codex P2: _hosted_auto_savings was using a fixed 30/70 blended cost
+    weight to pick a single fallback model per `model_resolved`. For
+    input-heavy or output-heavy requests, that's not the cheapest for
+    that request. The endpoint claims "cheapest per request" — and we
+    have per-row tokens — so cost should be minimized using each row's
+    actual input/output mix.
+
+    Setup: two candidates whose ranking flips depending on token mix.
+      A: cheap output, pricey input  (great for output-heavy traffic)
+      B: cheap input,  pricey output (great for input-heavy traffic)
+
+    Two request rows: one input-heavy, one output-heavy.
+    The cheapest possible total spans BOTH models (A for the
+    output-heavy row, B for the input-heavy row). A 30/70 blended
+    pick of one model can never beat that combined min.
+    """
+    from app.routes.analytics import _hosted_auto_savings
+
+    A = _StubModel("A", input_cost_per_token=10e-6, output_cost_per_token=1e-6)
+    B = _StubModel("B", input_cost_per_token=1e-6,  output_cost_per_token=10e-6)
+    Resolved = _StubModel("R", input_cost_per_token=100e-6, output_cost_per_token=100e-6)
+    catalog, by_id = _build([A, B, Resolved])
+
+    # Costs in microcents:
+    #   row1 (10000 in / 100 out): A → 10000*10 + 100*1   = 100100
+    #                              B → 10000*1  + 100*10  =  11000  ← cheapest
+    #   row2 (100 in / 10000 out): A → 100*10   + 10000*1 =  11000  ← cheapest
+    #                              B → 100*1    + 10000*10= 100100
+    # Per-row optimum total: 11000 + 11000 = 22000
+    # Blended-30/70 picks: A blended = 0.3*10+0.7*1 = 3.7
+    #                     B blended = 0.3*1+0.7*10 = 7.3 → A wins blended.
+    # Single-model A total: 100100 + 11000 = 111100. Per-row beats by 5×.
+    rows = [
+        # (input_tokens, output_tokens, cost_microcents, model_resolved)
+        (10000, 100,   500_000, "R"),  # actual cost arbitrary, > both candidates
+        (100,   10000, 500_000, "R"),
+    ]
+
+    result = _hosted_auto_savings(rows, catalog, by_id)
+    assert result["comparable_request_count"] == 2
+    # The hosted-auto cost must equal the per-row optimum (22000),
+    # not the single-model blended pick (111100). With a tolerance of
+    # 1 microcent for int rounding.
+    assert result["actual_microcents"] <= 22_001, (
+        f"hosted_auto picked {result['actual_microcents']} microcents — "
+        "expected per-row minimum of 22000. A 30/70 blended single-pick "
+        "would give 111100; that's the bug."
+    )
+
+
+def test_hosted_auto_falls_back_to_zero_for_non_catalog_resolved():
+    """Pre-existing behavior: rows whose model_resolved isn't in the
+    catalog are dropped from the comparison."""
+    from app.routes.analytics import _hosted_auto_savings
+
+    A = _StubModel("A", input_cost_per_token=1e-6, output_cost_per_token=1e-6)
+    catalog, by_id = _build([A])
+
+    rows = [(100, 100, 999_000, "not-in-catalog")]
+    result = _hosted_auto_savings(rows, catalog, by_id)
+    assert result["comparable_request_count"] == 0
+    assert result["actual_microcents"] == 0
+    assert result["saved_microcents"] == 0
+
+
+def test_hosted_auto_filters_candidates_by_capability():
+    """A row resolved to a vision-capable model can only be compared
+    against vision-capable candidates — never downgrade capabilities."""
+    from app.routes.analytics import _hosted_auto_savings
+
+    cheap_no_vision = _StubModel(
+        "cheap", supports_vision=False,
+        input_cost_per_token=1e-9, output_cost_per_token=1e-9,
+    )
+    pricey_with_vision = _StubModel(
+        "vis", supports_vision=True,
+        input_cost_per_token=1e-6, output_cost_per_token=1e-6,
+    )
+    resolved_with_vision = _StubModel(
+        "R", supports_vision=True,
+        input_cost_per_token=100e-6, output_cost_per_token=100e-6,
+    )
+    catalog, by_id = _build([cheap_no_vision, pricey_with_vision, resolved_with_vision])
+
+    rows = [(1000, 1000, 200_000, "R")]
+    result = _hosted_auto_savings(rows, catalog, by_id)
+    # Must pick `vis` (1e-6 each), not `cheap` (1e-9). Cost = 1000+1000 = 2000 microcents.
+    assert result["actual_microcents"] == 2000

--- a/tests/unit/test_router_cache.py
+++ b/tests/unit/test_router_cache.py
@@ -127,3 +127,99 @@ def test_orcarouter_upstream_combines_with_local_keys(monkeypatch):
     providers = {d.provider for d in deps}
     assert "openai" in providers
     assert "orcarouter" in providers
+
+
+def test_orcarouter_db_row_enables_hosted_upstream():
+    """Pasting the orcarouter key in the dashboard (→ DB row) lights up
+    hosted upstream, not just an inert provider entry. Mirrors what happens
+    after a user clicks "Activate fallback" on the hosted CTA card."""
+    from app.config import Settings
+    from app.router_cache import build_deployments
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.models.provider_key import ProviderKey
+    from packages.litellm_adapter.catalog import all_model_ids
+
+    s = Settings(_env_file=None)
+    db_row = ProviderKey(
+        provider="orcarouter",
+        encrypted_key=encrypt_credential("sk-orca-from-dashboard"),
+        key_prefix="sk-orca-...",
+        label="default",
+        is_enabled=True,
+    )
+    deps = build_deployments(env_keys={}, db_keys=[db_row], settings=s)
+    orca_deps = [d for d in deps if d.provider == "orcarouter"]
+    assert len(orca_deps) == len(all_model_ids())
+    for d in orca_deps:
+        assert d.api_key == "sk-orca-from-dashboard"
+        assert d.api_base == "https://api.orcarouter.ai/v1"
+
+
+def test_orcarouter_db_row_overrides_env_key(monkeypatch):
+    """DB-stored hosted key beats env, just like every other provider does.
+    Lets a user rotate via the dashboard without restarting the container."""
+    from app.config import Settings
+    from app.router_cache import build_deployments
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.models.provider_key import ProviderKey
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-from-env")
+    s = Settings(_env_file=None)
+
+    db_row = ProviderKey(
+        provider="orcarouter",
+        encrypted_key=encrypt_credential("sk-orca-from-db"),
+        key_prefix="sk-orca-...",
+        label="default",
+        is_enabled=True,
+    )
+    deps = build_deployments(env_keys={}, db_keys=[db_row], settings=s)
+    orca_deps = [d for d in deps if d.provider == "orcarouter"]
+    assert orca_deps  # at least one
+    assert all(d.api_key == "sk-orca-from-db" for d in orca_deps)
+
+
+def test_disabled_orcarouter_db_row_falls_back_to_env(monkeypatch):
+    """A disabled hosted DB row shouldn't shadow the env key — env is the
+    fallback when the dashboard-stored key is turned off."""
+    from app.config import Settings
+    from app.router_cache import build_deployments
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.models.provider_key import ProviderKey
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-from-env")
+    s = Settings(_env_file=None)
+
+    db_row = ProviderKey(
+        provider="orcarouter",
+        encrypted_key=encrypt_credential("sk-orca-disabled"),
+        key_prefix="sk-orca-...",
+        label="default",
+        is_enabled=False,
+    )
+    deps = build_deployments(env_keys={}, db_keys=[db_row], settings=s)
+    orca_deps = [d for d in deps if d.provider == "orcarouter"]
+    assert orca_deps
+    assert all(d.api_key == "sk-orca-from-env" for d in orca_deps)
+
+
+def test_hosted_key_source_reports_origin(monkeypatch):
+    """`hosted_key_source` underpins the dashboard's "Hosted fallback"
+    pill — must distinguish dashboard-set vs env-set vs unconfigured."""
+    from app.router_cache import hosted_key_source
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.models.provider_key import ProviderKey
+
+    assert hosted_key_source(env_key=None, db_keys=[]) is None
+    assert hosted_key_source(env_key="sk-orca-x", db_keys=[]) == "env"
+
+    db_row = ProviderKey(
+        provider="orcarouter",
+        encrypted_key=encrypt_credential("sk-orca-d"),
+        key_prefix="sk-orca-...",
+        label="default",
+        is_enabled=True,
+    )
+    assert hosted_key_source(env_key=None, db_keys=[db_row]) == "dashboard"
+    # DB beats env in the precedence reporting too
+    assert hosted_key_source(env_key="sk-orca-x", db_keys=[db_row]) == "dashboard"

--- a/tests/unit/test_router_cache.py
+++ b/tests/unit/test_router_cache.py
@@ -223,3 +223,54 @@ def test_hosted_key_source_reports_origin(monkeypatch):
     assert hosted_key_source(env_key=None, db_keys=[db_row]) == "dashboard"
     # DB beats env in the precedence reporting too
     assert hosted_key_source(env_key="sk-orca-x", db_keys=[db_row]) == "dashboard"
+
+
+def test_hosted_key_source_treats_undecryptable_db_row_as_unconfigured():
+    """A DB row whose ciphertext can't be decrypted (e.g. after encryption-
+    key rotation or DB corruption) is functionally unusable —
+    build_deployments silently drops it and never creates hosted
+    deployments. hosted_key_source must report the same view, otherwise
+    /v1/hosted lies about coverage and the dashboard shows "Active" while
+    requests fail."""
+    from app.router_cache import hosted_key_source
+    from packages.db.models.provider_key import ProviderKey
+
+    corrupt = ProviderKey(
+        provider="orcarouter",
+        encrypted_key=b"too-short-to-be-valid-aesgcm",
+        key_prefix="sk-orca-...",
+        label="default",
+        is_enabled=True,
+    )
+    # No env, only a corrupt DB row → unconfigured.
+    assert hosted_key_source(env_key=None, db_keys=[corrupt]) is None
+    # Env still wins as fallback when the DB row can't be decrypted.
+    assert hosted_key_source(env_key="sk-orca-env", db_keys=[corrupt]) == "env"
+
+
+def test_usable_providers_from_db_skips_undecryptable_rows():
+    """Helper that mirrors build_deployments' decryption filter so callers
+    reporting 'configured providers' (e.g. /v1/analytics/unreachable) can't
+    drift from what the router actually deploys."""
+    from app.router_cache import usable_providers_from_db
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.models.provider_key import ProviderKey
+
+    rows = [
+        ProviderKey(
+            provider="openai",
+            encrypted_key=encrypt_credential("sk-good"),
+            key_prefix="sk-...", label="default", is_enabled=True,
+        ),
+        ProviderKey(
+            provider="anthropic",
+            encrypted_key=b"corrupt-blob-cant-decrypt",
+            key_prefix="sk-ant-...", label="default", is_enabled=True,
+        ),
+        ProviderKey(
+            provider="google",
+            encrypted_key=encrypt_credential("sk-disabled"),
+            key_prefix="sk-...", label="default", is_enabled=False,
+        ),
+    ]
+    assert usable_providers_from_db(rows) == {"openai"}


### PR DESCRIPTION
## Summary
This PR adds hosted fallback configuration management and an "unreachable models" conversion tile to the dashboard. Users can now enable orcarouter as a standard fallback provider directly from the UI, and see which flagship models they're missing keys for—driving adoption of the free $5 trial credit offer.

## Key Changes

**Backend (Analytics & Hosted Status)**
- New `GET /v1/hosted` endpoint reports hosted fallback configuration state (unconfigured, env-sourced, or dashboard-sourced) and signup URL
- New `GET /v1/analytics/unreachable` endpoint returns a curated list of flagship catalog models the user can't currently reach, filtered by configured provider keys and hosted status
- Enhanced `GET /v1/analytics/savings` to include `hosted_auto` block: per-request, what would the cheapest catalog model with matching capabilities have cost? This upper-bounds additional savings hosted-auto could unlock
- Added `_hosted_auto_savings()` helper that computes capability-aware cost comparison without requiring client-side catalog logic

**Router & Config**
- `build_deployments()` now respects DB-stored orcarouter keys (dashboard-configured) with precedence over env vars, enabling key rotation without restart
- New `hosted_key_source()` utility distinguishes configuration origin (env vs dashboard) for status reporting
- Updated `HOSTED_PROVIDER_NAME` handling to support both env and DB-stored keys

**Dashboard UI**
- New "Hosted fallback" card on Overview & Providers tabs showing configuration status (Active/Not configured pill)
- Unconfigured state: sign-up CTA + inline form to paste `sk-orca-*` key
- Configured state: displays source (env/dashboard), shows projected additional savings from hosted-auto routing
- New "Models you can't reach" grid below hosted card: displays unreachable flagship models with provider, pricing, and capability badges (tools/vision/json)
- Enhanced savings KPI card with two-row breakdown: vs GPT-4o (existing) + vs hosted-auto (new)
- Form binding for hosted key submission/removal with proper state refresh

**Tests**
- `test_hosted_status.py`: Validates endpoint behavior across unconfigured, env-configured, and dashboard-configured states; confirms auth requirement
- `test_unreachable.py`: Verifies unreachable list filtering by provider keys, hosted status, and limit parameter
- `test_savings.py`: Confirms `hosted_auto` block presence and correctness; validates it never exceeds actual spend
- `test_router_cache.py`: Tests DB-stored orcarouter key precedence and `hosted_key_source()` reporting

## Implementation Details
- Unreachable models use a curated `_PROMOTED_MODEL_IDS` list (Claude, GPT-4o, Gemini, etc.) rather than the full 100+ catalog to avoid burying the conversion message
- Hosted-auto savings calculation respects capability requirements (tools, vision, json_mode) and uses the same blended cost weighting as the auto-router
- Dashboard state refresh on provider key changes ensures hosted/unreachable tiles stay in sync
- All hosted endpoints require authentication to prevent enumeration of configuration state

https://claude.ai/code/session_01At6SXP8AGHv249D9zp8Gea