### PR TITLE
Fix unreadable hover text on btn-primary / btn-danger anchors

### DIFF
--- a/design/style.css
+++ b/design/style.css
@@ -725,7 +725,12 @@ select {
   color: white;
   box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06), 0 4px 12px var(--brand-glow);
 }
-.btn-primary:hover { background: var(--brand-deep); box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06), 0 6px 18px var(--brand-glow); }
+/* Color is repeated on :hover so the rule beats the base `a:hover`
+   selector (specificity 0,1,1) when the button is rendered as an
+   `<a>` (e.g. the "Get free credit" CTA links to orcarouter.ai/register).
+   Without this, hover flips text to var(--brand-deep) on a blue
+   background and becomes unreadable. */
+.btn-primary:hover { background: var(--brand-deep); color: white; box-shadow: 0 1px 0 rgba(15, 23, 42, 0.06), 0 6px 18px var(--brand-glow); }
 .btn-ghost {
   background: var(--surface);
   border-color: var(--border);
@@ -738,7 +743,8 @@ select {
   color: var(--err);
   border-color: var(--err-soft);
 }
-.btn-danger:hover { background: var(--err-soft); border-color: var(--err); }
+/* Same `a:hover` override defense as .btn-primary above. */
+.btn-danger:hover { background: var(--err-soft); color: var(--err); border-color: var(--err); }
 .btn-sm { padding: 5px 10px; font-size: 12.5px; }
 .btn-full { width: 100%; padding: 11px 14px; font-size: 14px; }
 


### PR DESCRIPTION
## Summary

Hovering the **Get free credit on orcarouter.ai** buttons (and the providers-tab variant) made the text turn blue on a blue background, leaving it unreadable.

## Root cause

The base anchor rule

```css
a:hover { color: var(--brand-deep); }
```

has CSS specificity `(0,1,1)` — element + pseudo-class. `.btn-primary { color: white }` is `(0,1,0)` — single class. When the button is rendered as `<a class="btn btn-primary">` (the "Hosted fallback" CTA links to `https://www.orcarouter.ai/register`), `a:hover` wins on hover and flips the text to deep-blue on the brand-blue background.

`.btn-primary:hover` was only setting `background` and `box-shadow`, never reasserting `color`.

## Fix

Repeat `color: white` inside `.btn-primary:hover` so the rule's specificity becomes `(0,2,0)` and beats `a:hover`. Same defensive change on `.btn-danger:hover` (no current `<a class="btn btn-danger">` usage, but the latent bug is identical).

```diff
-.btn-primary:hover { background: var(--brand-deep); box-shadow: ... }
+.btn-primary:hover { background: var(--brand-deep); color: white; box-shadow: ... }
```

## Test plan
- [ ] Visual: open dashboard, hover the **Get free $5 credit on orcarouter.ai** button on the Overview tab — text stays white
- [ ] Visual: open Providers tab, hover the **Get free credit** button — same
- [x] `pytest -q` → 145 passed locally
- [x] `ruff check .` → clean

I haven't visually confirmed in a browser (no headless tooling here); the fix is grounded in the specificity reasoning above.

https://claude.ai/code/session_01At6SXP8AGHv249D9zp8Gea

---
_Generated by [Claude Code](https://claude.ai/code/session_01At6SXP8AGHv249D9zp8Gea)_