### PR TITLE
Fix model="auto" failures: wire LiteLLM cascade + catalog hygiene + security

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,16 @@ LOG_LEVEL=info
 # with everything routed through hosted.
 # ORCAROUTER_API_KEY=sk-orca-...
 # ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
+
+# ── Router behavior (cooldown + cascade) ──────────────
+# How long a deployment is skipped after a failure (404 / 408 / 429 / 401).
+# Default 1h is safe for prod. Lower for local dev (network blips shouldn't
+# lock a model out for an hour); set 0 in tests.
+# ROUTER_COOLDOWN_SECONDS=3600
+# ROUTER_ALLOWED_FAILS=0
+# ROUTER_PRE_CALL_CHECKS=true
+# In-deployment retry counts. The "auto" path uses 0 so cascade to the
+# next fallback model happens immediately on failure (avoids 30-90s of
+# perceived latency from retrying a dead deployment 2x first).
+# ROUTER_NUM_RETRIES_DEFAULT=2
+# ROUTER_NUM_RETRIES_AUTO=0

--- a/app/auto_routing.py
+++ b/app/auto_routing.py
@@ -1,17 +1,18 @@
-"""`model="auto"` — pick a catalog model that meets the request's capability
-requirements AND has a deployable provider configured. Selection rule depends
+"""`model="auto"` — pick catalog models that meet the request's capability
+requirements AND have a deployable provider configured. Selection rule depends
 on the active routing strategy.
 
 Two pure functions:
   - `required_capabilities(body)`  → set of {"tools", "vision", "json_mode"}
   - `choose_auto_model(needs, deployable, candidates, strategy, preferred_models)`
-    → model_id | None
+    → list of model_ids ordered by strategy (best first; empty if none)
 
 The chat handler resolves `model="auto"` by:
   1. computing needs = required_capabilities(request_body)
   2. computing deployable = {dep.model_name for dep in active_deployments}
-  3. calling choose_auto_model(...)
-  4. swapping the resolved id into the request before calling the router
+  3. calling choose_auto_model(...) to get top-N candidates
+  4. using candidates[0] as the primary model and candidates[1:] as Router
+     fallbacks so a 404/cooldown on the primary cascades automatically.
 
 Adapted from `apps/api/routes/chat.py:_required_capabilities` /
 `_score_model_for_auto` in the SaaS edition.
@@ -112,8 +113,15 @@ def choose_auto_model(
     candidates: Iterable[CatalogModel],
     strategy: str | None = None,
     preferred_models: list[str] | None = None,
-) -> str | None:
-    """Return a deployable model matching all `needs`, or None.
+    allowlist: list[str] | set[str] | None = None,
+    top_n: int = 5,
+) -> list[str]:
+    """Return up to `top_n` deployable models matching all `needs`, best first.
+
+    Empty list means no candidate satisfies the request. The first element is
+    the primary; subsequent elements are intended as LiteLLM Router fallbacks
+    so a 404 / cooldown on the primary cascades to the next-best candidate
+    without the user seeing an error.
 
     Selection rule by strategy:
       - `quality`: highest blended cost (proxy for "biggest/most-capable")
@@ -125,6 +133,11 @@ def choose_auto_model(
     If `preferred_models` is non-empty AND at least one entry is deployable
     + capability-matching, the eligible set is restricted to that list. This
     lets users pin a quality tier without giving up auto resolution.
+
+    If `allowlist` is non-empty, the eligible set is intersected with it
+    BEFORE the top-N cut so an allowed model that would otherwise rank 6+
+    isn't accidentally dropped. Empty intersection → empty result, and the
+    caller is responsible for surfacing the right HTTP error to the user.
 
     Excludes models with zero blended cost — those are unpriced entries in
     litellm's catalogue, not actually free, and routing to them would skew
@@ -141,10 +154,19 @@ def choose_auto_model(
         narrowed = [m for m in eligible if m.id in preferred_set]
         if narrowed:
             eligible = narrowed
+    if allowlist is not None:
+        # Apply the key's allowlist before sorting + truncation. Without
+        # this, an allowed model ranked beyond top_n would be dropped and
+        # the caller would falsely report no allowed match.
+        # `is not None` (not truthiness): an explicit empty allowlist is
+        # a "deny everything" signal from the operator; falsy check would
+        # silently invert that into "no restriction" — a security hole.
+        allow_set = set(allowlist)
+        eligible = [m for m in eligible if m.id in allow_set]
     if not eligible:
-        return None
+        return []
     if strategy == "quality":
         eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
     else:
         eligible.sort(key=lambda m: (_blended_cost(m), m.id))
-    return eligible[0].id
+    return [m.id for m in eligible[:top_n]]

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,34 @@ class Settings(BaseSettings):
     # ── Body limit (for image / file attachments) ──
     max_body_bytes: int = 100 * 1024 * 1024
 
+    # ── Router behavior (LiteLLM Router cooldown + cascade) ──
+    # How long a deployment stays cooled-down after a failure. LiteLLM's
+    # default is 1 second, which is effectively no cooldown — a dead model
+    # gets re-picked on the very next request. Production default is 1h.
+    # Local dev / CI may want lower (network blips shouldn't lock a model
+    # out for an hour); tests should set 0 to disable.
+    router_cooldown_seconds: int = 3600
+    # Global default for failures-before-cooldown across all error types,
+    # used by LiteLLM Router as the fallback when AllowedFailsPolicy returns
+    # a falsy value. We set 0 so the policy's "fail fast on hard errors"
+    # values (also 0) actually take effect — LiteLLM's internal
+    # `allowed_fails = policy_value or router.allowed_fails` short-circuits
+    # any 0 in the policy back to this default. Per-error-type leniency for
+    # transients (429 / 5xx / timeouts) still applies via non-zero policy
+    # values, set in client.py:_build_allowed_fails_policy().
+    router_allowed_fails: int = 0
+    # When True, LiteLLM filters deployments whose context window can't fit
+    # the request before dispatching. Cheap pre-flight that prevents wasted
+    # round-trips on prompts that would 422 anyway.
+    router_pre_call_checks: bool = True
+    # In-deployment retry count. The default applies to explicitly-pinned
+    # model requests (where the user said "use this exact model, retry it").
+    # The auto value is used when the request was model="auto" so cascade
+    # to the next fallback candidate happens immediately instead of after
+    # 2x in-deployment retries (which would add ~30-90s of perceived latency).
+    router_num_retries_default: int = 2
+    router_num_retries_auto: int = 0
+
     def env_provider_keys(self) -> dict[str, str]:
         """Return the configured ENV-sourced provider keys as {provider: key}."""
         out: dict[str, str] = {}

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -187,6 +187,13 @@ async def get_router(session) -> object:
             strategy=strategy,
             preferred_models=preferred_models,
             litellm_routing_strategy=litellm_routing_strategy(strategy),
+            # Wire LiteLLM Router built-ins from settings so a deployment
+            # that 404s once stays cooled down (no immediate re-pick), and
+            # the cascade engine has policy for which errors fail fast.
+            cooldown_time=float(settings.router_cooldown_seconds),
+            allowed_fails=settings.router_allowed_fails,
+            enable_pre_call_checks=settings.router_pre_call_checks,
+            num_retries=settings.router_num_retries_default,
         )
         return _cached_client
 

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -8,6 +8,7 @@ response in OpenAI's `text/event-stream` format with a terminal
 from __future__ import annotations
 
 import json
+import re
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable
@@ -19,11 +20,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import prompt_cache, router_cache
 from app.auto_routing import choose_auto_model, required_capabilities
+from app.config import get_settings
 from app.deps import get_db, get_key_context
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.db.models.request_log import RequestLog
 from packages.litellm_adapter.catalog import CATALOG
+from packages.litellm_adapter.types import UpstreamProviderError
 
 logger = structlog.get_logger()
 router = APIRouter(prefix="/v1", tags=["Chat Completions"])
@@ -38,6 +41,92 @@ def _chunk_to_dict(chunk) -> dict:
     return dict(chunk)
 
 
+# Suffix shapes that mark a response model as a more-specific *version* of the
+# requested model rather than a different one. Matched against the substring
+# AFTER `requested_group + "-"` in the served name.
+#   "2024-08-06"   — OpenAI dated version
+#   "20241022"     — Anthropic dated version (compact form)
+#   "001" / "002"  — Google Vertex / Gemini revision suffix
+#   "v1.5"         — explicit semver-like version
+#
+# Deliberately excluded:
+#   "preview"      — too ambiguous. "gpt-4-turbo-preview" is a distinct
+#                    catalog model from "gpt-4-turbo", not a version variant.
+#   "latest"       — providers don't return "-latest" in response.model;
+#                    it's only a request-side alias.
+#   "mini" / etc.  — branding suffixes, not versions.
+_VERSION_SUFFIX_RE = re.compile(
+    r"^("
+    r"\d{4}-\d{2}-\d{2}"     # YYYY-MM-DD
+    r"|\d{6,}"                # YYYYMMDD or compact dates / build numbers
+    r"|\d{1,4}"               # 001, 002, 1, 12, ...
+    r"|v\d[\d.]*"             # v1, v1.5, v2.0.1
+    r")$"
+)
+
+
+def _served_same_group_as_requested(
+    *, requested_group: str, served_model: str | None, client
+) -> bool:
+    """Return True iff the response's served model is in the same model_group
+    (model_name in our deployment taxonomy) as the requested primary.
+
+    LiteLLM frequently rewrites or expands model names in the response:
+      - prefixed form: requested "gpt-4o-mini", response.model = "openai/gpt-4o-mini"
+      - dated alias:   requested "gpt-4o", response.model = "gpt-4o-2024-08-06"
+      - bare provider model: requested "claude-3-5-sonnet-latest",
+                             response.model = "claude-3-5-sonnet-20241022"
+
+    Strict string equality would treat these as different models and disable
+    the prompt cache for almost all real traffic. Canonicalize via four
+    progressively-stricter passes:
+
+    1. Exact / prefix-stripped equality — handles "openai/gpt-4o-mini" vs "gpt-4o-mini".
+    2. Version-suffix variant — served = requested + "-" + (date | build | vN).
+       Catches OpenAI's "gpt-4o-2024-08-06" for "gpt-4o" without falsely
+       matching "gpt-4o-mini" for "gpt-4o" (mini is not a date pattern).
+    3. Deployment lookup — authoritative for the configured Router. If the
+       served name maps to a different deployment's model_name, real cascade.
+    4. Catalog lookup — if the bare name is a known distinct catalog entry,
+       treat as cascade. Otherwise (unknown rendering), permit caching.
+    """
+    if not served_model:
+        return True
+    if served_model == requested_group:
+        return True
+    bare = served_model.split("/", 1)[-1] if "/" in served_model else served_model
+    if bare == requested_group:
+        return True
+
+    # Pass 2: version-suffix variant (must run BEFORE deployment/catalog
+    # lookups, because dated variants like "gpt-4o-2024-08-06" are also
+    # in CATALOG_BY_ID as their own entries — those passes would falsely
+    # flag them as a different group).
+    if bare.startswith(requested_group + "-"):
+        suffix = bare[len(requested_group) + 1:]
+        if _VERSION_SUFFIX_RE.match(suffix):
+            return True
+
+    # Pass 3: deployment lookup. Authoritative — these are the model_groups
+    # we actually configured for this Router.
+    deployments = getattr(client, "_deployments", []) or []
+    for d in deployments:
+        if served_model in (d.litellm_model, d.model_name) or bare == d.model_name:
+            return d.model_name == requested_group
+
+    # Pass 4: catalog lookup. If the bare name is itself a recognized
+    # catalog model distinct from the requested group, treat as cascade.
+    # Imported lazily so the catalog isn't a hard dependency for this fn.
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+    if bare in CATALOG_BY_ID and bare != requested_group:
+        return False
+
+    # Bare name doesn't resemble any known model — likely a provider-side
+    # normalization we don't recognize. Permit caching to avoid disabling
+    # the cache wholesale for unfamiliar response shapes.
+    return True
+
+
 async def _build_log_row(
     *,
     body: ChatCompletionRequest,
@@ -47,16 +136,27 @@ async def _build_log_row(
     error_type: str | None,
     started_perf: float,
     strategy: str,
+    requested_model: str,
+    actual_resolved: str | None = None,
 ) -> RequestLog:
+    """Persist what the client asked for vs. what actually served the request.
+
+    `requested_model` is the value the client sent (e.g. "auto" or a pinned
+    model name) — captured before any auto-resolution so the log preserves
+    user intent. `actual_resolved` is the model that ultimately served the
+    response, which may differ from the auto-resolved primary if LiteLLM
+    Router cascaded to a fallback after a 404 / cooldown.
+    """
     latency_ms = int((time.perf_counter() - started_perf) * 1000)
     meta = response.get("_orca_meta", {})
     usage = response.get("usage", {}) or {}
+    resolved = actual_resolved or response.get("model") or requested_model
     return RequestLog(
         workspace_id=str(kc.workspace_id),
         api_key_id=str(kc.key_id),
         trace_id=str(uuid.uuid4()),
-        model_requested=body.model,
-        model_resolved=response.get("model", body.model),
+        model_requested=requested_model,
+        model_resolved=resolved,
         provider=meta.get("provider", "unknown"),
         routing_strategy=strategy,
         input_tokens=usage.get("prompt_tokens", 0),
@@ -76,7 +176,22 @@ async def chat_completions(
     kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ):
-    if kc.model_allowlist and body.model not in kc.model_allowlist:
+    # Capture client intent before any mutation so the request log and the
+    # `x-orca-requested-model` header always reflect what the user asked for,
+    # not the post-resolution primary.
+    requested_model = body.model
+    was_auto = body.model == "auto"
+
+    # Allowlist enforcement is split: pinned requests check up front, auto
+    # requests defer to after resolution (since "auto" itself is never in
+    # an allowlist literal). Without this exemption, every key with an
+    # allowlist would be locked out of `model="auto"`.
+    #
+    # `is not None` (not truthiness): an explicit empty list means "deny
+    # everything" — the operator's intent is to lock the key down. Falsy
+    # check would let an empty allowlist mean "no restriction", which
+    # silently inverts the operator's security posture.
+    if not was_auto and kc.model_allowlist is not None and body.model not in kc.model_allowlist:
         raise HTTPException(
             status_code=403,
             detail=f"Model '{body.model}' is not allowed for this API key",
@@ -89,12 +204,12 @@ async def chat_completions(
     preferred_models = raw_preferred if isinstance(raw_preferred, list) else []
 
     # Resolve `model="auto"` BEFORE building the request kwargs so the router
-    # sees a real model. Capability requirements come from the request body
-    # (tools / response_format / image content); deployable set comes from the
-    # current router's deployment list.
-    requested_model = body.model
+    # sees a real model. `candidates` is the top-N list from auto-routing;
+    # candidates[0] becomes the primary and candidates[1:] are passed to
+    # LiteLLM Router as fallbacks for automatic cascade on 404 / cooldown.
     resolved_model = body.model
-    if body.model == "auto":
+    candidates: list[str] = []
+    if was_auto:
         body_dict = body.model_dump(exclude_none=True)
         needs = required_capabilities(body_dict)
         deployable = {
@@ -108,14 +223,46 @@ async def chat_completions(
                     "configured key. No deployable provider found."
                 ),
             )
-        chosen = choose_auto_model(
+        # Pass the key's allowlist into the resolver so it filters BEFORE
+        # the top-N truncation. Without this, an allowed model ranked at
+        # position 6+ would be silently dropped by top_n=5 and the user
+        # would see a false 403 even though they have a valid candidate.
+        candidates = choose_auto_model(
             needs=needs,
             deployable=deployable,
             candidates=CATALOG,
             strategy=strategy,
             preferred_models=preferred_models,
+            allowlist=kc.model_allowlist,
         )
-        if chosen is None:
+        if not candidates:
+            # Empty result has two distinct causes — distinguish them so the
+            # operator can debug the right thing:
+            #   - 422: no model in the catalog can satisfy the request at all
+            #          (capability mismatch or no provider key configured)
+            #   - 403: capable models exist but none are in this key's allowlist
+            # Re-run the resolver without the allowlist to tell which case
+            # applies. Cheap (in-memory list comprehension, no DB / network).
+            # Use `is not None` to honor explicit empty allowlist (deny-all).
+            if kc.model_allowlist is not None:
+                any_capable = choose_auto_model(
+                    needs=needs,
+                    deployable=deployable,
+                    candidates=CATALOG,
+                    strategy=strategy,
+                    preferred_models=preferred_models,
+                    allowlist=None,
+                    top_n=1,
+                )
+                if any_capable:
+                    raise HTTPException(
+                        status_code=403,
+                        detail=(
+                            f"No deployable model in this key's allowlist "
+                            f"{kc.model_allowlist} satisfies the requested "
+                            f"capabilities ({sorted(needs) or 'none'})."
+                        ),
+                    )
             raise HTTPException(
                 status_code=422,
                 detail=(
@@ -124,11 +271,30 @@ async def chat_completions(
                     "supports them or pin a specific model."
                 ),
             )
-        resolved_model = chosen
-        body.model = chosen  # mutate for downstream
+
+        resolved_model = candidates[0]
+        body.model = candidates[0]  # mutate for downstream completion call
 
     started_perf = time.perf_counter()
     completion_kwargs = body.model_dump(exclude_none=True)
+
+    # Build the LiteLLM fallbacks argument from the auto candidate list.
+    # Format: [{primary_model_name: [fallback_1, fallback_2, ...]}]
+    # LiteLLM's async_function_with_fallbacks reads this from kwargs and
+    # cascades automatically when the primary deployment fails or is in
+    # cooldown — no explicit retry loop needed in this handler.
+    fallbacks_arg: list | None = None
+    if was_auto and len(candidates) > 1:
+        fallbacks_arg = [{candidates[0]: candidates[1:]}]
+
+    # On the auto path, set num_retries=0 so a dead primary cascades to the
+    # next fallback immediately. Default num_retries (configured on Router)
+    # would retry the primary 2x before cascading, adding 30-90s of latency
+    # before the user sees a working response.
+    settings = get_settings()
+    per_call_kwargs: dict = {}
+    if was_auto:
+        per_call_kwargs["num_retries"] = settings.router_num_retries_auto
 
     # ── Prompt cache (blocking deterministic requests only) ────────────
     cache_status = "BYPASS"
@@ -151,17 +317,22 @@ async def chat_completions(
             cache_status = "MISS"
 
     if cache_hit_response is not None:
-        # Log the hit so dashboards reflect real traffic, but mark provider="cache"
-        # and cost=0 so spend math stays right.
+        # Cache hit: served by us, no upstream call. Provider tagged "cache",
+        # cost is zero so the savings dashboard stays accurate. We use the
+        # resolved primary as the served model — cache lookup is keyed on
+        # the same model so there's no cascade ambiguity here.
+        cached_model = cache_hit_response.get("model", resolved_model)
         log = await _build_log_row(
             body=body, kc=kc,
             response={
-                "model": cache_hit_response.get("model", body.model),
+                "model": cached_model,
                 "usage": cache_hit_response.get("usage", {}),
                 "_orca_meta": {"provider": "cache", "latency_ms": 0},
             },
             status_code=200, error_type=None, started_perf=started_perf,
             strategy=strategy,
+            requested_model=requested_model,
+            actual_resolved=cached_model,
         )
         log.cost_microcents = 0
         db.add(log)
@@ -173,18 +344,33 @@ async def chat_completions(
             content=cache_hit_response,
             headers={
                 "x-orca-cache": "HIT",
-                "x-orca-resolved-model": resolved_model,
+                "x-orca-resolved-model": cached_model,
                 "x-orca-requested-model": requested_model,
                 "x-orca-routing-strategy": strategy,
             },
         )
 
     # ── Streaming path ─────────────────────────────────────────────────
+    # NOTE: LiteLLM Router can fall back to a different model only BEFORE the
+    # first chunk is emitted (or via MidStreamFallbackError, which only some
+    # providers raise). Once any byte of the SSE stream is sent to the client,
+    # mid-flight cascade is impossible — we have to surface the error and let
+    # the client decide what to do.
     if body.stream:
         try:
-            stream_obj = await client.acompletion(**completion_kwargs)
+            stream_obj = await client.acompletion(
+                **completion_kwargs,
+                fallbacks=fallbacks_arg,
+                **per_call_kwargs,
+            )
         except HTTPException:
             raise
+        except UpstreamProviderError as exc:
+            logger.warning("chat_completion_upstream_error", error=str(exc))
+            raise HTTPException(
+                status_code=exc.http_status,
+                detail=f"Upstream provider error: {exc}",
+            ) from exc
         except Exception as exc:
             logger.warning("chat_completion_upstream_error", error=str(exc))
             raise HTTPException(status_code=503, detail=f"Upstream provider error: {exc}") from exc
@@ -194,7 +380,9 @@ async def chat_completions(
             agg_usage: dict = {}
             agg_provider = "unknown"
             agg_latency = 0
-            agg_model = body.model
+            # The first chunk's `model` field tells us what LiteLLM actually
+            # served (could be a cascaded fallback, not the resolved primary).
+            agg_model: str | None = None
             status_code = 200
             error_type: str | None = None
             try:
@@ -212,21 +400,57 @@ async def chat_completions(
                         agg_model = d["model"]
                     yield f"data: {json.dumps(d, separators=(',', ':'))}\n\n"
             except Exception as exc:
+                # Translate the underlying LiteLLM exception so the request
+                # log records the meaningful error_type (rate_limit_error,
+                # model_not_found, ...) instead of just the raw class name.
+                # The HTTP status is already 200 because headers were sent
+                # before the first chunk; the SSE error frame carries the
+                # type string for clients that parse it.
+                from packages.litellm_adapter.client import _translate_error
+                try:
+                    translated = _translate_error(exc)
+                except Exception:
+                    translated = None
+                if isinstance(translated, UpstreamProviderError):
+                    error_type = translated.error_type
+                    sse_error_type = translated.error_type
+                else:
+                    error_type = type(exc).__name__
+                    sse_error_type = "upstream_error"
+                # Mid-stream the response status is locked to 200 (headers
+                # already flushed). Record 503 in the log to flag the
+                # underlying upstream failure for analytics.
                 status_code = 503
-                error_type = type(exc).__name__
-                logger.warning("chat_completion_stream_error", error=str(exc))
+                logger.warning(
+                    "chat_completion_stream_error",
+                    error=str(exc), error_type=error_type,
+                )
                 err_body = {
                     "error": {
                         "message": f"Upstream provider error: {exc}",
-                        "type": "upstream_error",
+                        "type": sse_error_type,
                     }
                 }
                 yield f"data: {json.dumps(err_body)}\n\n"
             finally:
                 yield "data: [DONE]\n\n"
+                # Real LiteLLM stream chunks don't carry _orca_meta (the
+                # adapter only injects it on non-stream responses, since
+                # wrapping every chunk would be wasteful). Look up provider
+                # attribution from the served model name against the active
+                # deployments — same lookup the non-stream adapter does.
+                if agg_provider == "unknown" and agg_model:
+                    deployments = getattr(client, "_deployments", []) or []
+                    bare_served = (
+                        agg_model.split("/", 1)[-1] if "/" in agg_model else agg_model
+                    )
+                    for d in deployments:
+                        if agg_model in (d.litellm_model, d.model_name) or bare_served == d.model_name:
+                            agg_provider = d.provider
+                            break
                 # Synthesize a response-shaped dict for the log helper.
                 synthetic = {
-                    "model": agg_model,
+                    "model": agg_model or resolved_model,
                     "usage": agg_usage,
                     "_orca_meta": {"provider": agg_provider, "latency_ms": agg_latency},
                 }
@@ -235,6 +459,8 @@ async def chat_completions(
                     status_code=status_code, error_type=error_type,
                     started_perf=started_perf,
                     strategy=strategy,
+                    requested_model=requested_model,
+                    actual_resolved=agg_model,
                 )
                 db.add(log)
                 try:
@@ -248,6 +474,10 @@ async def chat_completions(
             headers={
                 "Cache-Control": "no-cache",
                 "X-Accel-Buffering": "no",
+                # Headers are sent before the first chunk, so we can only
+                # promise the resolved primary here. The actual served model
+                # ends up in each chunk's `model` field — clients reading the
+                # stream get authoritative info from there.
                 "x-orca-resolved-model": resolved_model,
                 "x-orca-requested-model": requested_model,
                 "x-orca-routing-strategy": strategy,
@@ -258,10 +488,27 @@ async def chat_completions(
     status_code = 200
     error_type: str | None = None
     response: dict = {}
+    actual_resolved: str | None = None
     try:
-        response = await client.acompletion(**completion_kwargs)
+        response = await client.acompletion(
+            **completion_kwargs,
+            fallbacks=fallbacks_arg,
+            **per_call_kwargs,
+        )
+        # The response.model field is what LiteLLM ultimately served — could
+        # be the resolved primary, or a cascaded fallback if the primary 404'd.
+        if isinstance(response, dict):
+            actual_resolved = response.get("model") or resolved_model
     except HTTPException:
         raise
+    except UpstreamProviderError as exc:
+        status_code = exc.http_status
+        error_type = exc.error_type
+        logger.warning("chat_completion_upstream_error", error=str(exc), error_type=exc.error_type)
+        raise HTTPException(
+            status_code=exc.http_status,
+            detail=f"Upstream provider error: {exc}",
+        ) from exc
     except Exception as exc:
         status_code = 503
         error_type = type(exc).__name__
@@ -273,6 +520,11 @@ async def chat_completions(
             status_code=status_code, error_type=error_type,
             started_perf=started_perf,
             strategy=strategy,
+            requested_model=requested_model,
+            # On failure actual_resolved is None — fall back to the resolved
+            # primary so the log row records what we tried, not "auto" (which
+            # _build_log_row would otherwise default to via requested_model).
+            actual_resolved=actual_resolved or resolved_model,
         )
         db.add(log)
         try:
@@ -283,8 +535,23 @@ async def chat_completions(
     if isinstance(response, dict) and "_orca_meta" in response:
         response = {k: v for k, v in response.items() if k != "_orca_meta"}
 
-    # Write to cache on MISS (don't write on BYPASS — that's by design).
-    if cache_status == "MISS" and cache_lookup_key is not None and isinstance(response, dict):
+    # Write to cache on MISS only when the served model is in the same
+    # model_group as the resolved primary. If LiteLLM Router cascaded to a
+    # different group (fallback), the response is from a DIFFERENT model
+    # than the cache key implies, and caching it would poison future
+    # requests for the primary. Equivalent names within the same group
+    # (prefix, dated alias) ARE safe to cache — see the helper for details.
+    cache_safe_to_write = (
+        cache_status == "MISS"
+        and cache_lookup_key is not None
+        and isinstance(response, dict)
+        and _served_same_group_as_requested(
+            requested_group=resolved_model,
+            served_model=actual_resolved,
+            client=client,
+        )
+    )
+    if cache_safe_to_write:
         try:
             await prompt_cache.get_backend().set(cache_lookup_key, response, ttl=3600)
         except Exception as exc:
@@ -294,7 +561,10 @@ async def chat_completions(
         content=response,
         headers={
             "x-orca-cache": cache_status,
-            "x-orca-resolved-model": resolved_model,
+            # actual_resolved reflects post-cascade truth (might differ from
+            # the primary if Router fell back). Falls back to resolved_model
+            # if the response shape is unexpected.
+            "x-orca-resolved-model": actual_resolved or resolved_model,
             "x-orca-requested-model": requested_model,
             "x-orca-routing-strategy": strategy,
         },

--- a/packages/auth/encryption.py
+++ b/packages/auth/encryption.py
@@ -1,9 +1,14 @@
 """Provider credential encryption — AES-256-GCM.
 
-Vendored from main repo, simplified — reads CREDENTIAL_ENCRYPTION_KEY directly
-from env. If unset, derives a deterministic dev key from a fixed seed so that
-local development doesn't require any setup. In production, set a real
-64-char hex string.
+Vendored from main repo, simplified. Reads CREDENTIAL_ENCRYPTION_KEY from the
+loaded Settings (which honors `.env`) with `os.environ` as a fallback for
+test fixtures that set the env var directly.
+
+If neither yields a key, derives a deterministic dev key from a fixed seed
+so local development doesn't require any setup. **In production, set a real
+64-char hex string** — the dev fallback is publicly known via the source
+code, so anyone with read access to the SQLite file could decrypt provider
+keys with it.
 """
 
 from __future__ import annotations
@@ -15,7 +20,21 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 
 
 def _get_encryption_key() -> bytes:
-    key_hex = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "")
+    # Prefer Settings (which loads .env) over raw os.environ, because
+    # pydantic-settings does NOT propagate .env values into os.environ.
+    # Without this lookup, a user who follows the README and writes
+    # CREDENTIAL_ENCRYPTION_KEY=... in .env would silently get the dev
+    # fallback constant — the worst possible "secure by default" failure.
+    key_hex = ""
+    try:
+        from app.config import get_settings
+        key_hex = get_settings().credential_encryption_key or ""
+    except Exception:
+        # Settings may not be importable in some isolated test contexts;
+        # fall through to env-only behavior.
+        pass
+    if not key_hex:
+        key_hex = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "")
     if key_hex:
         try:
             raw = bytes.fromhex(key_hex)

--- a/packages/auth/hashing.py
+++ b/packages/auth/hashing.py
@@ -1,8 +1,10 @@
 """API key generation, hashing, password utilities.
 
-Vendored from main repo, simplified — no Settings dependency, pepper read
-directly from env. Lite is single-tenant so the brute-force surface is
-the operator's own machine.
+Vendored from main repo, simplified. Reads API_KEY_PEPPER from the loaded
+Settings (which honors `.env`) with `os.environ` as a fallback for tests.
+Lite is single-tenant so the brute-force surface is the operator's own
+machine, but the pepper still matters for offline attacks against a stolen
+SQLite file.
 """
 
 import hashlib
@@ -12,7 +14,20 @@ import secrets
 
 
 def _get_api_key_pepper() -> bytes | None:
-    pepper = os.environ.get("API_KEY_PEPPER", "")
+    # Prefer Settings (which loads .env) over raw os.environ. pydantic-settings
+    # does NOT propagate .env values into os.environ, so a user who follows
+    # the README and sets API_KEY_PEPPER in .env would otherwise silently get
+    # un-peppered (plain SHA-256) hashes — a downgrade from the documented
+    # security posture.
+    pepper = ""
+    try:
+        from app.config import get_settings
+        pepper = get_settings().api_key_pepper or ""
+    except Exception:
+        # Settings may not be importable in some isolated test contexts.
+        pass
+    if not pepper:
+        pepper = os.environ.get("API_KEY_PEPPER", "")
     if not pepper or len(pepper) < 32:
         return None
     return pepper.encode("utf-8")

--- a/packages/litellm_adapter/catalog.py
+++ b/packages/litellm_adapter/catalog.py
@@ -13,6 +13,7 @@ of unrelated modules don't need it).
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import date
 
 # ── Provider mapping: litellm prefix → (our provider id, litellm prefix string) ──
 # Each entry maps a litellm provider key (the part before the `/` in the model
@@ -51,6 +52,30 @@ class CatalogModel:
     supports_json_mode: bool = False
     input_cost_per_token: float = 0.0
     output_cost_per_token: float = 0.0
+    # ISO-8601 (YYYY-MM-DD) sourced from litellm meta, or None when unknown.
+    # Surfaced for UI display; routing-time exclusion happens at load via
+    # `_is_obviously_dead` below, not by reading this field.
+    deprecation_date: str | None = None
+
+
+def _is_obviously_dead(meta: dict) -> bool:
+    """Return True when meta declares a deprecation_date that is today or earlier.
+
+    Filters out models that the upstream provider has already retired, per
+    LiteLLM's community-maintained metadata. We trust this only as a hint —
+    providers sometimes pull a model earlier than the published date, which
+    is why LiteLLM Router's runtime cooldown is the second line of defense.
+
+    Tolerates malformed values (placeholder strings like LiteLLM's `sample_spec`
+    entry) by treating them as "not dead".
+    """
+    dep = meta.get("deprecation_date", "")
+    if not isinstance(dep, str) or not dep:
+        return False
+    try:
+        return date.fromisoformat(dep) <= date.today()
+    except ValueError:
+        return False
 
 
 def _is_chat_model(meta: dict) -> bool:
@@ -85,6 +110,12 @@ def _build_catalog_from_litellm() -> list[CatalogModel]:
         provider_id, prefix = mapped
         if not _is_chat_model(meta) and _strip_prefix(raw_id) not in _FORCE_INCLUDE:
             continue
+        # Drop models the upstream provider has already retired per LiteLLM's
+        # metadata. Models that LiteLLM hasn't marked yet but the provider has
+        # killed (e.g. early-deprecation cases) are caught at runtime by the
+        # Router's cooldown after the first 404.
+        if _is_obviously_dead(meta):
+            continue
 
         canonical = _strip_prefix(raw_id)
         # Some entries duplicate (e.g. "openai/gpt-4o" and "gpt-4o"); first wins.
@@ -92,6 +123,7 @@ def _build_catalog_from_litellm() -> list[CatalogModel]:
             continue
         seen.add(canonical)
 
+        dep_raw = meta.get("deprecation_date")
         out.append(
             CatalogModel(
                 id=canonical,
@@ -108,12 +140,15 @@ def _build_catalog_from_litellm() -> list[CatalogModel]:
                 ),
                 input_cost_per_token=float(meta.get("input_cost_per_token") or 0.0),
                 output_cost_per_token=float(meta.get("output_cost_per_token") or 0.0),
+                deprecation_date=dep_raw if isinstance(dep_raw, str) and dep_raw else None,
             )
         )
 
     # Make sure a few flagship aliases are always present even if the litellm
     # version pins a different canonical ID. This keeps demos / examples stable
-    # across litellm upgrades.
+    # across litellm upgrades. Each alias still respects deprecation: if the
+    # underlying model is past its deprecation_date in litellm's metadata, the
+    # alias is skipped here as well.
     flagship = {
         "claude-3-5-sonnet-latest": (
             "anthropic", "anthropic/", True, True, False,
@@ -126,16 +161,49 @@ def _build_catalog_from_litellm() -> list[CatalogModel]:
     }
     existing_ids = {m.id for m in out}
     for fid, (prov, prefix, tools, vision, json_mode, in_c, out_c) in flagship.items():
-        if fid not in existing_ids:
-            out.append(CatalogModel(
-                id=fid, provider=prov, litellm_prefix=prefix,
-                supports_tools=tools, supports_vision=vision,
-                supports_json_mode=json_mode,
-                input_cost_per_token=in_c, output_cost_per_token=out_c,
-            ))
+        if fid in existing_ids:
+            continue
+        # Inherit deprecation_date from any model_cost entry whose stripped id
+        # matches this alias. If any of them is dead, treat the alias as dead.
+        flagship_dep = _flagship_deprecation(model_cost, fid)
+        if _is_obviously_dead({"deprecation_date": flagship_dep}):
+            continue
+        out.append(CatalogModel(
+            id=fid, provider=prov, litellm_prefix=prefix,
+            supports_tools=tools, supports_vision=vision,
+            supports_json_mode=json_mode,
+            input_cost_per_token=in_c, output_cost_per_token=out_c,
+            deprecation_date=flagship_dep,
+        ))
 
     out.sort(key=lambda m: (m.provider, m.id))
     return out
+
+
+def _flagship_deprecation(model_cost: dict, fid: str) -> str | None:
+    """Find the earliest deprecation_date among model_cost entries matching `fid`.
+
+    A flagship alias like `claude-3-5-sonnet-latest` is a virtual name we add on
+    top of whatever the provider currently calls the latest version. If the
+    underlying versions have all been retired, the alias should be retired too.
+    Returns the earliest ISO date string found, or None if no match has one.
+    """
+    earliest: str | None = None
+    for raw, meta in model_cost.items():
+        if not isinstance(meta, dict):
+            continue
+        if _strip_prefix(raw) != fid:
+            continue
+        dep = meta.get("deprecation_date")
+        if not isinstance(dep, str) or not dep:
+            continue
+        try:
+            date.fromisoformat(dep)
+        except ValueError:
+            continue
+        if earliest is None or dep < earliest:
+            earliest = dep
+    return earliest
 
 
 # Tiny fallback used when litellm isn't importable.

--- a/packages/litellm_adapter/client.py
+++ b/packages/litellm_adapter/client.py
@@ -17,6 +17,40 @@ from packages.litellm_adapter.types import ProviderDeployment, UpstreamProviderE
 logger = structlog.get_logger(__name__)
 
 
+def _build_allowed_fails_policy():
+    """Construct an AllowedFailsPolicy that fails fast on hard errors and is
+    lenient on transient ones. Returns None if litellm doesn't expose the type
+    (older versions), in which case the caller's `allowed_fails` int applies
+    uniformly.
+
+    LiteLLM cooldown semantics (1.83.x): a deployment is cooled down when
+    its failure count *exceeds* the resolved allowed-fails value, where
+    `resolved = policy_value or router.allowed_fails`. Because `0` is
+    falsy in that `or`, a policy value of 0 alone has NO effect — it
+    silently inherits the router default. We rely on the caller setting
+    `router_allowed_fails=0` (see app/config.py) so 0-valued policy entries
+    here actually take effect: cool down on the very first failure for
+    hard errors, give transient errors more headroom via non-zero values.
+    """
+    try:
+        from litellm.types.router import AllowedFailsPolicy
+    except Exception:
+        return None
+    return AllowedFailsPolicy(
+        # 4xx including 404 / model_not_found: deployment is genuinely
+        # broken. Cool down on first failure (requires router default 0).
+        BadRequestErrorAllowedFails=0,
+        # 401: probably a wrong key. Don't keep hammering it.
+        AuthenticationErrorAllowedFails=0,
+        # 429: transient rate limit. Tolerate up to 3 in-window before cooling.
+        RateLimitErrorAllowedFails=3,
+        # 5xx: provider-side transient. Two strikes.
+        InternalServerErrorAllowedFails=2,
+        # Network timeouts: transient. Two strikes.
+        TimeoutErrorAllowedFails=2,
+    )
+
+
 def _translate_error(exc: Exception) -> UpstreamProviderError:
     import litellm
 
@@ -44,6 +78,13 @@ class OrcaLiteLLMClient:
         strategy: str | None = None,
         preferred_models: list[str] | None = None,
         litellm_routing_strategy: str | None = None,
+        # Router behavior knobs. Defaults keep prior behavior when caller
+        # doesn't inject — but app code (router_cache.py) injects from
+        # Settings so the deployment respects user config.
+        cooldown_time: float = 1.0,
+        allowed_fails: int | None = None,
+        enable_pre_call_checks: bool = False,
+        num_retries: int = 2,
     ):
         # Stash routing config on the instance so chat.py can read it without
         # re-querying the DB on every request.
@@ -81,16 +122,51 @@ class OrcaLiteLLMClient:
 
         router_kwargs: dict = {
             "model_list": model_list,
-            "num_retries": 2,
+            "num_retries": num_retries,
             "timeout": 30.0,
+            "enable_pre_call_checks": enable_pre_call_checks,
         }
+        # cooldown_time=0 must translate to disable_cooldowns=True. Otherwise
+        # LiteLLM treats 0 as falsy and silently substitutes its 1-second
+        # default — the test/dev "no cooldown" mode wouldn't actually take
+        # effect, and a single 4xx in CI would cool a deployment for 1s and
+        # cross-contaminate the next test.
+        if cooldown_time and cooldown_time > 0:
+            router_kwargs["cooldown_time"] = cooldown_time
+        else:
+            router_kwargs["disable_cooldowns"] = True
+        if allowed_fails is not None:
+            router_kwargs["allowed_fails"] = allowed_fails
+            # Per-error-type policy: 4xx (model_not_found, bad payload) means
+            # the deployment is genuinely broken — fail fast. 429 / timeouts
+            # are usually transient, so give them more chances before cooldown
+            # to avoid taking a model offline because of one rate-limit spike.
+            policy = _build_allowed_fails_policy()
+            if policy is not None:
+                router_kwargs["allowed_fails_policy"] = policy
         if litellm_routing_strategy:
             router_kwargs["routing_strategy"] = litellm_routing_strategy
 
         self._router = Router(**router_kwargs)
         self._deployments = deployments
 
-    async def acompletion(self, **kwargs) -> dict:
+    async def acompletion(self, *, fallbacks: list | None = None, **kwargs):
+        """Dispatch a chat completion through the LiteLLM Router.
+
+        Returns:
+          - Streaming (`stream=True`): the LiteLLM stream wrapper, an async
+            iterable of chunk objects. The caller (chat.py) is responsible for
+            iterating and dict-converting each chunk. We do NOT coerce the
+            wrapper to a dict here — that would consume the stream eagerly
+            and produce garbage.
+          - Non-streaming: a plain dict (the OpenAI ChatCompletion response)
+            with an extra `_orca_meta` key carrying provider attribution and
+            measured latency.
+
+        The `fallbacks` kwarg is passed through to LiteLLM's internal
+        `async_function_with_fallbacks` cascade engine in the format
+        `[{primary_model: [fb1, fb2, ...]}]`.
+        """
         if self._router is None:
             raise UpstreamProviderError(
                 "No provider keys configured. Set OPENAI_API_KEY (or another) "
@@ -98,11 +174,23 @@ class OrcaLiteLLMClient:
                 http_status=503,
                 error_type="no_providers_configured",
             )
+        if fallbacks is not None:
+            kwargs["fallbacks"] = fallbacks
+        is_streaming = bool(kwargs.get("stream"))
         started = time.perf_counter()
         try:
             resp = await self._router.acompletion(**kwargs)
         except Exception as exc:
             raise _translate_error(exc) from exc
+
+        if is_streaming:
+            # Stream wrappers are async iterables, not dicts. Return the raw
+            # wrapper so the caller can `async for` over chunks. We forfeit
+            # the `_orca_meta` injection on streams (provider attribution and
+            # latency for stream requests degrade to defaults in the request
+            # log) — a documented tradeoff that keeps this adapter thin and
+            # avoids wrapping LiteLLM's stream object.
+            return resp
 
         latency_ms = int((time.perf_counter() - started) * 1000)
         # Convert litellm's ModelResponse to a plain dict + attach orca metadata.

--- a/tests/integration/test_auto_model.py
+++ b/tests/integration/test_auto_model.py
@@ -174,6 +174,296 @@ async def test_auto_with_quality_strategy_picks_different_model_than_cheapest(au
     assert cheapest_pick != quality_pick
 
 
+async def test_auto_passes_fallbacks_to_router(auto_client):
+    """Auto resolution must hand LiteLLM Router a fallback chain so a 404 on
+    the primary cascades to the next-cheapest candidate without surfacing an
+    error. Without this, the user sees a 503 the first time the resolver
+    picks a stale model."""
+    client, captured = auto_client
+    # Replay the captured kwargs: we need fallbacks too, so wrap the existing
+    # acompletion mock to record EVERY kwarg the handler sent.
+    from unittest.mock import AsyncMock
+
+    from app import router_cache
+    full_kwargs: dict = {}
+
+    fake = await router_cache.get_router(None)
+
+    async def _record(**kwargs):
+        full_kwargs.clear()
+        full_kwargs.update(kwargs)
+        return {
+            "id": "x", "model": kwargs.get("model"),
+            "object": "chat.completion", "created": 0,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "_orca_meta": {"provider": "openai", "latency_ms": 1},
+        }
+
+    fake.acompletion = AsyncMock(side_effect=_record)
+
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200
+
+    # `fallbacks` should be a list with one dict mapping primary → list of others.
+    fb = full_kwargs.get("fallbacks")
+    assert isinstance(fb, list) and len(fb) == 1, (
+        f"expected fallbacks=[{{primary: [...]}}], got {fb!r}"
+    )
+    assert isinstance(fb[0], dict) and len(fb[0]) == 1
+    primary, alts = next(iter(fb[0].items()))
+    # Primary in the fallbacks dict must match the resolved model used in the call.
+    assert primary == full_kwargs["model"]
+    # At least one fallback alternative — auto routing returns top-N (default 5).
+    assert isinstance(alts, list) and len(alts) >= 1
+    # And primary != any fallback (no self-loops).
+    assert primary not in alts
+
+
+async def test_auto_uses_zero_in_deployment_retries_for_immediate_cascade(auto_client):
+    """When `model="auto"` is in play, the per-call num_retries should be 0
+    so a dead primary cascades to the fallback immediately. Default
+    num_retries=2 would retry the dead deployment 2x first, adding 30-90s
+    of perceived latency before the user sees a working response."""
+    from unittest.mock import AsyncMock
+
+    from app import router_cache
+
+    seen: dict = {}
+
+    async def _record(**kwargs):
+        seen.clear()
+        seen.update(kwargs)
+        return {
+            "id": "x", "model": kwargs.get("model"),
+            "object": "chat.completion", "created": 0,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "_orca_meta": {"provider": "openai", "latency_ms": 1},
+        }
+
+    fake = await router_cache.get_router(None)
+    fake.acompletion = AsyncMock(side_effect=_record)
+
+    client, _ = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200
+    assert seen.get("num_retries") == 0
+
+
+async def test_pinned_model_does_not_pass_fallbacks(auto_client):
+    """When the user explicitly pins a model, we should NOT inject fallbacks —
+    explicit pin means "use this exact model, don't substitute"."""
+    from unittest.mock import AsyncMock
+
+    from app import router_cache
+
+    seen: dict = {}
+
+    async def _record(**kwargs):
+        seen.clear()
+        seen.update(kwargs)
+        return {
+            "id": "x", "model": kwargs.get("model"),
+            "object": "chat.completion", "created": 0,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "_orca_meta": {"provider": "openai", "latency_ms": 1},
+        }
+
+    fake = await router_cache.get_router(None)
+    fake.acompletion = AsyncMock(side_effect=_record)
+
+    client, _ = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200
+    assert seen.get("fallbacks") is None
+    # Pinned requests use the default num_retries (not the auto override).
+    assert seen.get("num_retries") is None  # not overridden per-call
+
+
+async def test_auto_with_allowlist_picks_only_allowed_model(auto_client, monkeypatch):
+    """A key with a model_allowlist must constrain `model="auto"` to candidates
+    inside the allowlist. The pre-fix code rejected `auto` outright at the
+    early allowlist check (since "auto" is never literally in any allowlist),
+    making auto unusable for any rate-limited / scoped key."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    from packages.db.models.api_key import ApiKey
+
+    # Mutate the seeded API key: add a single-model allowlist.
+    factory = session_mod._session_factory
+    async with factory() as s:
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        assert len(rows) == 1
+        rows[0].model_allowlist = ["gpt-4o-mini"]
+        await s.commit()
+
+    client, captured = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    # The resolver must have narrowed candidates to the allowlist.
+    assert captured["model"] == "gpt-4o-mini"
+
+
+async def test_auto_with_allowlist_returns_403_when_no_intersection(auto_client):
+    """If capable models exist but none are in the key's allowlist, return 403
+    (not 422). 403 says "you can't use this here", which is the right signal
+    for the operator to either widen the allowlist or rotate the key."""
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.api_key import ApiKey
+
+    factory = session_mod._session_factory
+    async with factory() as s:
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        # An allowlist of made-up names — no auto candidate will match.
+        rows[0].model_allowlist = ["model-that-does-not-exist"]
+        await s.commit()
+
+    client, _ = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 403, r.text
+    # Error message must point at the allowlist, not capability — these are
+    # different debug paths for the operator.
+    assert "allowlist" in r.text.lower()
+
+
+async def test_pinned_request_with_empty_allowlist_is_denied(auto_client):
+    """An empty model_allowlist=[] means "deny all models" — operator's
+    explicit lock-down. A pinned request must 403 instead of routing.
+
+    Pre-fix code used `if kc.model_allowlist:` (truthiness), which treated
+    [] as "no allowlist set" and let every model through. This silently
+    inverted the operator's security intent."""
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.api_key import ApiKey
+
+    factory = session_mod._session_factory
+    async with factory() as s:
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        rows[0].model_allowlist = []   # explicit deny-all
+        await s.commit()
+
+    client, _ = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_auto_with_empty_allowlist_returns_403(auto_client):
+    """Same lock-down semantics for `model="auto"`: explicit empty allowlist
+    means no model is allowed, even if many are deployable + capable."""
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.api_key import ApiKey
+
+    factory = session_mod._session_factory
+    async with factory() as s:
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        rows[0].model_allowlist = []
+        await s.commit()
+
+    client, _ = auto_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 403, r.text
+
+
+async def test_auto_returns_422_not_403_when_allowlist_set_but_no_capable_model(tmp_sqlite_url, monkeypatch):
+    """Edge case: key has an allowlist AND no capable model exists at all.
+    The error should still be 422 (capability problem), not 403 (allowlist
+    problem) — the allowlist is irrelevant when there's nothing to allow.
+
+    Pre-fix code returned 403 because it conflated empty-after-allowlist with
+    no-allowed-model, even when the real issue was no capable deployment."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    # No provider keys → no deployable models at all.
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+        # Set an allowlist so the 403/422 distinction is exercised.
+        from sqlalchemy import select
+        from packages.db.models.api_key import ApiKey
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        rows[0].model_allowlist = ["gpt-4o-mini"]
+        await s.commit()
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    fake = AsyncMock()
+    fake.acompletion = AsyncMock()
+    fake._deployments = []  # nothing deployable
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    from app.main import create_app
+    app = create_app()
+
+    from httpx import ASGITransport, AsyncClient
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        r = await c.post(
+            "/v1/chat/completions",
+            json={"model": "auto", "messages": [{"role": "user", "content": "hi"}]},
+        )
+
+    # Must be 422 — there's no capable model. The allowlist is irrelevant
+    # when the underlying problem is "no deployable model exists".
+    assert r.status_code == 422, r.text
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_auto_returns_422_when_no_capable_model_is_deployable(tmp_sqlite_url, monkeypatch):
     """If no provider keys cover the required capabilities, surface a clear 422."""
     monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)

--- a/tests/integration/test_chat_caching.py
+++ b/tests/integration/test_chat_caching.py
@@ -126,6 +126,104 @@ async def test_streaming_is_not_cached(cached_client):
         pass
 
 
+async def test_cascade_does_not_poison_cache(cached_client, monkeypatch):
+    """If LiteLLM Router cascades to a different model_group, the response
+    must NOT be written to the cache key computed from the requested model.
+    Otherwise a later pinned request to the original model could get the
+    fallback's cached answer without ever hitting upstream — silent
+    cross-model contamination.
+
+    The "different model_group" detection looks up the served model in the
+    active deployments list. The fixture's deployments include every OpenAI
+    model from the catalog, so we cascade from gpt-4o-mini to gpt-4o (also
+    deployable, but a different model_name).
+    """
+    from app import router_cache
+
+    # Mock acompletion to claim it served a DIFFERENT model_group than
+    # requested. gpt-4o is in the fixture's deployment list with its own
+    # model_name, so the cache safety check will detect this as a cascade
+    # away from the requested gpt-4o-mini group.
+    fake = await router_cache.get_router(None)
+
+    async def _cascade(**kwargs):
+        return {
+            "id": "x",
+            "model": "gpt-4o",   # different model_group than the requested gpt-4o-mini
+            "object": "chat.completion", "created": 0,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "from gpt-4o"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "_orca_meta": {"provider": "openai", "latency_ms": 1},
+        }
+
+    fake.acompletion = AsyncMock(side_effect=_cascade)
+
+    client, _ = cached_client
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}], "temperature": 0}
+
+    r1 = await client.post("/v1/chat/completions", json=body)
+    assert r1.status_code == 200
+    # Header reflects the actually-served model (post-cascade truth).
+    assert r1.headers["x-orca-resolved-model"] == "gpt-4o"
+
+    # Second identical request: if cache had been poisoned, this would
+    # be a HIT and acompletion wouldn't be called. Instead, MISS again
+    # because the first response was correctly NOT cached under
+    # gpt-4o-mini's key (it was a gpt-4o response).
+    fake.acompletion.reset_mock()
+    fake.acompletion.side_effect = _cascade
+    r2 = await client.post("/v1/chat/completions", json=body)
+    assert r2.status_code == 200
+    assert r2.headers["x-orca-cache"] == "MISS", (
+        "second call must MISS — cache poisoning prevention requires that "
+        "responses served by a different model_group than requested are NOT cached"
+    )
+    assert fake.acompletion.await_count == 1
+
+
+async def test_cache_writes_when_served_model_is_prefixed_form(cached_client):
+    """LiteLLM frequently returns response.model with the provider prefix
+    (e.g. "openai/gpt-4o-mini" instead of bare "gpt-4o-mini"). That's the
+    SAME model — just a different rendering — so the cache write must
+    proceed. Strict string equality on response.model would treat this as
+    a cascade and silently disable the cache for almost all real traffic."""
+    from app import router_cache
+
+    fake = await router_cache.get_router(None)
+
+    async def _prefixed(**kwargs):
+        # Same model the request asked for, returned with the LiteLLM
+        # prefix appended (a common LiteLLM rewrite).
+        return {
+            "id": "x",
+            "model": f"openai/{kwargs.get('model')}",
+            "object": "chat.completion", "created": 0,
+            "choices": [{"index": 0, "message": {"role": "assistant", "content": "Hi!"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+            "_orca_meta": {"provider": "openai", "latency_ms": 1},
+        }
+
+    fake.acompletion = AsyncMock(side_effect=_prefixed)
+
+    client, _ = cached_client
+    body = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}], "temperature": 0}
+
+    r1 = await client.post("/v1/chat/completions", json=body)
+    assert r1.status_code == 200
+
+    # Second identical request must HIT — proves cache wrote despite the
+    # prefix mismatch. Without canonicalization this would MISS forever.
+    fake.acompletion.reset_mock()
+    fake.acompletion.side_effect = _prefixed
+    r2 = await client.post("/v1/chat/completions", json=body)
+    assert r2.status_code == 200
+    assert r2.headers["x-orca-cache"] == "HIT", (
+        "second call should HIT — cache write must proceed when served "
+        "model is the same group as requested, even with a provider prefix"
+    )
+    assert fake.acompletion.await_count == 0
+
+
 async def test_cache_hit_does_not_double_log(cached_client):
     """A cache hit still writes a RequestLog row, but with cached=True context.
 

--- a/tests/unit/test_auto_routing.py
+++ b/tests/unit/test_auto_routing.py
@@ -1,4 +1,4 @@
-"""model="auto" — pick the cheapest model that meets capability requirements.
+"""model="auto" — pick top-N models that meet capability requirements.
 
 The contract:
   1. Inspect the request to figure out required capabilities (tools, vision,
@@ -7,10 +7,15 @@ The contract:
   2. From the catalog, filter to models that advertise every required
      capability.
   3. From the deployable subset (configured providers + hosted upstream),
-     pick the cheapest by blended (input + output) per-token cost.
-  4. Return that model id, which the chat handler then sends to the router.
+     return the top-N by blended (input + output) per-token cost — the first
+     element is the primary, the rest are intended as LiteLLM Router
+     fallbacks for automatic cascade on 404 / cooldown.
+  4. The chat handler sends candidates[0] as the model and candidates[1:]
+     as fallbacks via `acompletion(fallbacks=...)`.
 
-This is the differentiated feature that LiteLLM's Router does not provide.
+This is the differentiated feature that LiteLLM's Router does not provide
+on its own — Router does the cascade, but it needs to know which models to
+fall back to. choose_auto_model produces that ordered list.
 """
 
 from __future__ import annotations
@@ -84,7 +89,9 @@ def test_choose_model_picks_cheapest_meeting_no_requirements():
     ]
     deployable = {"cheap", "medium", "expensive"}
     chosen = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
-    assert chosen == "cheap"
+    # Cheapest first, then the rest in cost order — the full ordered list
+    # becomes the primary + fallback chain.
+    assert chosen == ["cheap", "medium", "expensive"]
 
 
 def test_choose_model_excludes_non_deployable():
@@ -98,7 +105,7 @@ def test_choose_model_excludes_non_deployable():
     ]
     deployable = {"cheap-and-keyed"}  # only this provider has a key
     chosen = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
-    assert chosen == "cheap-and-keyed"
+    assert chosen == ["cheap-and-keyed"]
 
 
 def test_choose_model_filters_by_capability():
@@ -115,10 +122,13 @@ def test_choose_model_filters_by_capability():
     chosen = choose_auto_model(
         needs={"vision"}, deployable=deployable, candidates=candidates
     )
-    assert chosen == "vision-capable"
+    # Only one capable model survives the capability filter.
+    assert chosen == ["vision-capable"]
 
 
-def test_choose_model_returns_none_when_no_candidate_satisfies():
+def test_choose_model_returns_empty_when_no_candidate_satisfies():
+    """Empty list (not None) signals "no available candidate" so callers can
+    treat the return type uniformly without isinstance checks."""
     from app.auto_routing import choose_auto_model
     from packages.litellm_adapter.catalog import CatalogModel
 
@@ -128,7 +138,7 @@ def test_choose_model_returns_none_when_no_candidate_satisfies():
     chosen = choose_auto_model(
         needs={"vision"}, deployable={"text-only"}, candidates=candidates
     )
-    assert chosen is None
+    assert chosen == []
 
 
 def test_choose_model_uses_blended_input_plus_output_cost():
@@ -145,7 +155,8 @@ def test_choose_model_uses_blended_input_plus_output_cost():
     chosen = choose_auto_model(
         needs=set(), deployable={"a", "b"}, candidates=candidates
     )
-    assert chosen == "a"
+    # `a` wins the blended-cost comparison (output dominates).
+    assert chosen == ["a", "b"]
 
 
 # ── strategy-aware selection ────────────────────────────────────────────
@@ -166,7 +177,8 @@ def test_choose_model_quality_strategy_picks_most_expensive():
         candidates=candidates,
         strategy="quality",
     )
-    assert chosen == "expensive"
+    # `quality` reverses the order — most expensive first, then descending.
+    assert chosen == ["expensive", "medium", "cheap"]
 
 
 def test_choose_model_cheapest_strategy_matches_default():
@@ -183,7 +195,7 @@ def test_choose_model_cheapest_strategy_matches_default():
         candidates=candidates,
         strategy="cheapest",
     )
-    assert chosen == "cheap"
+    assert chosen == ["cheap", "expensive"]
 
 
 def test_choose_model_preferred_models_narrows_eligible_set():
@@ -203,7 +215,8 @@ def test_choose_model_preferred_models_narrows_eligible_set():
         strategy="cheapest",
         preferred_models=["preferred-mid", "preferred-big"],
     )
-    assert chosen == "preferred-mid"  # cheapest within the preferred set
+    # Eligible set is restricted to the preferred list, then sorted cheapest-first.
+    assert chosen == ["preferred-mid", "preferred-big"]
 
 
 def test_choose_model_preferred_models_falls_back_when_none_eligible():
@@ -220,7 +233,7 @@ def test_choose_model_preferred_models_falls_back_when_none_eligible():
         candidates=candidates,
         preferred_models=["does-not-exist", "neither-does-this"],
     )
-    assert chosen == "cheap"
+    assert chosen == ["cheap"]
 
 
 # ── litellm strategy mapping ────────────────────────────────────────────
@@ -241,3 +254,143 @@ def test_litellm_routing_strategy_returns_none_for_unknown_or_empty():
     assert litellm_routing_strategy(None) is None
     assert litellm_routing_strategy("") is None
     assert litellm_routing_strategy("not-a-real-strategy") is None
+
+
+# ── top-N truncation ────────────────────────────────────────────────────
+
+def test_choose_model_caps_results_at_top_n():
+    """Caller can opt into a smaller fallback chain to keep latency tight."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel(f"m{i}", "openai", "openai/", True, False, False,
+                     1e-7 * (i + 1), 4e-7 * (i + 1))
+        for i in range(10)
+    ]
+    deployable = {f"m{i}" for i in range(10)}
+    chosen = choose_auto_model(
+        needs=set(), deployable=deployable, candidates=candidates, top_n=3
+    )
+    # Cheapest 3 in cost order; the rest are dropped.
+    assert chosen == ["m0", "m1", "m2"]
+
+
+def test_choose_model_default_top_n_is_5():
+    """Default cap of 5 keeps the LiteLLM fallbacks list at a reasonable length."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel(f"m{i}", "openai", "openai/", True, False, False,
+                     1e-7 * (i + 1), 4e-7 * (i + 1))
+        for i in range(10)
+    ]
+    chosen = choose_auto_model(
+        needs=set(), deployable={f"m{i}" for i in range(10)}, candidates=candidates
+    )
+    assert len(chosen) == 5
+
+
+def test_allowlist_filters_before_top_n_truncation():
+    """An allowed model that ranks beyond top_n must NOT be falsely dropped.
+
+    The pre-fix code applied allowlist after the top-N truncation, so an
+    allow-listed model at position 6 would get filtered out by the top_n=5
+    cut, and the caller would see an empty result and falsely report 403.
+    """
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    # 10 models, allowed model is the *last* (most expensive) one.
+    candidates = [
+        CatalogModel(f"m{i}", "openai", "openai/", True, False, False,
+                     1e-7 * (i + 1), 4e-7 * (i + 1))
+        for i in range(10)
+    ]
+    deployable = {f"m{i}" for i in range(10)}
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable=deployable,
+        candidates=candidates,
+        allowlist=["m9"],   # only the rank-10 (most expensive) model is allowed
+    )
+    assert chosen == ["m9"], (
+        "allowed model ranked beyond top_n must survive — "
+        "filter must run before truncation"
+    )
+
+
+def test_allowlist_with_intersection_returns_only_allowed():
+    """When multiple allowed models exist, return them in cost order, capped at top_n."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-8, 1e-8),
+        CatalogModel("medium", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap", "medium", "expensive"},
+        candidates=candidates,
+        allowlist=["medium", "expensive"],
+    )
+    # cheap is filtered out by allowlist; medium wins on cost.
+    assert chosen == ["medium", "expensive"]
+
+
+def test_allowlist_with_no_intersection_returns_empty():
+    """Empty result when no eligible model is in the allowlist — caller decides 403/422."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap"},
+        candidates=candidates,
+        allowlist=["model-not-in-deployable"],
+    )
+    assert chosen == []
+
+
+def test_explicit_empty_allowlist_denies_all():
+    """An empty list is an explicit "allow nothing" signal — used by operators
+    to fully lock down a key. Falsy-check (`if allowlist`) would silently
+    treat it as "no restriction" and route normally, inverting intent."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap"},
+        candidates=candidates,
+        allowlist=[],   # explicit deny-all
+    )
+    assert chosen == [], "empty allowlist must deny everything"
+
+
+def test_none_allowlist_means_no_restriction():
+    """Distinct from empty list: allowlist=None means "no allowlist set" — all
+    eligible models pass through. The is-not-None check in the implementation
+    relies on this distinction."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"cheap"},
+        candidates=candidates,
+        allowlist=None,
+    )
+    assert chosen == ["cheap"]

--- a/tests/unit/test_cache_group_check.py
+++ b/tests/unit/test_cache_group_check.py
@@ -1,0 +1,200 @@
+"""Unit tests for _served_same_group_as_requested in app/routes/chat.py.
+
+The helper decides whether to write a response to the prompt cache after
+LiteLLM Router returns. It must distinguish three cases:
+  1. Same model_group — cache write is safe.
+  2. Different model_group (real cascade) — skip cache to prevent poisoning.
+  3. Unknown rendering of the same model — be permissive, allow cache.
+
+Integration tests cover the wire-up; these unit tests pin the classification
+logic for each branch so future refactors don't silently shift behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class _FakeDeployment:
+    model_name: str
+    litellm_model: str
+
+
+class _FakeClient:
+    def __init__(self, deployments: list[_FakeDeployment] | None = None):
+        self._deployments = deployments or []
+
+
+def test_returns_true_when_served_is_none():
+    """Missing response.model — assume same (don't penalize on uncertainty)."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini", served_model=None, client=_FakeClient()
+    ) is True
+
+
+def test_returns_true_on_exact_match():
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini", served_model="gpt-4o-mini", client=_FakeClient()
+    ) is True
+
+
+def test_returns_true_when_only_provider_prefix_differs():
+    """LiteLLM frequently returns 'openai/gpt-4o-mini' for a request that
+    asked for 'gpt-4o-mini' — same model, different rendering."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="openai/gpt-4o-mini",
+        client=_FakeClient(),
+    ) is True
+
+
+def test_returns_true_for_dated_openai_alias():
+    """OpenAI returns the specific dated version even when you asked for
+    the bare alias. Same logical model — must allow cache write."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o",
+        served_model="gpt-4o-2024-08-06",
+        client=_FakeClient(),
+    ) is True
+
+
+def test_returns_true_for_compact_dated_anthropic_alias():
+    """Anthropic uses the YYYYMMDD compact form (e.g. claude-3-5-sonnet-20241022)."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="claude-3-5-sonnet",
+        served_model="claude-3-5-sonnet-20241022",
+        client=_FakeClient(),
+    ) is True
+
+
+def test_returns_true_for_numeric_revision_suffix():
+    """Vertex / Gemini family models use -001 / -002 revision suffixes."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gemini-2.0-flash",
+        served_model="gemini-2.0-flash-001",
+        client=_FakeClient(),
+    ) is True
+
+
+def test_returns_false_when_served_is_a_different_catalog_model():
+    """Requested gpt-4o-mini, served gpt-4o — both real OpenAI models, NOT
+    a version variant. Must classify as cascade and skip cache."""
+    from app.routes.chat import _served_same_group_as_requested
+    # gpt-4o exists in CATALOG_BY_ID under its own model_name. The check
+    # should detect this and return False (cascade) — not be fooled by
+    # the shared "gpt-4o" prefix.
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="gpt-4o",
+        client=_FakeClient(),
+    ) is False
+
+
+def test_returns_false_when_deployment_lookup_finds_different_group():
+    """The active deployment list is authoritative — if served maps to a
+    different deployment's model_name, that's a real cascade."""
+    from app.routes.chat import _served_same_group_as_requested
+    deployments = [
+        _FakeDeployment(model_name="claude-3-5-sonnet-latest",
+                        litellm_model="anthropic/claude-3-5-sonnet-latest"),
+    ]
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="anthropic/claude-3-5-sonnet-latest",
+        client=_FakeClient(deployments),
+    ) is False
+
+
+def test_returns_true_when_deployment_lookup_finds_same_group():
+    """Round-trip: served name maps back to a deployment with matching model_name."""
+    from app.routes.chat import _served_same_group_as_requested
+    deployments = [
+        _FakeDeployment(model_name="gpt-4o-mini",
+                        litellm_model="openai/gpt-4o-mini"),
+    ]
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="openai/gpt-4o-mini",
+        client=_FakeClient(deployments),
+    ) is True
+
+
+def test_unknown_served_name_defaults_to_same_group():
+    """When served name is neither in deployments nor catalog, be permissive
+    — the alternative (always skip cache for unknown renderings) would
+    silently disable caching for any provider quirk we haven't seen yet."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="some-unknown-rendering-blah",
+        client=_FakeClient(),
+    ) is True
+
+
+def test_version_suffix_does_not_confuse_distinct_models():
+    """Reverse direction: requested gpt-4o-mini, served gpt-4o. The "-mini"
+    suffix on the requested name shouldn't make us think gpt-4o is a variant
+    of gpt-4o-mini. (Variants only flow served-is-longer, not the other way.)
+    Combined with catalog detection, this returns False (cascade)."""
+    from app.routes.chat import _served_same_group_as_requested
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4o-mini",
+        served_model="gpt-4o",
+        client=_FakeClient(),
+    ) is False
+
+
+def test_preview_suffix_is_not_a_version_variant():
+    """`gpt-4-turbo-preview` is a DISTINCT catalog model from `gpt-4-turbo`,
+    not a version of it. The version-suffix pass must NOT match `-preview`
+    or the cache will be poisoned across these two models. Catalog lookup
+    catches the cascade after the version pass falls through."""
+    from app.routes.chat import _served_same_group_as_requested
+    # Both gpt-4-turbo and gpt-4-turbo-preview are in CATALOG_BY_ID as
+    # distinct entries. The catalog lookup should detect this as a cascade.
+    assert _served_same_group_as_requested(
+        requested_group="gpt-4-turbo",
+        served_model="gpt-4-turbo-preview",
+        client=_FakeClient(),
+    ) is False, (
+        "gpt-4-turbo-preview is a separate model from gpt-4-turbo; "
+        "version-suffix matching must NOT cover -preview"
+    )
+
+
+# NOTE on `-latest` aliases (e.g. claude-3-5-sonnet-latest): providers don't
+# return "-latest" in response.model — clients request it, providers respond
+# with the specific dated form. When user requested "claude-3-5-sonnet-latest"
+# and provider returned "claude-3-5-sonnet-20241022", our helper currently
+# treats the dated form as a distinct catalog entry and returns False
+# (cache skipped). Acceptable limitation: cache is just unused in this case,
+# not poisoned. Fixing it would require an alias map maintained against
+# LiteLLM's catalog, which we choose not to take on for v1.
+
+
+def test_partial_substring_is_not_a_version_variant():
+    """An arbitrary suffix that isn't a date/version must NOT trigger the
+    same-group classification. Otherwise 'gpt-4o-something-random' would
+    incorrectly match 'gpt-4o'."""
+    from app.routes.chat import _served_same_group_as_requested
+    # "something-random" doesn't match any version-suffix pattern, so the
+    # version pass falls through. Then deployment + catalog lookups don't
+    # find this name. Permissive default kicks in → True.
+    # We document this as a known acceptable edge: an unknown suffix is
+    # treated as "same group" since we can't prove it isn't.
+    result = _served_same_group_as_requested(
+        requested_group="gpt-4o",
+        served_model="gpt-4o-something-random",
+        client=_FakeClient(),
+    )
+    # Permissive: True. Document the choice; if a real provider ever
+    # ships a non-versioned alias that's actually a different model,
+    # we'd want to revisit.
+    assert result is True

--- a/tests/unit/test_encryption_reads_settings.py
+++ b/tests/unit/test_encryption_reads_settings.py
@@ -1,0 +1,92 @@
+"""Encryption key + API-key pepper must come from Settings (which loads .env)
+in addition to os.environ — pydantic-settings does NOT propagate .env values
+into os.environ, so reading os.environ alone silently falls back to the
+public dev-fallback constant for any operator who follows the README.
+
+These tests prove both helpers see the same value Settings exposes, even
+when os.environ has nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch):
+    """Strip the env vars these helpers also fall back to, so the test
+    isolates whether Settings is being consulted at all."""
+    monkeypatch.delenv("CREDENTIAL_ENCRYPTION_KEY", raising=False)
+    monkeypatch.delenv("API_KEY_PEPPER", raising=False)
+
+
+def test_encryption_reads_credential_key_from_settings(monkeypatch):
+    """A key set on Settings (mimicking .env) must produce ciphertext that
+    decrypts back round-trip. Without the Settings lookup, encrypt would
+    use the dev fallback and decrypt would too — a green test that proves
+    nothing. So we ALSO confirm the key is not the dev fallback by checking
+    that encrypting under a different Settings key produces different
+    ciphertext for the same plaintext."""
+    from app import config as cfg
+
+    # Two distinct hex keys — encrypt under each, ciphertext must differ.
+    key_a = "00" * 32
+    key_b = "ff" * 32
+
+    cfg.get_settings.cache_clear()
+    monkeypatch.setenv("CREDENTIAL_ENCRYPTION_KEY", "")  # ensure env path is empty
+
+    # Build a Settings instance with our key and pin it via monkeypatch so
+    # cleanup restores the real cached settings after the test. Pass
+    # `_env_file=None` per-instance instead of mutating the class-level
+    # model_config (which would persist across tests in the same process).
+    s_a = cfg.Settings(_env_file=None, credential_encryption_key=key_a)
+    monkeypatch.setattr(cfg, "get_settings", lambda: s_a)
+    from packages.auth.encryption import decrypt_credential, encrypt_credential
+
+    blob_a = encrypt_credential("hello world")
+    assert decrypt_credential(blob_a) == "hello world"
+
+    # Swap settings to a different key. The blob from key A must NOT
+    # decrypt under key B — that's the only thing that proves the helper
+    # is actually reading the Settings field instead of using a fixed
+    # constant. Successful decrypt under one's own key + failed cross-key
+    # decrypt together rule out the dev fallback.
+    s_b = cfg.Settings(_env_file=None, credential_encryption_key=key_b)
+    monkeypatch.setattr(cfg, "get_settings", lambda: s_b)
+    # AES-GCM with the wrong key fails with InvalidTag, never silently
+    # returns garbage. Pin the specific exception so future failures of
+    # _other_ kinds (e.g. settings not loaded at all) get flagged as bugs
+    # instead of being swallowed by a too-broad `pytest.raises(Exception)`.
+    import pytest
+    from cryptography.exceptions import InvalidTag
+    with pytest.raises(InvalidTag):
+        decrypt_credential(blob_a)
+    # Sanity check: under key B, encrypting + decrypting still works.
+    blob_b = encrypt_credential("hello world")
+    assert decrypt_credential(blob_b) == "hello world"
+
+
+def test_pepper_reads_from_settings(monkeypatch):
+    """API_KEY_PEPPER set on Settings (mimicking .env) must be used by
+    hash_api_key, even when os.environ has no pepper at all."""
+    from app import config as cfg
+
+    pepper_long_enough = "x" * 64
+    cfg.get_settings.cache_clear()
+    s = cfg.Settings(_env_file=None, api_key_pepper=pepper_long_enough)
+    monkeypatch.setattr(cfg, "get_settings", lambda: s)
+    from packages.auth.hashing import hash_api_key
+
+    h_with_settings = hash_api_key("sk-orca-test")
+
+    # Now point Settings at empty pepper — hash should change because the
+    # helper falls back to plain SHA-256 with no pepper.
+    s_empty = cfg.Settings(_env_file=None, api_key_pepper="")
+    monkeypatch.setattr(cfg, "get_settings", lambda: s_empty)
+    h_no_pepper = hash_api_key("sk-orca-test")
+
+    assert h_with_settings != h_no_pepper, (
+        "settings-based pepper must change the hash; if these match, the "
+        "helper isn't reading from Settings"
+    )

--- a/tests/unit/test_litellm_client.py
+++ b/tests/unit/test_litellm_client.py
@@ -1,0 +1,131 @@
+"""Unit tests for OrcaLiteLLMClient — focused on the stream/non-stream branch.
+
+Round 5 of /codex review caught a real production bug: the adapter always
+called `model_dump()` on the LiteLLM response, but `stream=True` returns a
+`CustomStreamWrapper` (an async iterable), not a response object with
+`model_dump`. Streaming through the production adapter would either crash
+or return garbage. Integration tests had been mocking `client.acompletion`
+directly so the real adapter path was untested.
+
+These tests pin the contract: stream=True returns the raw wrapper for the
+caller to iterate; stream=False returns a dict with `_orca_meta` injected.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+class _FakeChunkAsyncIter:
+    """Stand-in for litellm's CustomStreamWrapper — async iterable of chunks."""
+
+    def __init__(self, chunks):
+        self._chunks = list(chunks)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+
+@pytest.fixture
+def fake_router_with_stream(monkeypatch):
+    """Build an OrcaLiteLLMClient whose Router is mocked to return a stream
+    wrapper for stream=True and a ModelResponse-like object for stream=False.
+    """
+    from packages.litellm_adapter.client import OrcaLiteLLMClient
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    deployments = [
+        ProviderDeployment(
+            model_name="gpt-4o-mini",
+            litellm_model="openai/gpt-4o-mini",
+            api_key="sk-test",
+            provider="openai",
+        )
+    ]
+
+    # Patch the Router class so __init__ doesn't try to talk to upstream.
+    fake_router = MagicMock()
+
+    class _ResponseModel:
+        def __init__(self, model: str):
+            self.model = model
+
+        def model_dump(self):
+            return {"model": self.model, "choices": [], "usage": {}}
+
+    async def _acompletion(**kwargs):
+        if kwargs.get("stream"):
+            return _FakeChunkAsyncIter([
+                {"id": "x", "model": "gpt-4o-mini",
+                 "choices": [{"delta": {"content": "hi"}}]},
+                {"id": "x", "model": "gpt-4o-mini",
+                 "choices": [{"delta": {}, "finish_reason": "stop"}],
+                 "usage": {"prompt_tokens": 1, "completion_tokens": 1}},
+            ])
+        return _ResponseModel("gpt-4o-mini")
+
+    fake_router.acompletion = AsyncMock(side_effect=_acompletion)
+    # The adapter imports Router inside __init__, so patch the source
+    # symbol on the litellm package before construction.
+    import litellm
+    monkeypatch.setattr(litellm, "Router", lambda **_: fake_router)
+
+    client = OrcaLiteLLMClient(deployments=deployments, strategy="balanced")
+    return client
+
+
+async def test_acompletion_stream_returns_async_iterable_not_dict(fake_router_with_stream):
+    """Production bug from round-5 review: passing stream=True must not
+    eagerly coerce the wrapper to a dict. The caller (chat.py SSE path)
+    needs to `async for` over it."""
+    result = await fake_router_with_stream.acompletion(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+    # Result must be async-iterable.
+    assert hasattr(result, "__aiter__"), (
+        f"stream=True must return an async iterable, got {type(result).__name__}"
+    )
+    # Drain it.
+    chunks = []
+    async for c in result:
+        chunks.append(c)
+    assert len(chunks) == 2
+
+
+async def test_acompletion_non_stream_returns_dict_with_orca_meta(fake_router_with_stream):
+    """Non-stream path must keep returning a dict with the _orca_meta
+    injection — that's the contract the existing chat.py blocking path
+    and request_log writer rely on."""
+    result = await fake_router_with_stream.acompletion(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert isinstance(result, dict)
+    assert result.get("model") == "gpt-4o-mini"
+    assert "_orca_meta" in result
+    assert result["_orca_meta"].get("provider") == "openai"
+
+
+async def test_acompletion_stream_raises_no_providers_when_router_is_none():
+    """No-key configurations short-circuit before LiteLLM gets called.
+    Stream requests must hit the same guard as non-stream ones."""
+    from packages.litellm_adapter.client import OrcaLiteLLMClient
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    # Empty deployments → self._router is None.
+    client = OrcaLiteLLMClient(deployments=[])
+    with pytest.raises(UpstreamProviderError):
+        await client.acompletion(
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "hi"}],
+            stream=True,
+        )


### PR DESCRIPTION
## Summary

- Wire LiteLLM Router built-in cooldown + cascade so `model="auto"` survives a dead deployment transparently (the user's `gemini-2.0-flash-lite` 503 is the motivating case — Google killed it before LiteLLM marked deprecation_date).
- Filter the catalog at load time on litellm `deprecation_date`, propagating the filter through flagship-alias backfill so retired aliases don't sneak back in.
- Fix two security holes in the same code area: encryption key + API-key pepper now read from `Settings` (which honors `.env`) so operators following the README don't silently fall back to the public dev-fallback constant.

## What changed (high level)

| Layer | Change |
|---|---|
| Catalog | `_is_obviously_dead` filter on `deprecation_date`; flagship aliases inherit deprecation via `_flagship_deprecation`; new `CatalogModel.deprecation_date` field for UI |
| Adapter | `acompletion` branches on `stream=True` (returns LiteLLM wrapper raw — production streaming was broken before); per-error `AllowedFailsPolicy` (4xx/auth fail-fast=0, 429/5xx/timeout lenient); `cooldown_time<=0` → `disable_cooldowns=True`; per-call `fallbacks` + `num_retries` pass-through |
| Auto resolver | `choose_auto_model` returns `list[str]` top-N (default 5); `allowlist` kwarg filters BEFORE truncation (so an allowed model ranked beyond top_n isn't dropped); empty `[]` allowlist now means deny-all (was falsy → all-allowed, security hole) |
| Chat handler | feeds top-N to LiteLLM as `fallbacks=[{primary: [fb1, fb2, ...]}]`; auto path uses `num_retries=0` for immediate cascade (avoids 30-90s perceived latency from retrying a dead deployment 2x first); 422-vs-403 split distinguishes "no capable model" from "no allowed model"; cache write only when served model is in same model_group as requested primary (prevents cross-model poisoning); `UpstreamProviderError.http_status` is honored instead of collapsing all errors to 503; mid-stream errors translated for accurate `RequestLog.error_type`; `_build_log_row` takes `requested_model` + `actual_resolved` separately |
| Settings | `router_cooldown_seconds=3600`, `router_allowed_fails=0`, `router_pre_call_checks=True`, `router_num_retries_default=2`, `router_num_retries_auto=0` (all overridable via `.env`) |
| Security | `packages/auth/encryption.py` + `hashing.py` now prefer Settings over `os.environ.get(...)`. pydantic-settings does NOT propagate `.env` to `os.environ`, so the previous code silently used the public dev-fallback constant whenever the operator put the key in `.env` per README |
| Allowlist re-check | `chat.py` line 79 now exempts `"auto"` (was hard-blocking auto for any key with an allowlist); allowlist re-applied after auto resolves |

## Tests

- 127 → 180 tests (+53), all green, ruff clean
- New: `test_cache_group_check.py` (12 unit tests pinning the same-group classifier — prefix / dated alias / numeric revision / catalog-known different model / deployment-known different)
- New: `test_litellm_client.py` (3 unit tests on the adapter's stream branch — production bug catch)
- New: `test_encryption_reads_settings.py` (proves Settings lookup is wired via cross-key decrypt-fails assertion with `cryptography.exceptions.InvalidTag`)
- Updated: `test_auto_routing.py` (signature change + top_n + allowlist filtering before truncation + empty-allowlist deny-all + None-vs-empty distinction)
- Updated: `test_auto_model.py` integration (fallbacks payload format, num_retries=0 on auto path, pinned doesn't get fallbacks, allowlist 422/403 split, empty allowlist denies pinned + auto)
- Updated: `test_chat_caching.py` (cascade does not poison cache, prefix-equivalent responses still cache)

## Review history (for reviewers)

This branch went through 6 rounds of `/codex` independent review. 37 total findings surfaced, 26 actually fixed. Severity trajectory: round 1 had 4 HIGH; rounds 2-5 each had 1 HIGH; round 6 had zero HIGH (only 1 MED + 2 LOW), signalling convergence.

## Test plan

- [x] `PYTHONPATH=. pytest -v` — 180 passed
- [x] `ruff check` on changed files — clean
- [ ] Manual: `docker compose up`, send `model="auto"` hello world with at least one provider key configured. Expect 200 with `x-orca-resolved-model` header showing a live model (not the requested primary if the primary is dead — cascade did its job)
- [ ] Manual: set `CREDENTIAL_ENCRYPTION_KEY` only in `.env` (not env), restart, add a provider key via dashboard, then `sqlite3 orca.db 'select hex(encrypted_key) from provider_keys'` and verify the bytes differ from a previous run with a different .env key (proves `.env` is honored, not the dev fallback)
- [ ] Manual: dashboard set strategy `cheapest` → `model="auto"` resolves to a cheap model
- [ ] Manual: dashboard set `model_allowlist=[]` on an API key → both pinned and auto requests return 403

## Out of scope (separate PRs)

- Streaming SSE error handling (the `[DONE]` sentinel after error frame inconsistency)
- `cost_microcents=0` placeholder in `_build_log_row` (analytics dashboard always reports `$0`)
- `max_body_bytes` setting that's never read
- Pre-existing test isolation issue in `test_unreachable.py` (sensitive to `.env` real provider keys)
- Provider-side `/v1/models` as authoritative catalog source (architectural upgrade)
- Quality strategy semantics (currently picks most expensive = old Opus 4 over new Opus 4.7; needs external quality score signal e.g. Artificial Analysis API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)