### PR TITLE
docs(zh): rewrite Chinese README to fix mistranslations

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Deutsch)
+# OrcaRouter Lite
 
-> Diese Datei ist eine von der Community gepflegte Zusammenfassung. Verbindliche technische Details stehen im [englischen README](./README.md).
+**Selbst gehosteter LLM-Router mit verwaltetem Sicherheitsnetz.**
+OpenAI-kompatibel. BYOK. Einzelner Workspace. Streaming. `model="auto"`.
 
-## Sprachlinks
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Sprachen
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Überblick
+OrcaRouter Lite ist die Open-Source-Edition für einen einzelnen Workspace von [OrcaRouter](https://www.orcarouter.ai). Führen Sie es auf Ihrem Laptop aus, liefern Sie es in Ihrem Produkt aus oder nutzen Sie das gehostete `api.orcarouter.ai` direkt für die Long-Tail-Modelle, deren Schlüssel Sie nicht selbst verwalten möchten.
 
-OrcaRouter Lite ist ein selbst gehosteter LLM-Router mit OpenAI-kompatibler API, BYOK, Streaming und automatischer Auswahl des günstigsten geeigneten Modells über `model="auto"`.
+> **Warum wir?** LiteLLM ist eine Bibliothek; OpenRouter ist Closed-Source und gehostet; Ollama ist nur lokal. Wir sind der **selbst gehostete Server mit verwaltetem Fallback** — ein Satz, den keiner der anderen sagen kann.
 
+## 60-Sekunden-Schnellstart
+
+Zwei Möglichkeiten, OrcaRouter zu nutzen:
+
+### Pfad A — Selbst gehostet (BYOK)
+
+Führen Sie Lite auf Ihrem eigenen Rechner aus; bringen Sie Ihre eigenen Provider-Schlüssel mit.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# mindestens einen hinzufügen: OPENAI_API_KEY=sk-...  (oder ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+Basis-URL: `http://localhost:8000/v1`. Verwenden Sie den beim Start ausgegebenen `sk-orca-*`-Schlüssel.
+
+### Pfad B — Gehostet (Konto erforderlich)
+
+Kein Klonen, kein Docker. Registrieren, Schlüssel holen, jedes OpenAI-SDK auf den Hosted-Endpunkt zeigen.
+
+```bash
+# 1. Registrieren auf https://www.orcarouter.ai und sk-orca-* Schlüssel kopieren
+# 2. https://api.orcarouter.ai/v1 als Basis-URL verwenden
+```
+
+**Konto erforderlich.** Hosted übernimmt Routing, Abrechnung und den Long Tail an Providern — pro Token über Ihr OrcaRouter-Konto abgerechnet. Siehe [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Dann von einem beliebigen OpenAI-SDK aufrufen
+
+Die folgenden Beispiele verwenden die localhost-Basis-URL aus Pfad A — tauschen Sie sie gegen `https://api.orcarouter.ai/v1`, wenn Sie Pfad B nutzen.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # oder "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Öffnen Sie `http://localhost:8000/` für das Dashboard — Provider, Routing, Analytics, Schlüssel (nur Pfad A).
+
+## Warum?
+
+| | OrcaRouter Lite | LiteLLM-Bibliothek | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Selbst gehosteter Server | ✓ | als Bibliothek | ✗ | ✓ |
+| OpenAI-kompatibel | ✓ | ✓ | ✓ | ✓ |
+| Multi-Provider (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Eingebautes Dashboard | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (günstigstes geeignetes) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hosted als Fallback | ✓ | ✗ | n/a | ✗ |
+| Kein Postgres / kein Redis erforderlich | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — das Hauptmerkmal
+
+Senden Sie `model="auto"`, und OrcaRouter wählt das **günstigste** Modell aus Ihren konfigurierten Providern, das die Anforderungsfähigkeiten der Anfrage erfüllt (Tools, Vision, JSON-Modus). Keine manuellen Routing-Regeln; keine Rate-Limit-Akrobatik; keine `if x: ...`-Kostenoptimierung in Ihrem Code.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → leitet an das günstigste VISION-fähige Modell, das Ihre Schlüssel abdecken
+```
+
+Das aufgelöste Modell wird dem Aufrufer über den Antwort-Header `x-orca-resolved-model` zurückgegeben, sodass Sie protokollieren/anzeigen können, was tatsächlich verwendet wurde.
+
+## Hosted als Upstream (Lite + Hosted)
+
+Lite läuft schon? Setzen Sie `ORCAROUTER_API_KEY` auf Ihren `sk-orca-*` von [www.orcarouter.ai](https://www.orcarouter.ai), und Hosted wird zu einem weiteren Provider in der Routing-Kette — und deckt Modelle ab, die Ihre lokalen Schlüssel nicht haben:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Anwendungsfälle:
+- **Vor dem Kauf testen** — keine lokalen Provider-Schlüssel nötig
+- **Lokales Logging** — Hosted erledigt Routing, Lite speichert RequestLog-Zeilen für das Dashboard
+- **Failover** — lokale Provider fallen aus, Hosted ist das Sicherheitsnetz
+
+## Streaming
+
+OpenAI-kompatibles SSE-Format mit dem üblichen `data: ... \n\n`-Framing und einem abschließenden `[DONE]`-Sentinel — Drop-in für jedes SDK, das bereits von OpenAI streamt.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Modellkatalog
+
+Beim Start werden über 100 Chat-Modelle aus [LiteLLMs von der Community gepflegter Preisdatenbank](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) geladen — keine Modellliste, die manuell gepflegt werden muss. Jeder Eintrag enthält:
+
+- `id` (z. B. `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (auf Ihre konfigurierten Schlüssel abgebildet)
+- Capability-Flags: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Kosten pro Token für Input/Output (treibt das Einsparungs-Widget + `model="auto"` an)
+
+`GET /v1/models` liefert den Katalog im OpenAI-Format zurück.
+
+## Anderswo deployen
+
+| Plattform | One-Click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Repo verbinden, Root-Verzeichnis = `.` |
+| Bare Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (Image folgt) |
+
+## Was ist enthalten
+
+- `POST /v1/chat/completions` — Proxy + Streaming + `model="auto"` + provider-übergreifender Prompt-Cache
+- `GET  /v1/models` — auffindbarer Modellkatalog (100+ Modelle aus `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — verschlüsselte Provider-Schlüssel setzen / auflisten / widerrufen
+- `GET/PUT /v1/routing` — Strategie ändern (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — lokale Analytics, keine Telemetrie verlässt die Box
+- `GET  /v1/hosted` — Status des Hosted-Fallbacks (treibt die "Get $5 free credit"-Karte des Dashboards an)
+- `GET/POST/DELETE /v1/keys/...` — API-Schlüssel auflisten / rotieren / widerrufen
+- Single-Page-Dashboard unter `/`
+- Standardmäßig SQLite; Postgres optional via `DATABASE_URL`; Redis optional
+
+### Provider-übergreifender Prompt-Cache
+
+Deterministische Anfragen (`temperature=0` oder fest gepinnter `seed`) werden bei Wiederholung aus dem Cache bedient — funktioniert bei **jedem** Provider, nicht nur bei Anthropic. Backend ist Redis, wenn `REDIS_URL` gesetzt ist, ansonsten ein In-Process-LRU. Cache-Treffer kommen sofort mit `x-orca-cache: HIT` zurück und kosten 0 $.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # gleicher Payload erneut
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← aus dem Cache, kein Upstream-Aufruf
+```
+
+### Einsparungs-Widget
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` zeigt, was Ihr Traffic mit immer-GPT-4 gekostet hätte gegenüber dem, was er tatsächlich gekostet hat. Das Dashboard zeigt das als Kachel an.
+
+### Integrationen
+
+Drop-in-Konfigurationen für [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) und jedes Tool, das das OpenAI-Chat-Completions-Protokoll spricht. Siehe [`integrations/`](./integrations/).
+
+## Was bewusst nicht enthalten ist
+
+Dies ist die **Single-Workspace**-Edition. Per Design ohne:
+- Mandantenfähigkeit, RBAC, SSO
+- Abrechnung, Wallets, Punkte, Partnerprogramm
+- Admin-Konsole, Audit-Logs, Trust & Safety
+- Multi-Pod-Deployment / Kubernetes
+- E-Mail / Slack / Webhooks für Alerts
+
+Dafür siehe das gehostete Produkt oder die (kommende) Teams-Edition.
+
+## Testen
+
+Test-First entwickelt. Jedes hier ausgelieferte Verhalten hatte zuerst einen fehlschlagenden Test.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Tests | Was |
+|---|---|---|
+| 1. Config | 5 | env-Loading, Defaults, `env_provider_keys()` |
+| 2. Seed | 3 | Bootstrap-Workspace + API-Schlüssel + RoutingConfig, idempotent |
+| 3. Auth-Middleware | 4 | Bearer-Token-Validierung, 401 bei fehlend/ungültig |
+| 4. App-Factory | 3 | /health, Error-Envelope, /v1/*-Gating |
+| 5. Provider-Schlüssel CRUD | 5 | im Speicher verschlüsselt, Klartext geht nie hin und zurück |
+| 6. Router-Cache | 13 | env+DB+hosted Deployment-Assembly mit Präzedenz |
+| 7. Chat Completion | 5 | OpenAI-Format, RequestLog, Validierung |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + Strategie-Update |
+| 10. Streaming | 4 | SSE-Format, `[DONE]`-Sentinel, Log-Writeback |
+| 11. Katalog | 7 | 100+ Modelle, Capability-Flags, Pricing |
+| 12. `model="auto"` | 21 | Capability-Erkennung, günstigstes-mit-passenden-Anforderungen (Unit + Integration) |
+| 13. Kosteneinsparungen | 9 | Einsparungen vs. Always-GPT-4-Baseline + Hosted-Auto-Vergleich |
+| 14. Prompt-Cache | 15 | provider-übergreifender Exact-Match-Cache + Chat-Integration |
+| 15. Benchmark | 4 | summarize() + render_markdown()-Aggregation |
+| 16. Hosted-Status | 7 | `/v1/hosted` Config-Source + Signup-URL-Surface |
+| 17. Hosted-Auto-Einsparungen | 3 | `_hosted_auto_savings`-Edge-Cases auf synthetischen Katalogen |
+| 18. Unerreichbare Modelle | 7 | "Modelle, die du nicht erreichen kannst"-Kachel verschwindet, wenn Hosted aktiv ist |
+| **Gesamt** | **127** | |
+
+## Architektur
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] OpenAI-kompatible Chat-Completions
+- [x] Streaming (SSE)
+- [x] `model="auto"` günstigstes-geeignetes Routing
+- [x] Hosted-als-Upstream
+- [x] Verschlüsseltes BYOK im Speicher
+- [x] Lokales Analytics-Dashboard
+- [x] CI (GitHub Actions)
+- [x] Provider-übergreifendes Prompt-Caching
+- [x] Continue.dev / Aider / LangChain / Cursor / Vercel-AI-SDK-Integrationen
+- [x] Öffentlicher Benchmark + Einsparungs-Behauptung
+- [ ] Embeddings + Image-Gen-Proxy
+
+Siehe [DEMO.md](./DEMO.md) für die Failover-Demo.
+
+## Lizenz
+
+MIT. Siehe [LICENSE](./LICENSE).

--- a/README.es.md
+++ b/README.es.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Español)
+# OrcaRouter Lite
 
-> Este documento es un resumen traducido por la comunidad. Para los detalles técnicos canónicos, consulta el [README en inglés](./README.md).
+**Enrutador LLM autoalojado con red de seguridad gestionada.**
+Compatible con OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 
-## Enlaces de idioma
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Idiomas
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Resumen
+OrcaRouter Lite es la edición open source de un solo workspace de [OrcaRouter](https://www.orcarouter.ai). Ejecútalo en tu portátil, intégralo en tu producto o usa directamente el `api.orcarouter.ai` alojado para la larga cola de modelos cuyas claves no quieres gestionar.
 
-OrcaRouter Lite es un enrutador LLM autoalojado con API compatible con OpenAI, soporte BYOK, streaming y selección automática del modelo más económico que cumpla capacidades mediante `model="auto"`.
+> **¿Por qué nosotros?** LiteLLM es una librería; OpenRouter es de código cerrado y alojado; Ollama es solo local. Nosotros somos el **servidor autoalojado con respaldo gestionado** — una frase que ninguno de ellos puede decir.
 
+## Inicio rápido en 60 segundos
+
+Dos formas de usar OrcaRouter:
+
+### Camino A — Autoalojado (BYOK)
+
+Ejecuta Lite en tu propia máquina; trae tus propias claves de proveedor.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# añade al menos una: OPENAI_API_KEY=sk-...  (o ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+URL base: `http://localhost:8000/v1`. Usa la clave `sk-orca-*` que se imprime al arrancar.
+
+### Camino B — Alojado (requiere cuenta)
+
+Sin clonar, sin docker. Regístrate, obtén una clave, apunta cualquier SDK de OpenAI al servicio alojado.
+
+```bash
+# 1. Regístrate en https://www.orcarouter.ai y copia tu clave sk-orca-*
+# 2. Usa https://api.orcarouter.ai/v1 como URL base
+```
+
+**Requiere cuenta.** El servicio alojado se encarga del enrutamiento, la facturación y la larga cola de proveedores — facturado por token en tu cuenta de OrcaRouter. Consulta [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Luego invócalo desde cualquier SDK de OpenAI
+
+Los ejemplos de abajo usan la URL base de localhost del Camino A — cámbiala por `https://api.orcarouter.ai/v1` si estás en el Camino B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # o "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Abre `http://localhost:8000/` para el panel — proveedores, enrutamiento, analítica, claves (solo Camino A).
+
+## ¿Por qué?
+
+| | OrcaRouter Lite | Librería LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Servidor autoalojado | ✓ | como librería | ✗ | ✓ |
+| Compatible con OpenAI | ✓ | ✓ | ✓ | ✓ |
+| Multiproveedor (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Panel integrado | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (el más barato capaz) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Alojado como respaldo | ✓ | ✗ | n/a | ✗ |
+| Sin Postgres / sin Redis requerido | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — la característica estrella
+
+Envía `model="auto"` y OrcaRouter elige el modelo **más barato** entre los proveedores configurados que cumpla los requisitos de capacidad de la solicitud (tools, vision, modo JSON). Sin reglas de enrutamiento manuales; sin acrobacias con rate-limits; sin optimización de costes con `if x: ...` en tu código.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → enruta al modelo más barato compatible con VISION que cubran tus claves
+```
+
+El modelo resuelto se expone de vuelta a quien llama a través de la cabecera de respuesta `x-orca-resolved-model`, para que puedas registrar/mostrar lo que realmente se usó.
+
+## Alojado como upstream (Lite + alojado)
+
+¿Ya tienes Lite en marcha? Configura `ORCAROUTER_API_KEY` con tu `sk-orca-*` de [www.orcarouter.ai](https://www.orcarouter.ai) y el alojado pasa a ser un proveedor más en la cadena de enrutamiento — cubriendo modelos que tus claves locales no tienen:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Casos de uso:
+- **Probar antes de comprar** — sin necesidad de claves de proveedor locales
+- **Logging local** — el alojado gestiona el enrutamiento, Lite guarda filas de RequestLog para el panel
+- **Failover** — los proveedores locales fallan, el alojado es la red de seguridad
+
+## Streaming
+
+Formato SSE compatible con OpenAI con el framing estándar `data: ... \n\n` y un sentinel terminal `[DONE]` — drop-in para cualquier SDK que ya transmita desde OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Catálogo de modelos
+
+Se cargan más de 100 modelos de chat al arrancar desde la [base de datos de precios mantenida por la comunidad de LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — sin lista de modelos que mantener manualmente. Cada entrada expone:
+
+- `id` (p. ej. `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (mapeado a tus claves configuradas)
+- Flags de capacidad: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Coste por token de entrada/salida (alimenta el widget de ahorro + `model="auto"`)
+
+`GET /v1/models` devuelve el catálogo en formato OpenAI.
+
+## Despliegue en otros sitios
+
+| Plataforma | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Conecta el repo, directorio raíz = `.` |
+| Docker pelado | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (imagen próximamente) |
+
+## Qué incluye
+
+- `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + caché de prompts entre proveedores
+- `GET  /v1/models` — catálogo de modelos descubrible (100+ modelos desde `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — crea / lista / revoca claves de proveedor cifradas
+- `GET/PUT /v1/routing` — cambia la estrategia (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — analítica local, sin telemetría que salga de la caja
+- `GET  /v1/hosted` — estado del respaldo alojado (alimenta la tarjeta "Get $5 free credit" del panel)
+- `GET/POST/DELETE /v1/keys/...` — lista / rota / revoca claves de API
+- Panel de una sola página en `/`
+- SQLite por defecto; Postgres opt-in vía `DATABASE_URL`; Redis opcional
+
+### Caché de prompts entre proveedores
+
+Las solicitudes deterministas (`temperature=0` o `seed` fijado) se sirven desde caché en repeticiones — funciona con **todos** los proveedores, no solo Anthropic. El backend es Redis si `REDIS_URL` está definido, en caso contrario un LRU en proceso. Los aciertos de caché se devuelven al instante con `x-orca-cache: HIT` y cuestan $0.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # mismo payload otra vez
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← servido desde caché, sin llamada upstream
+```
+
+### Widget de ahorros
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` informa de lo que tu tráfico habría costado con siempre-GPT-4 frente a lo que costó realmente. El panel lo muestra como una tarjeta.
+
+### Integraciones
+
+Configuraciones drop-in para [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) y cualquier herramienta que hable el protocolo de Chat Completions de OpenAI. Consulta [`integrations/`](./integrations/).
+
+## Lo que deliberadamente no incluye
+
+Esta es la edición de **un solo workspace**. Por diseño, sin:
+- multi-tenant, RBAC, SSO
+- facturación, monederos, puntos, programa de partners
+- consola de administración, logs de auditoría, trust & safety
+- despliegue multi-pod / Kubernetes
+- email / Slack / webhooks para alertas
+
+Para eso, consulta el producto alojado o la (próxima) edición Teams.
+
+## Pruebas
+
+Construido con test-first. Cada comportamiento entregado aquí tuvo primero un test fallando.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Tests | Qué |
+|---|---|---|
+| 1. Config | 5 | carga de env, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + clave API + RoutingConfig, idempotente |
+| 3. Middleware de auth | 4 | validación de bearer-token, 401 si falta/es inválida |
+| 4. App factory | 3 | /health, sobre de error, gating /v1/* |
+| 5. CRUD de claves de proveedor | 5 | cifrado en reposo, el plaintext nunca va y vuelve |
+| 6. Caché del router | 13 | ensamblado de despliegue env+DB+alojado con precedencia |
+| 7. Chat completion | 5 | formato OpenAI, RequestLog, validación |
+| 8. Analítica | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + actualización de estrategia |
+| 10. Streaming | 4 | formato SSE, sentinel `[DONE]`, log writeback |
+| 11. Catálogo | 7 | 100+ modelos, flags de capacidad, pricing |
+| 12. `model="auto"` | 21 | detección de capacidades, el más barato que cumple (unit + integración) |
+| 13. Ahorro de costes | 9 | ahorros vs baseline siempre-GPT-4 + comparación hosted-auto |
+| 14. Caché de prompts | 15 | caché de coincidencia exacta entre proveedores + integración chat |
+| 15. Benchmark | 4 | agregación de summarize() + render_markdown() |
+| 16. Estado de hosted | 7 | `/v1/hosted` config-source + superficie de URL de signup |
+| 17. Ahorros de hosted-auto | 3 | casos límite de `_hosted_auto_savings` en catálogos sintéticos |
+| 18. Modelos inalcanzables | 7 | la tarjeta "modelos que no puedes alcanzar" se vacía cuando hosted está activo |
+| **Total** | **127** | |
+
+## Arquitectura
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] Chat completions compatibles con OpenAI
+- [x] Streaming (SSE)
+- [x] Enrutamiento del más barato capaz con `model="auto"`
+- [x] Hosted-como-upstream
+- [x] BYOK cifrado en reposo
+- [x] Panel local de analítica
+- [x] CI (GitHub Actions)
+- [x] Caché de prompts entre proveedores
+- [x] Integraciones con Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Benchmark público + reclamo de ahorros
+- [ ] Proxy de embeddings + generación de imágenes
+
+Consulta [DEMO.md](./DEMO.md) para la demo de failover.
+
+## Licencia
+
+MIT. Consulta [LICENSE](./LICENSE).

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Français)
+# OrcaRouter Lite
 
-> Ce document est un résumé de traduction communautaire. Pour les détails techniques de référence, consultez le [README anglais](./README.md).
+**Routeur LLM auto-hébergé avec filet de sécurité géré.**
+Compatible OpenAI. BYOK. Workspace unique. Streaming. `model="auto"`.
 
-## Liens de langue
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Langues
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Vue d’ensemble
+OrcaRouter Lite est l'édition open source mono-workspace d'[OrcaRouter](https://www.orcarouter.ai). Exécutez-le sur votre laptop, embarquez-le dans votre produit, ou utilisez directement `api.orcarouter.ai` hébergé pour la longue traîne de modèles dont vous ne voulez pas gérer les clés.
 
-OrcaRouter Lite est un routeur LLM auto-hébergé avec API compatible OpenAI, BYOK, streaming et routage automatique vers le modèle le moins cher répondant aux capacités via `model="auto"`.
+> **Pourquoi nous ?** LiteLLM est une bibliothèque ; OpenRouter est en source fermée et hébergé ; Ollama est uniquement local. Nous sommes le **serveur auto-hébergé avec un fallback géré** — une phrase qu'aucun d'eux ne peut prononcer.
 
+## Démarrage rapide en 60 secondes
+
+Deux façons d'utiliser OrcaRouter :
+
+### Voie A — Auto-hébergé (BYOK)
+
+Exécutez Lite sur votre propre machine ; apportez vos propres clés de fournisseur.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# ajoutez au moins une : OPENAI_API_KEY=sk-...  (ou ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+URL de base : `http://localhost:8000/v1`. Utilisez la clé `sk-orca-*` affichée au démarrage.
+
+### Voie B — Hébergé (compte requis)
+
+Pas de clone, pas de docker. Inscrivez-vous, récupérez une clé, pointez n'importe quel SDK OpenAI sur l'instance hébergée.
+
+```bash
+# 1. Inscrivez-vous sur https://www.orcarouter.ai et copiez votre clé sk-orca-*
+# 2. Utilisez https://api.orcarouter.ai/v1 comme URL de base
+```
+
+**Compte requis.** L'instance hébergée gère le routage, la facturation et la longue traîne de fournisseurs — facturé au token sur votre compte OrcaRouter. Voir [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Puis appelez-le depuis n'importe quel SDK OpenAI
+
+Les exemples ci-dessous utilisent l'URL de base localhost de la Voie A — remplacez par `https://api.orcarouter.ai/v1` si vous êtes sur la Voie B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # ou "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Ouvrez `http://localhost:8000/` pour le tableau de bord — fournisseurs, routage, analytics, clés (Voie A uniquement).
+
+## Pourquoi ?
+
+| | OrcaRouter Lite | Bibliothèque LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Serveur auto-hébergé | ✓ | en tant que bibliothèque | ✗ | ✓ |
+| Compatible OpenAI | ✓ | ✓ | ✓ | ✓ |
+| Multi-fournisseur (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Tableau de bord intégré | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (le moins cher capable) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hébergé en fallback | ✓ | ✗ | n/a | ✗ |
+| Pas de Postgres / pas de Redis requis | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — la fonctionnalité phare
+
+Envoyez `model="auto"` et OrcaRouter choisit le modèle **le moins cher** parmi vos fournisseurs configurés qui répond aux exigences de capacité de la requête (tools, vision, mode JSON). Pas de règles de routage manuelles ; pas d'acrobaties avec les rate-limits ; pas d'optimisation de coût `if x: ...` dans votre code.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → route vers le modèle compatible VISION le moins cher couvert par vos clés
+```
+
+Le modèle résolu est exposé en retour aux appelants via l'en-tête de réponse `x-orca-resolved-model`, pour que vous puissiez logger/afficher ce qui a réellement été utilisé.
+
+## Hébergé en upstream (Lite + hébergé)
+
+Lite déjà en marche ? Définissez `ORCAROUTER_API_KEY` avec votre `sk-orca-*` de [www.orcarouter.ai](https://www.orcarouter.ai), et l'hébergé devient un fournisseur de plus dans la chaîne de routage — couvrant les modèles que vos clés locales ne couvrent pas :
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Cas d'usage :
+- **Essayer avant d'acheter** — pas besoin de clés de fournisseur locales
+- **Logging local** — l'hébergé gère le routage, Lite stocke les lignes RequestLog pour le tableau de bord
+- **Failover** — les fournisseurs locaux échouent, l'hébergé est le filet de sécurité
+
+## Streaming
+
+Format SSE compatible OpenAI avec le framing standard `data: ... \n\n` et un sentinel terminal `[DONE]` — drop-in pour tout SDK qui stream déjà depuis OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Catalogue de modèles
+
+Plus de 100 modèles de chat sont chargés au démarrage depuis la [base de données de prix maintenue par la communauté de LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — pas de liste de modèles à maintenir à la main. Chaque entrée expose :
+
+- `id` (par ex. `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (mappé sur vos clés configurées)
+- Drapeaux de capacité : `supports_tools`, `supports_vision`, `supports_json_mode`
+- Coût par token entrée/sortie (alimente le widget d'économies + `model="auto"`)
+
+`GET /v1/models` renvoie le catalogue au format OpenAI.
+
+## Déployer ailleurs
+
+| Plateforme | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Connectez le repo, répertoire racine = `.` |
+| Docker brut | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (image bientôt) |
+
+## Ce qu'il y a dans la boîte
+
+- `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache de prompts inter-fournisseurs
+- `GET  /v1/models` — catalogue de modèles découvrable (100+ modèles depuis `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — définir / lister / révoquer des clés de fournisseur chiffrées
+- `GET/PUT /v1/routing` — changer la stratégie (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — analytics locales, aucune télémétrie ne sort de la boîte
+- `GET  /v1/hosted` — statut du fallback hébergé (alimente la carte « Get $5 free credit » du tableau de bord)
+- `GET/POST/DELETE /v1/keys/...` — lister / faire tourner / révoquer des clés API
+- Tableau de bord en page unique sur `/`
+- SQLite par défaut ; Postgres opt-in via `DATABASE_URL` ; Redis optionnel
+
+### Cache de prompts inter-fournisseurs
+
+Les requêtes déterministes (`temperature=0` ou `seed` figée) sont servies depuis le cache lors des répétitions — fonctionne sur **tous** les fournisseurs, pas seulement Anthropic. Le backend est Redis si `REDIS_URL` est défini, sinon un LRU en processus. Les hits cache reviennent instantanément avec `x-orca-cache: HIT` et coûtent 0 $.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # même payload, deuxième fois
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← servi depuis le cache, pas d'appel upstream
+```
+
+### Widget d'économies
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` indique ce que votre trafic aurait coûté en toujours-GPT-4 face à ce qu'il a réellement coûté. Le tableau de bord l'affiche sous forme de tuile.
+
+### Intégrations
+
+Configurations drop-in pour [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) et tout outil parlant le protocole OpenAI Chat Completions. Voir [`integrations/`](./integrations/).
+
+## Ce qui n'est délibérément pas inclus
+
+C'est l'édition **mono-workspace**. Par conception, pas de :
+- multi-tenant, RBAC, SSO
+- facturation, wallets, points, programme partenaire
+- console d'administration, logs d'audit, trust & safety
+- déploiement multi-pod / Kubernetes
+- e-mail / Slack / webhooks pour les alertes
+
+Pour cela, voyez le produit hébergé ou la (future) édition Teams.
+
+## Tests
+
+Construit en test-first. Chaque comportement livré ici a d'abord eu un test qui échouait.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Tests | Quoi |
+|---|---|---|
+| 1. Config | 5 | chargement env, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + clé API + RoutingConfig, idempotent |
+| 3. Middleware d'auth | 4 | validation bearer-token, 401 si manquant/invalide |
+| 4. App factory | 3 | /health, enveloppe d'erreur, gating /v1/* |
+| 5. CRUD clés de fournisseur | 5 | chiffré au repos, le plaintext ne fait jamais d'aller-retour |
+| 6. Cache du routeur | 13 | assemblage de déploiement env+DB+hosted avec préséance |
+| 7. Chat completion | 5 | format OpenAI, RequestLog, validation |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + mise à jour de stratégie |
+| 10. Streaming | 4 | format SSE, sentinel `[DONE]`, log writeback |
+| 11. Catalogue | 7 | 100+ modèles, drapeaux de capacité, pricing |
+| 12. `model="auto"` | 21 | détection de capacité, le moins cher répondant aux besoins (unit + intégration) |
+| 13. Économies de coût | 9 | économies vs baseline toujours-GPT-4 + comparaison hosted-auto |
+| 14. Cache de prompts | 15 | cache exact-match inter-fournisseurs + intégration chat |
+| 15. Benchmark | 4 | agrégation summarize() + render_markdown() |
+| 16. Statut hosted | 7 | `/v1/hosted` config-source + surface URL d'inscription |
+| 17. Économies hosted-auto | 3 | cas limites de `_hosted_auto_savings` sur catalogues synthétiques |
+| 18. Modèles inaccessibles | 7 | la tuile « modèles inaccessibles » se vide quand hosted est actif |
+| **Total** | **127** | |
+
+## Architecture
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] Chat completions compatibles OpenAI
+- [x] Streaming (SSE)
+- [x] Routage `model="auto"` le moins cher capable
+- [x] Hosted-en-upstream
+- [x] BYOK chiffré au repos
+- [x] Tableau de bord d'analytics local
+- [x] CI (GitHub Actions)
+- [x] Cache de prompts inter-fournisseurs
+- [x] Intégrations Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Benchmark public + revendication d'économies
+- [ ] Proxy embeddings + génération d'images
+
+Voir [DEMO.md](./DEMO.md) pour la démo de failover.
+
+## Licence
+
+MIT. Voir [LICENSE](./LICENSE).

--- a/README.hi.md
+++ b/README.hi.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (हिन्दी)
+# OrcaRouter Lite
 
-> यह समुदाय द्वारा तैयार किया गया संक्षिप्त अनुवाद है। आधिकारिक तकनीकी विवरण के लिए [अंग्रेज़ी README](./README.md) देखें।
+**मैनेज्ड सेफ्टी नेट के साथ self-hosted LLM राउटर।**
+OpenAI-compatible। BYOK। एकल-वर्कस्पेस। स्ट्रीमिंग। `model="auto"`।
 
-## भाषा लिंक
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## भाषाएँ
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## अवलोकन
+OrcaRouter Lite, [OrcaRouter](https://www.orcarouter.ai) का ओपन-सोर्स single-workspace संस्करण है। इसे अपने लैपटॉप पर चलाएँ, अपने प्रोडक्ट में पैक करें, या उन मॉडलों की लंबी टेल के लिए सीधे hosted `api.orcarouter.ai` का उपयोग करें जिनकी कुंजियाँ आप खुद नहीं मैनेज करना चाहते।
 
-OrcaRouter Lite एक self-hosted LLM राउटर है जो OpenAI-compatible API, BYOK, streaming, और `model="auto"` के जरिए सबसे किफायती सक्षम मॉडल का स्वचालित रूटिंग देता है।
+> **हम क्यों?** LiteLLM एक लाइब्रेरी है; OpenRouter closed-source hosted है; Ollama केवल local है। हम **मैनेज्ड फ़ॉलबैक के साथ self-hosted सर्वर** हैं — एक ऐसा वाक्य जो उनमें से कोई नहीं कह सकता।
 
+## 60-सेकंड क्विकस्टार्ट
+
+OrcaRouter उपयोग करने के दो तरीके:
+
+### पथ A — Self-hosted (BYOK)
+
+Lite को अपनी मशीन पर चलाएँ; अपनी provider कुंजियाँ साथ लाएँ।
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# कम से कम एक जोड़ें: OPENAI_API_KEY=sk-...  (या ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+बेस URL: `http://localhost:8000/v1`। स्टार्टअप पर प्रिंट हुई `sk-orca-*` कुंजी का उपयोग करें।
+
+### पथ B — Hosted (खाता आवश्यक)
+
+न क्लोन, न docker। पंजीकरण करें, कुंजी प्राप्त करें, किसी भी OpenAI SDK को hosted पर पॉइंट करें।
+
+```bash
+# 1. https://www.orcarouter.ai पर पंजीकरण करें और अपनी sk-orca-* कुंजी कॉपी करें
+# 2. बेस URL के रूप में https://api.orcarouter.ai/v1 का उपयोग करें
+```
+
+**खाता आवश्यक।** Hosted, रूटिंग, बिलिंग और providers की लंबी टेल को संभालता है — आपके OrcaRouter खाते पर प्रति-टोकन बिलिंग के साथ। देखें [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction)।
+
+### फिर इसे किसी भी OpenAI SDK से कॉल करें
+
+नीचे के उदाहरण पथ A के localhost बेस URL का उपयोग करते हैं — यदि आप पथ B पर हैं तो `https://api.orcarouter.ai/v1` से बदलें।
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # या "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+डैशबोर्ड के लिए `http://localhost:8000/` खोलें — providers, रूटिंग, analytics, कुंजियाँ (केवल पथ A)।
+
+## क्यों?
+
+| | OrcaRouter Lite | LiteLLM लाइब्रेरी | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Self-hosted सर्वर | ✓ | लाइब्रेरी के रूप में | ✗ | ✓ |
+| OpenAI-compatible | ✓ | ✓ | ✓ | ✓ |
+| Multi-provider (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| बिल्ट-इन डैशबोर्ड | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (सबसे सस्ता सक्षम) | ✓ | ✗ | ✗ | n/a |
+| स्ट्रीमिंग | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hosted-as-fallback | ✓ | ✗ | n/a | ✗ |
+| न Postgres / न Redis आवश्यक | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — मुख्य फ़ीचर
+
+`model="auto"` भेजें और OrcaRouter आपके कॉन्फ़िगर किए गए providers में से **सबसे सस्ता** मॉडल चुनेगा जो request की क्षमता आवश्यकताओं (tools, vision, JSON मोड) को पूरा करता है। न मैनुअल रूटिंग नियम; न rate-limit जिमनास्टिक्स; आपके कोड में न कोई `if x: ...` कॉस्ट ऑप्टिमाइज़ेशन।
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → आपकी कुंजियों द्वारा कवर सबसे सस्ते VISION-सक्षम मॉडल पर रूट करता है
+```
+
+समाधान किया गया मॉडल `x-orca-resolved-model` रिस्पॉन्स हेडर के माध्यम से कॉलर को वापस उजागर किया जाता है, ताकि आप लॉग/प्रदर्शित कर सकें कि वास्तव में क्या उपयोग हुआ।
+
+## Hosted को upstream के रूप में (Lite + hosted)
+
+पहले से Lite चला रहे हैं? `ORCAROUTER_API_KEY` को [www.orcarouter.ai](https://www.orcarouter.ai) से अपनी `sk-orca-*` पर सेट करें, और hosted रूटिंग चेन में एक और provider बन जाता है — उन मॉडलों को कवर करते हुए जो आपकी local कुंजियों के पास नहीं हैं:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+उपयोग के मामले:
+- **खरीदने-से-पहले-आज़माएँ** — local provider कुंजियों की आवश्यकता नहीं
+- **लोकल लॉगिंग** — hosted रूटिंग संभालता है, Lite डैशबोर्ड के लिए RequestLog रिकॉर्ड संग्रहित करता है
+- **Failover** — local providers विफल होते हैं, hosted सेफ्टी नेट है
+
+## स्ट्रीमिंग
+
+मानक `data: ... \n\n` फ्रेमिंग और टर्मिनल `[DONE]` सेन्टिनल के साथ OpenAI-compatible SSE फ़ॉर्मेट — किसी भी SDK के लिए drop-in जो पहले से OpenAI से स्ट्रीम करता है।
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## मॉडल कैटलॉग
+
+स्टार्टअप पर 100+ चैट मॉडल [LiteLLM के समुदाय-संचालित मूल्य डेटाबेस](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) से लोड किए जाते हैं — कोई मॉडल सूची मैनुअली बनाए रखने के लिए नहीं। प्रत्येक प्रविष्टि उजागर करती है:
+
+- `id` (जैसे `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (आपकी कॉन्फ़िगर की गई कुंजियों पर मैप)
+- क्षमता फ्लैग्स: `supports_tools`, `supports_vision`, `supports_json_mode`
+- प्रति-टोकन इनपुट/आउटपुट लागत (बचत विजेट + `model="auto"` को चलाती है)
+
+`GET /v1/models` OpenAI-format कैटलॉग लौटाता है।
+
+## कहीं और डिप्लॉय करें
+
+| प्लेटफ़ॉर्म | वन-क्लिक |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | रेपो कनेक्ट करें, root dir = `.` |
+| बेयर Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (इमेज जल्द आ रही है) |
+
+## बॉक्स में क्या है
+
+- `POST /v1/chat/completions` — proxy + स्ट्रीमिंग + `model="auto"` + cross-provider प्रॉम्प्ट कैश
+- `GET  /v1/models` — खोज योग्य मॉडल कैटलॉग (`litellm.model_cost` से 100+ मॉडल)
+- `GET/PUT/DELETE /v1/providers/{provider}` — एन्क्रिप्टेड provider कुंजियाँ सेट / सूचीबद्ध / रद्द करें
+- `GET/PUT /v1/routing` — रणनीति बदलें (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — local analytics, कोई टेलीमेट्री बॉक्स से बाहर नहीं जाती
+- `GET  /v1/hosted` — hosted-fallback स्थिति (डैशबोर्ड के "Get $5 free credit" कार्ड को चलाती है)
+- `GET/POST/DELETE /v1/keys/...` — API कुंजियाँ सूचीबद्ध / रोटेट / रद्द करें
+- `/` पर सिंगल-पेज डैशबोर्ड
+- डिफ़ॉल्ट रूप से SQLite; `DATABASE_URL` के माध्यम से Postgres opt-in; Redis वैकल्पिक
+
+### Cross-provider प्रॉम्प्ट कैश
+
+डिटरमिनिस्टिक requests (`temperature=0` या पिन की गई `seed`) दोहराव पर कैश से सर्व होते हैं — यह **हर** provider पर काम करता है, केवल Anthropic पर नहीं। Backend Redis है यदि `REDIS_URL` सेट है, अन्यथा in-process LRU। कैश हिट तुरंत `x-orca-cache: HIT` के साथ लौटते हैं और लागत $0।
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # वही payload फिर से
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← कैश से सर्व, कोई upstream कॉल नहीं
+```
+
+### बचत विजेट
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` बताता है कि आपका ट्रैफ़िक हमेशा-GPT-4 पर कितना खर्च होता बनाम वास्तव में कितना खर्च हुआ। डैशबोर्ड इसे एक टाइल के रूप में दिखाता है।
+
+### इंटीग्रेशन
+
+[Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) और किसी भी टूल के लिए drop-in कॉन्फ़िगरेशन जो OpenAI Chat Completions प्रोटोकॉल बोलता है। देखें [`integrations/`](./integrations/)।
+
+## जो जानबूझकर नहीं है
+
+यह **single-workspace** संस्करण है। डिज़ाइन के अनुसार, नहीं:
+- मल्टी-टेनेंसी, RBAC, SSO
+- बिलिंग, वॉलेट्स, पॉइंट्स, पार्टनर प्रोग्राम
+- एडमिन कंसोल, ऑडिट लॉग्स, trust & safety
+- मल्टी-पॉड डिप्लॉयमेंट / Kubernetes
+- अलर्ट्स के लिए ईमेल / Slack / webhooks
+
+उनके लिए, hosted प्रोडक्ट या (आगामी) Teams संस्करण देखें।
+
+## टेस्टिंग
+
+टेस्ट-फ़र्स्ट बनाया गया। यहाँ शिप किए गए हर व्यवहार के लिए पहले एक फेल होने वाला टेस्ट था।
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| स्लाइस | टेस्ट | क्या |
+|---|---|---|
+| 1. Config | 5 | env लोडिंग, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + API कुंजी + RoutingConfig, idempotent |
+| 3. Auth मिडलवेयर | 4 | bearer-token सत्यापन, अनुपस्थित/अमान्य पर 401 |
+| 4. App factory | 3 | /health, error envelope, /v1/* gating |
+| 5. Provider कुंजी CRUD | 5 | रेस्ट पर एन्क्रिप्टेड, plaintext कभी round-trip नहीं करता |
+| 6. राउटर कैश | 13 | प्राथमिकता के साथ env+DB+hosted डिप्लॉयमेंट असेंबली |
+| 7. चैट कंप्लीशन | 5 | OpenAI फ़ॉर्मेट, RequestLog, सत्यापन |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + रणनीति अपडेट |
+| 10. स्ट्रीमिंग | 4 | SSE फ़ॉर्मेट, `[DONE]` सेन्टिनल, log writeback |
+| 11. कैटलॉग | 7 | 100+ मॉडल, क्षमता फ्लैग्स, pricing |
+| 12. `model="auto"` | 21 | क्षमता डिटेक्शन, सबसे-सस्ता-जो-ज़रूरत-पूरी-करता-है (unit + एकीकरण) |
+| 13. लागत बचत | 9 | हमेशा-GPT-4 बेसलाइन बनाम बचत + hosted-auto तुलना |
+| 14. प्रॉम्प्ट कैश | 15 | cross-provider exact-match कैश + चैट एकीकरण |
+| 15. Benchmark | 4 | summarize() + render_markdown() एग्रीगेशन |
+| 16. Hosted स्थिति | 7 | `/v1/hosted` config-source + signup-URL surface |
+| 17. Hosted-auto बचत | 3 | सिंथेटिक कैटलॉग पर `_hosted_auto_savings` एज केस |
+| 18. अनुपलब्ध मॉडल | 7 | "जिन मॉडलों तक नहीं पहुँच सकते" टाइल hosted चालू होने पर खाली हो जाती है |
+| **कुल** | **127** | |
+
+## आर्किटेक्चर
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## रोडमैप
+
+- [x] OpenAI-compatible चैट कंप्लीशन
+- [x] स्ट्रीमिंग (SSE)
+- [x] `model="auto"` सबसे-सस्ता-सक्षम रूटिंग
+- [x] Hosted-as-upstream
+- [x] रेस्ट पर एन्क्रिप्टेड BYOK
+- [x] लोकल analytics डैशबोर्ड
+- [x] CI (GitHub Actions)
+- [x] Cross-provider प्रॉम्प्ट कैशिंग
+- [x] Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK इंटीग्रेशन
+- [x] सार्वजनिक benchmark + बचत दावा
+- [ ] Embeddings + image-gen proxy
+
+Failover डेमो के लिए [DEMO.md](./DEMO.md) देखें।
+
+## लाइसेंस
+
+MIT। देखें [LICENSE](./LICENSE)।

--- a/README.it.md
+++ b/README.it.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Italiano)
+# OrcaRouter Lite
 
-> Questo documento è un riepilogo tradotto dalla community. Per i dettagli tecnici ufficiali, consulta il [README in inglese](./README.md).
+**Router LLM self-hosted con rete di sicurezza gestita.**
+Compatibile con OpenAI. BYOK. Workspace singolo. Streaming. `model="auto"`.
 
-## Link lingua
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Lingue
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Panoramica
+OrcaRouter Lite è l'edizione open source single-workspace di [OrcaRouter](https://www.orcarouter.ai). Eseguilo sul tuo laptop, integralo nel tuo prodotto, oppure usa direttamente l'`api.orcarouter.ai` ospitato per la long tail di modelli di cui non vuoi gestire le chiavi.
 
-OrcaRouter Lite è un router LLM self-hosted con API compatibile OpenAI, BYOK, streaming e instradamento automatico verso il modello più economico che soddisfa le capacità tramite `model="auto"`.
+> **Perché noi?** LiteLLM è una libreria; OpenRouter è closed-source e ospitato; Ollama è solo locale. Noi siamo il **server self-hosted con fallback gestito** — una frase che nessuno di loro può dire.
 
+## Quickstart in 60 secondi
+
+Due modi per usare OrcaRouter:
+
+### Strada A — Self-hosted (BYOK)
+
+Esegui Lite sulla tua macchina; porta le tue chiavi provider.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# aggiungi almeno una: OPENAI_API_KEY=sk-...  (o ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+URL base: `http://localhost:8000/v1`. Usa la chiave `sk-orca-*` stampata all'avvio.
+
+### Strada B — Hosted (account richiesto)
+
+Niente clone, niente docker. Registrati, ottieni una chiave, punta qualsiasi SDK OpenAI all'hosted.
+
+```bash
+# 1. Registrati su https://www.orcarouter.ai e copia la tua chiave sk-orca-*
+# 2. Usa https://api.orcarouter.ai/v1 come URL base
+```
+
+**Account richiesto.** L'hosted gestisce routing, fatturazione e la long tail di provider — fatturato per token sul tuo account OrcaRouter. Vedi [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Poi chiamalo da qualsiasi SDK OpenAI
+
+Gli esempi qui sotto usano l'URL base localhost della Strada A — sostituisci con `https://api.orcarouter.ai/v1` se sei sulla Strada B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # o "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Apri `http://localhost:8000/` per la dashboard — provider, routing, analytics, chiavi (solo Strada A).
+
+## Perché?
+
+| | OrcaRouter Lite | Libreria LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Server self-hosted | ✓ | come libreria | ✗ | ✓ |
+| Compatibile con OpenAI | ✓ | ✓ | ✓ | ✓ |
+| Multi-provider (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Dashboard integrata | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (più economico capace) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hosted come fallback | ✓ | ✗ | n/a | ✗ |
+| Nessun Postgres / nessun Redis richiesto | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — la feature di punta
+
+Invia `model="auto"` e OrcaRouter sceglie il modello **più economico** tra i provider configurati che soddisfa i requisiti di capacità della richiesta (tools, vision, modalità JSON). Niente regole di routing manuali; niente acrobazie con i rate-limit; niente ottimizzazione costo `if x: ...` nel tuo codice.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → instrada al modello più economico VISION-capable coperto dalle tue chiavi
+```
+
+Il modello risolto viene esposto a chi chiama tramite l'header di risposta `x-orca-resolved-model`, così puoi loggare/mostrare cosa è stato effettivamente usato.
+
+## Hosted come upstream (Lite + hosted)
+
+Hai già Lite in esecuzione? Imposta `ORCAROUTER_API_KEY` con il tuo `sk-orca-*` di [www.orcarouter.ai](https://www.orcarouter.ai), e l'hosted diventa un provider in più nella catena di routing — coprendo i modelli che le tue chiavi locali non hanno:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Casi d'uso:
+- **Prova-prima-di-comprare** — nessuna chiave provider locale necessaria
+- **Logging locale** — l'hosted gestisce il routing, Lite memorizza le righe RequestLog per la dashboard
+- **Failover** — i provider locali falliscono, l'hosted è la rete di sicurezza
+
+## Streaming
+
+Formato SSE compatibile OpenAI con il framing standard `data: ... \n\n` e un sentinel terminale `[DONE]` — drop-in per qualsiasi SDK che già fa streaming da OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Catalogo modelli
+
+Oltre 100 modelli di chat vengono caricati all'avvio dal [database di prezzi mantenuto dalla community di LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — nessuna lista di modelli da mantenere a mano. Ogni voce espone:
+
+- `id` (es. `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (mappato sulle tue chiavi configurate)
+- Flag di capacità: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Costo per token input/output (alimenta il widget risparmi + `model="auto"`)
+
+`GET /v1/models` restituisce il catalogo nel formato OpenAI.
+
+## Deploy altrove
+
+| Piattaforma | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Collega il repo, root dir = `.` |
+| Docker nudo | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (immagine in arrivo) |
+
+## Cosa c'è nella scatola
+
+- `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache prompt cross-provider
+- `GET  /v1/models` — catalogo modelli scopribile (100+ modelli da `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — imposta / lista / revoca chiavi provider cifrate
+- `GET/PUT /v1/routing` — cambia strategia (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — analytics locali, nessuna telemetria esce dalla scatola
+- `GET  /v1/hosted` — stato del fallback hosted (alimenta la card "Get $5 free credit" della dashboard)
+- `GET/POST/DELETE /v1/keys/...` — lista / ruota / revoca chiavi API
+- Dashboard single-page su `/`
+- SQLite di default; Postgres opt-in via `DATABASE_URL`; Redis opzionale
+
+### Cache prompt cross-provider
+
+Le richieste deterministiche (`temperature=0` o `seed` fissato) vengono servite dalla cache alle ripetizioni — funziona su **ogni** provider, non solo Anthropic. Il backend è Redis se `REDIS_URL` è impostato, altrimenti un LRU in-process. Gli hit della cache tornano istantaneamente con `x-orca-cache: HIT` e costano $0.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # stesso payload di nuovo
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← servito dalla cache, nessuna chiamata upstream
+```
+
+### Widget risparmi
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` riporta quanto sarebbe costato il tuo traffico con sempre-GPT-4 rispetto a quanto è effettivamente costato. La dashboard lo mostra come tile.
+
+### Integrazioni
+
+Configurazioni drop-in per [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualsiasi tool che parli il protocollo OpenAI Chat Completions. Vedi [`integrations/`](./integrations/).
+
+## Cosa volutamente non c'è
+
+Questa è l'edizione **single-workspace**. Per design, niente:
+- multi-tenancy, RBAC, SSO
+- fatturazione, wallet, punti, programma partner
+- console di amministrazione, log di audit, trust & safety
+- deploy multi-pod / Kubernetes
+- email / Slack / webhook per gli alert
+
+Per quelli, vedi il prodotto hosted o la (futura) edizione Teams.
+
+## Testing
+
+Costruito test-first. Ogni comportamento spedito qui ha avuto prima un test che falliva.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Test | Cosa |
+|---|---|---|
+| 1. Config | 5 | caricamento env, default, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + chiave API + RoutingConfig, idempotente |
+| 3. Middleware di auth | 4 | validazione bearer-token, 401 su mancante/invalido |
+| 4. App factory | 3 | /health, error envelope, gating /v1/* |
+| 5. CRUD chiavi provider | 5 | cifrato a riposo, il plaintext non fa mai andata-ritorno |
+| 6. Cache router | 13 | assemblaggio deployment env+DB+hosted con precedenza |
+| 7. Chat completion | 5 | formato OpenAI, RequestLog, validazione |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + aggiornamento strategia |
+| 10. Streaming | 4 | formato SSE, sentinel `[DONE]`, log writeback |
+| 11. Catalogo | 7 | 100+ modelli, flag di capacità, pricing |
+| 12. `model="auto"` | 21 | rilevamento capacità, più-economico-che-soddisfa-i-bisogni (unit + integrazione) |
+| 13. Risparmio costi | 9 | risparmi vs baseline sempre-GPT-4 + confronto hosted-auto |
+| 14. Cache prompt | 15 | cache exact-match cross-provider + integrazione chat |
+| 15. Benchmark | 4 | aggregazione summarize() + render_markdown() |
+| 16. Stato hosted | 7 | `/v1/hosted` config-source + superficie URL di signup |
+| 17. Risparmi hosted-auto | 3 | edge case di `_hosted_auto_savings` su cataloghi sintetici |
+| 18. Modelli irraggiungibili | 7 | la tile "modelli che non puoi raggiungere" si svuota quando hosted è attivo |
+| **Totale** | **127** | |
+
+## Architettura
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] Chat completions compatibili OpenAI
+- [x] Streaming (SSE)
+- [x] Routing `model="auto"` più-economico-capace
+- [x] Hosted-come-upstream
+- [x] BYOK cifrato a riposo
+- [x] Dashboard analytics locale
+- [x] CI (GitHub Actions)
+- [x] Caching prompt cross-provider
+- [x] Integrazioni Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Benchmark pubblico + claim sui risparmi
+- [ ] Proxy embeddings + image-gen
+
+Vedi [DEMO.md](./DEMO.md) per la demo di failover.
+
+## Licenza
+
+MIT. Vedi [LICENSE](./LICENSE).

--- a/README.pt.md
+++ b/README.pt.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Português)
+# OrcaRouter Lite
 
-> Este documento é um resumo traduzido pela comunidade. Para detalhes técnicos oficiais, consulte o [README em inglês](./README.md).
+**Roteador LLM self-hosted com rede de segurança gerenciada.**
+Compatível com OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 
-## Links de idioma
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Idiomas
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Visão geral
+OrcaRouter Lite é a edição open source single-workspace do [OrcaRouter](https://www.orcarouter.ai). Rode no seu laptop, embarque no seu produto, ou use diretamente o `api.orcarouter.ai` hospedado para a long tail de modelos cujas chaves você não quer gerenciar.
 
-OrcaRouter Lite é um roteador LLM self-hosted com API compatível com OpenAI, suporte BYOK, streaming e roteamento automático para o modelo mais barato que atenda às capacidades com `model="auto"`.
+> **Por que nós?** LiteLLM é uma biblioteca; OpenRouter é closed-source e hospedado; Ollama é apenas local. Nós somos o **servidor self-hosted com fallback gerenciado** — uma frase que nenhum deles pode dizer.
 
+## Quickstart de 60 segundos
+
+Duas formas de usar o OrcaRouter:
+
+### Caminho A — Self-hosted (BYOK)
+
+Rode o Lite na sua própria máquina; traga suas próprias chaves de provider.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# adicione pelo menos uma: OPENAI_API_KEY=sk-...  (ou ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+URL base: `http://localhost:8000/v1`. Use a chave `sk-orca-*` impressa na inicialização.
+
+### Caminho B — Hospedado (conta necessária)
+
+Sem clone, sem docker. Registre-se, pegue uma chave, aponte qualquer SDK OpenAI para o hospedado.
+
+```bash
+# 1. Registre-se em https://www.orcarouter.ai e copie sua chave sk-orca-*
+# 2. Use https://api.orcarouter.ai/v1 como URL base
+```
+
+**Conta necessária.** O hospedado cuida de roteamento, faturamento e da long tail de providers — cobrado por token na sua conta OrcaRouter. Veja [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Depois chame de qualquer SDK OpenAI
+
+Os exemplos abaixo usam a URL base localhost do Caminho A — troque por `https://api.orcarouter.ai/v1` se estiver no Caminho B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # ou "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Abra `http://localhost:8000/` para o dashboard — providers, roteamento, analytics, chaves (apenas Caminho A).
+
+## Por quê?
+
+| | OrcaRouter Lite | Biblioteca LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Servidor self-hosted | ✓ | como biblioteca | ✗ | ✓ |
+| Compatível com OpenAI | ✓ | ✓ | ✓ | ✓ |
+| Multi-provider (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Dashboard embutido | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (mais barato capaz) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hospedado como fallback | ✓ | ✗ | n/a | ✗ |
+| Sem Postgres / sem Redis necessário | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — a feature destaque
+
+Envie `model="auto"` e o OrcaRouter escolhe o modelo **mais barato** entre os providers configurados que atende aos requisitos de capacidade da requisição (tools, vision, modo JSON). Nada de regras de roteamento manuais; nada de ginástica com rate-limits; nada de otimização de custo `if x: ...` no seu código.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → roteia para o modelo mais barato com VISION coberto pelas suas chaves
+```
+
+O modelo resolvido é exposto de volta para quem chamou via header de resposta `x-orca-resolved-model`, para que você possa logar/exibir o que foi realmente usado.
+
+## Hospedado como upstream (Lite + hospedado)
+
+Já está rodando o Lite? Defina `ORCAROUTER_API_KEY` com seu `sk-orca-*` de [www.orcarouter.ai](https://www.orcarouter.ai), e o hospedado vira mais um provider na cadeia de roteamento — cobrindo modelos que suas chaves locais não têm:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Casos de uso:
+- **Teste-antes-de-comprar** — sem precisar de chaves de provider locais
+- **Logging local** — o hospedado cuida do roteamento, o Lite armazena linhas de RequestLog para o dashboard
+- **Failover** — providers locais falham, o hospedado é a rede de segurança
+
+## Streaming
+
+Formato SSE compatível com OpenAI, com framing padrão `data: ... \n\n` e um sentinel terminal `[DONE]` — drop-in para qualquer SDK que já faz streaming a partir da OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Catálogo de modelos
+
+Mais de 100 modelos de chat são carregados na inicialização a partir do [banco de preços mantido pela comunidade do LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — sem lista de modelos para manter manualmente. Cada entrada expõe:
+
+- `id` (ex.: `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (mapeado para suas chaves configuradas)
+- Flags de capacidade: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Custo por token de entrada/saída (alimenta o widget de economia + `model="auto"`)
+
+`GET /v1/models` retorna o catálogo no formato OpenAI.
+
+## Deploy em outro lugar
+
+| Plataforma | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Conecte o repo, root dir = `.` |
+| Docker puro | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (imagem em breve) |
+
+## O que vem na caixa
+
+- `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache de prompt cross-provider
+- `GET  /v1/models` — catálogo de modelos descobrível (100+ modelos de `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — define / lista / revoga chaves de provider criptografadas
+- `GET/PUT /v1/routing` — muda a estratégia (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — analytics locais, nenhuma telemetria sai da caixa
+- `GET  /v1/hosted` — status do fallback hospedado (alimenta o card "Get $5 free credit" do dashboard)
+- `GET/POST/DELETE /v1/keys/...` — lista / rotaciona / revoga chaves API
+- Dashboard single-page em `/`
+- SQLite por padrão; Postgres opt-in via `DATABASE_URL`; Redis opcional
+
+### Cache de prompt cross-provider
+
+Requisições determinísticas (`temperature=0` ou `seed` fixada) são servidas do cache em repetições — funciona em **todos** os providers, não só Anthropic. O backend é Redis se `REDIS_URL` estiver definido, caso contrário um LRU in-process. Cache hits voltam instantaneamente com `x-orca-cache: HIT` e custam $0.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # mesmo payload de novo
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← servido do cache, sem chamada upstream
+```
+
+### Widget de economias
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` reporta quanto seu tráfego teria custado em sempre-GPT-4 versus o que custou de fato. O dashboard mostra como um tile.
+
+### Integrações
+
+Configurações drop-in para [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualquer ferramenta que fale o protocolo OpenAI Chat Completions. Veja [`integrations/`](./integrations/).
+
+## O que deliberadamente não tem
+
+Esta é a edição **single-workspace**. Por design, sem:
+- multi-tenancy, RBAC, SSO
+- faturamento, wallets, pontos, programa de parceiros
+- console admin, logs de auditoria, trust & safety
+- deploy multi-pod / Kubernetes
+- e-mail / Slack / webhooks para alertas
+
+Para isso, veja o produto hospedado ou a (futura) edição Teams.
+
+## Testes
+
+Construído test-first. Cada comportamento entregue aqui teve antes um teste falhando.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Testes | O quê |
+|---|---|---|
+| 1. Config | 5 | carregamento de env, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + chave API + RoutingConfig, idempotente |
+| 3. Middleware de auth | 4 | validação de bearer-token, 401 em ausente/inválido |
+| 4. App factory | 3 | /health, envelope de erro, gating /v1/* |
+| 5. CRUD de chaves de provider | 5 | criptografado em repouso, plaintext nunca faz round-trip |
+| 6. Cache do router | 13 | montagem de deployment env+DB+hospedado com precedência |
+| 7. Chat completion | 5 | formato OpenAI, RequestLog, validação |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + atualização de estratégia |
+| 10. Streaming | 4 | formato SSE, sentinel `[DONE]`, log writeback |
+| 11. Catálogo | 7 | 100+ modelos, flags de capacidade, pricing |
+| 12. `model="auto"` | 21 | detecção de capacidade, mais-barato-que-atende (unit + integração) |
+| 13. Economia de custo | 9 | economias vs baseline sempre-GPT-4 + comparação hosted-auto |
+| 14. Cache de prompt | 15 | cache exact-match cross-provider + integração chat |
+| 15. Benchmark | 4 | agregação summarize() + render_markdown() |
+| 16. Status do hospedado | 7 | `/v1/hosted` config-source + superfície da URL de signup |
+| 17. Economias hosted-auto | 3 | edge cases de `_hosted_auto_savings` em catálogos sintéticos |
+| 18. Modelos inalcançáveis | 7 | o tile "modelos que você não pode alcançar" se esvazia quando hosted está ligado |
+| **Total** | **127** | |
+
+## Arquitetura
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] Chat completions compatíveis com OpenAI
+- [x] Streaming (SSE)
+- [x] Roteamento `model="auto"` mais-barato-capaz
+- [x] Hospedado-como-upstream
+- [x] BYOK criptografado em repouso
+- [x] Dashboard de analytics local
+- [x] CI (GitHub Actions)
+- [x] Caching de prompt cross-provider
+- [x] Integrações Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Benchmark público + reivindicação de economia
+- [ ] Proxy de embeddings + image-gen
+
+Veja [DEMO.md](./DEMO.md) para o demo de failover.
+
+## Licença
+
+MIT. Veja [LICENSE](./LICENSE).

--- a/README.ru.md
+++ b/README.ru.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Русский)
+# OrcaRouter Lite
 
-> Это краткий перевод от сообщества. За точными техническими деталями обращайтесь к [английскому README](./README.md).
+**Self-hosted LLM-роутер с управляемой страховочной сеткой.**
+OpenAI-совместимый. BYOK. Один рабочий пространство (workspace). Стриминг. `model="auto"`.
 
-## Языковые ссылки
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Языки
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Обзор
+OrcaRouter Lite — это open-source-редакция [OrcaRouter](https://www.orcarouter.ai) для одного workspace. Запустите его на ноутбуке, поставьте в свой продукт или используйте hosted-эндпоинт `api.orcarouter.ai` напрямую для длинного хвоста моделей, ключи которых вы не хотите вести самостоятельно.
 
-OrcaRouter Lite — это self-hosted LLM-роутер с OpenAI-совместимым API, поддержкой BYOK, стримингом и автоматическим выбором самой дешёвой подходящей модели через `model="auto"`.
+> **Почему мы?** LiteLLM — это библиотека; OpenRouter — closed-source и hosted; Ollama — только локально. Мы — **self-hosted-сервер с управляемым fallback** — фразу, которую никто из них сказать не может.
 
+## Быстрый старт за 60 секунд
+
+Два способа использовать OrcaRouter:
+
+### Путь A — Self-hosted (BYOK)
+
+Запустите Lite на своей машине; принесите свои ключи провайдеров.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# добавьте хотя бы один: OPENAI_API_KEY=sk-...  (или ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+Базовый URL: `http://localhost:8000/v1`. Используйте ключ `sk-orca-*`, выведенный при старте.
+
+### Путь B — Hosted (требуется аккаунт)
+
+Без клонирования, без docker. Зарегистрируйтесь, получите ключ, направьте любой OpenAI SDK на hosted-эндпоинт.
+
+```bash
+# 1. Зарегистрируйтесь на https://www.orcarouter.ai и скопируйте свой ключ sk-orca-*
+# 2. Используйте https://api.orcarouter.ai/v1 как базовый URL
+```
+
+**Требуется аккаунт.** Hosted берёт на себя маршрутизацию, биллинг и длинный хвост провайдеров — оплата по токенам на вашем аккаунте OrcaRouter. См. [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Затем вызывайте из любого OpenAI SDK
+
+В примерах ниже используется localhost-URL из Пути A — замените на `https://api.orcarouter.ai/v1`, если вы на Пути B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # или "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Откройте `http://localhost:8000/` для дашборда — провайдеры, маршрутизация, аналитика, ключи (только Путь A).
+
+## Почему?
+
+| | OrcaRouter Lite | Библиотека LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Self-hosted-сервер | ✓ | как библиотека | ✗ | ✓ |
+| OpenAI-совместимый | ✓ | ✓ | ✓ | ✓ |
+| Мульти-провайдер (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Встроенный дашборд | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (самый дешёвый подходящий) | ✓ | ✗ | ✗ | n/a |
+| Стриминг | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hosted как fallback | ✓ | ✗ | n/a | ✗ |
+| Без Postgres / без Redis | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — главная фича
+
+Отправьте `model="auto"`, и OrcaRouter выберет **самую дешёвую** модель среди настроенных провайдеров, которая удовлетворяет требованиям запроса по возможностям (tools, vision, JSON-режим). Никаких ручных правил маршрутизации; никакой акробатики с rate-limit; никаких `if x: ...`-оптимизаций по цене в вашем коде.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → маршрутизирует на самую дешёвую VISION-модель, покрытую вашими ключами
+```
+
+Выбранная модель возвращается вызывающему через заголовок ответа `x-orca-resolved-model`, чтобы вы могли логировать/показывать, что фактически использовалось.
+
+## Hosted как upstream (Lite + hosted)
+
+Уже запустили Lite? Установите `ORCAROUTER_API_KEY` равным вашему `sk-orca-*` с [www.orcarouter.ai](https://www.orcarouter.ai), и hosted станет ещё одним провайдером в цепочке маршрутизации — покрывая модели, которых нет у ваших локальных ключей:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Сценарии:
+- **Try-before-you-buy** — локальные ключи провайдеров не нужны
+- **Локальное логирование** — hosted делает маршрутизацию, Lite пишет строки RequestLog для дашборда
+- **Failover** — локальные провайдеры падают, hosted — страховочная сетка
+
+## Стриминг
+
+OpenAI-совместимый SSE-формат со стандартным `data: ... \n\n`-фреймингом и завершающим маркером `[DONE]` — drop-in для любого SDK, который уже стримит из OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Каталог моделей
+
+При старте загружается более 100 чат-моделей из [community-поддерживаемой базы цен LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — никакого списка моделей вручную. Каждая запись содержит:
+
+- `id` (например, `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (мапится на ваши настроенные ключи)
+- Capability-флаги: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Стоимость на токен входа/выхода (питает виджет экономии + `model="auto"`)
+
+`GET /v1/models` возвращает каталог в формате OpenAI.
+
+## Деплой в другом месте
+
+| Платформа | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Подключите репо, корневая директория = `.` |
+| Голый Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (образ скоро) |
+
+## Что в коробке
+
+- `POST /v1/chat/completions` — proxy + стриминг + `model="auto"` + кросс-провайдерный кэш промптов
+- `GET  /v1/models` — обнаруживаемый каталог моделей (100+ моделей из `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — установка / список / отзыв зашифрованных ключей провайдеров
+- `GET/PUT /v1/routing` — смена стратегии (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — локальная аналитика, никакая телеметрия не уходит из коробки
+- `GET  /v1/hosted` — статус hosted-fallback (питает карточку «Get $5 free credit» в дашборде)
+- `GET/POST/DELETE /v1/keys/...` — список / ротация / отзыв API-ключей
+- Single-page-дашборд по `/`
+- SQLite по умолчанию; Postgres опционально через `DATABASE_URL`; Redis опционально
+
+### Кросс-провайдерный кэш промптов
+
+Детерминированные запросы (`temperature=0` или закреплённый `seed`) при повторе обслуживаются из кэша — работает на **любом** провайдере, не только Anthropic. Бэкенд — Redis, если задан `REDIS_URL`, иначе in-process LRU. Попадания в кэш возвращаются мгновенно с `x-orca-cache: HIT` и стоят $0.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # тот же payload снова
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← из кэша, без запроса к upstream
+```
+
+### Виджет экономии
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` показывает, сколько ваш трафик стоил бы на «всегда GPT-4» против того, сколько стоил на самом деле. Дашборд показывает это в виде плитки.
+
+### Интеграции
+
+Готовые конфиги для [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) и любого инструмента, говорящего на протоколе OpenAI Chat Completions. См. [`integrations/`](./integrations/).
+
+## Чего намеренно нет
+
+Это редакция **single-workspace**. По дизайну, нет:
+- мульти-арендности, RBAC, SSO
+- биллинга, кошельков, баллов, партнёрской программы
+- админ-консоли, audit-логов, trust & safety
+- multi-pod-деплоя / Kubernetes
+- email / Slack / webhook-алертов
+
+Для этого см. hosted-продукт или (будущую) Teams-редакцию.
+
+## Тестирование
+
+Сделано test-first. У каждого поведения, выпущенного здесь, сначала был падающий тест.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Слайс | Тесты | Что |
+|---|---|---|
+| 1. Config | 5 | загрузка env, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + API-ключ + RoutingConfig, идемпотентно |
+| 3. Auth-middleware | 4 | валидация bearer-токена, 401 при отсутствии/невалидном |
+| 4. App factory | 3 | /health, error-конверт, gating /v1/* |
+| 5. CRUD ключей провайдеров | 5 | шифровано at rest, plaintext не делает round-trip |
+| 6. Кэш роутера | 13 | сборка деплоя env+DB+hosted с приоритетами |
+| 7. Chat completion | 5 | формат OpenAI, RequestLog, валидация |
+| 8. Аналитика | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + обновление стратегии |
+| 10. Стриминг | 4 | SSE-формат, маркер `[DONE]`, log writeback |
+| 11. Каталог | 7 | 100+ моделей, capability-флаги, цены |
+| 12. `model="auto"` | 21 | детект возможностей, самый-дешёвый-из-подходящих (unit + интеграция) |
+| 13. Экономия затрат | 9 | экономия vs always-GPT-4 baseline + сравнение hosted-auto |
+| 14. Кэш промптов | 15 | кросс-провайдерный exact-match-кэш + интеграция с чатом |
+| 15. Бенчмарк | 4 | агрегация summarize() + render_markdown() |
+| 16. Hosted-статус | 7 | `/v1/hosted` config-source + signup-URL surface |
+| 17. Hosted-auto-экономия | 3 | edge cases `_hosted_auto_savings` на синтетических каталогах |
+| 18. Недоступные модели | 7 | плитка «модели, до которых вы не дотянетесь» очищается, когда hosted включён |
+| **Всего** | **127** | |
+
+## Архитектура
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Roadmap
+
+- [x] OpenAI-совместимые chat completions
+- [x] Стриминг (SSE)
+- [x] `model="auto"` маршрутизация на самый-дешёвый-подходящий
+- [x] Hosted-как-upstream
+- [x] Зашифрованный BYOK at rest
+- [x] Локальный аналитический дашборд
+- [x] CI (GitHub Actions)
+- [x] Кросс-провайдерное кэширование промптов
+- [x] Интеграции Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Публичный бенчмарк + заявление по экономии
+- [ ] Прокси для embeddings + image-gen
+
+См. [DEMO.md](./DEMO.md) для демо failover.
+
+## Лицензия
+
+MIT. См. [LICENSE](./LICENSE).

--- a/README.vi.md
+++ b/README.vi.md
@@ -1,8 +1,15 @@
-# OrcaRouter Lite (Tiếng Việt)
+# OrcaRouter Lite
 
-> Đây là bản tóm tắt dịch bởi cộng đồng. Với thông tin kỹ thuật chuẩn, vui lòng xem [README tiếng Anh](./README.md).
+**Bộ định tuyến LLM tự lưu trữ với lưới an toàn được quản lý.**
+Tương thích OpenAI. BYOK. Workspace đơn. Streaming. `model="auto"`.
 
-## Liên kết ngôn ngữ
+![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
+
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
+
+## Ngôn ngữ
 
 - [English](./README.md)
 - [日本語](./README.ja.md)
@@ -17,7 +24,296 @@
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-## Tổng quan
+OrcaRouter Lite là phiên bản mã nguồn mở single-workspace của [OrcaRouter](https://www.orcarouter.ai). Chạy trên laptop, đóng gói vào sản phẩm của bạn, hoặc dùng trực tiếp `api.orcarouter.ai` được host cho phần đuôi dài các mô hình mà bạn không muốn tự quản lý khoá.
 
-OrcaRouter Lite là bộ định tuyến LLM tự lưu trữ, tương thích API OpenAI, hỗ trợ BYOK, streaming và tự động chọn mô hình rẻ nhất đáp ứng yêu cầu bằng `model="auto"`.
+> **Tại sao là chúng tôi?** LiteLLM là một thư viện; OpenRouter là dịch vụ host mã nguồn đóng; Ollama chỉ chạy local. Chúng tôi là **server tự lưu trữ với fallback được quản lý** — một câu mà không ai trong số họ nói được.
 
+## Khởi động nhanh trong 60 giây
+
+Hai cách dùng OrcaRouter:
+
+### Đường A — Tự lưu trữ (BYOK)
+
+Chạy Lite trên máy của bạn; mang theo khoá provider của riêng bạn.
+
+```bash
+git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
+cd OrcaRouter-Lite
+cp .env.example .env
+# thêm ít nhất một: OPENAI_API_KEY=sk-...  (hoặc ORCAROUTER_API_KEY=...)
+
+docker compose up
+# logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
+```
+
+URL gốc: `http://localhost:8000/v1`. Dùng khoá `sk-orca-*` được in ra khi khởi động.
+
+### Đường B — Hosted (cần tài khoản)
+
+Không clone, không docker. Đăng ký, lấy khoá, trỏ bất kỳ OpenAI SDK nào tới hosted.
+
+```bash
+# 1. Đăng ký tại https://www.orcarouter.ai và sao chép khoá sk-orca-* của bạn
+# 2. Dùng https://api.orcarouter.ai/v1 làm URL gốc
+```
+
+**Cần tài khoản.** Hosted lo định tuyến, tính phí và phần đuôi dài các provider — tính theo token trên tài khoản OrcaRouter của bạn. Xem [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction).
+
+### Sau đó gọi từ bất kỳ OpenAI SDK nào
+
+Các ví dụ bên dưới dùng URL gốc localhost của Đường A — đổi sang `https://api.orcarouter.ai/v1` nếu bạn đang ở Đường B.
+
+<details>
+<summary><b>Python</b></summary>
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://localhost:8000/v1",
+    api_key="sk-orca-abc123...",
+)
+r = client.chat.completions.create(
+    model="auto",  # hoặc "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(r.choices[0].message.content)
+```
+</details>
+
+<details>
+<summary><b>Node.js</b></summary>
+
+```js
+import OpenAI from "openai";
+
+const client = new OpenAI({
+  baseURL: "http://localhost:8000/v1",
+  apiKey: "sk-orca-abc123...",
+});
+
+const r = await client.chat.completions.create({
+  model: "auto",
+  messages: [{ role: "user", content: "Hello!" }],
+});
+console.log(r.choices[0].message.content);
+```
+</details>
+
+<details>
+<summary><b>curl</b></summary>
+
+```bash
+curl http://localhost:8000/v1/chat/completions \
+  -H "Authorization: Bearer sk-orca-abc123..." \
+  -H "Content-Type: application/json" \
+  -d '{"model":"auto","messages":[{"role":"user","content":"Hello!"}]}'
+```
+</details>
+
+Mở `http://localhost:8000/` để vào dashboard — providers, định tuyến, analytics, khoá (chỉ Đường A).
+
+## Tại sao?
+
+| | OrcaRouter Lite | Thư viện LiteLLM | OpenRouter | Ollama |
+|---|---|---|---|---|
+| Server tự lưu trữ | ✓ | dạng thư viện | ✗ | ✓ |
+| Tương thích OpenAI | ✓ | ✓ | ✓ | ✓ |
+| Đa provider (OpenAI/Anthropic/Google/…) | ✓ | ✓ | ✓ | ✗ |
+| Dashboard tích hợp | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"` (rẻ nhất đáp ứng) | ✓ | ✗ | ✗ | n/a |
+| Streaming | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| Hosted làm fallback | ✓ | ✗ | n/a | ✗ |
+| Không cần Postgres / không cần Redis | ✓ | n/a | n/a | ✓ |
+
+## `model="auto"` — tính năng chủ lực
+
+Gửi `model="auto"` và OrcaRouter sẽ chọn mô hình **rẻ nhất** trong các provider đã cấu hình mà đáp ứng yêu cầu năng lực của request (tools, vision, chế độ JSON). Không cần luật định tuyến thủ công; không cần xoay sở rate-limit; không cần tối ưu chi phí kiểu `if x: ...` trong code của bạn.
+
+```python
+client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": [
+        {"type": "text", "text": "What's in this image?"},
+        {"type": "image_url", "image_url": {"url": "data:..."}},
+    ]}],
+)
+# → định tuyến đến mô hình hỗ trợ VISION rẻ nhất mà khoá của bạn bao phủ
+```
+
+Mô hình được chọn được trả về cho bên gọi qua header phản hồi `x-orca-resolved-model`, để bạn có thể log/hiển thị mô hình thực sự đã dùng.
+
+## Hosted làm upstream (Lite + hosted)
+
+Đã chạy Lite rồi? Đặt `ORCAROUTER_API_KEY` bằng `sk-orca-*` của bạn từ [www.orcarouter.ai](https://www.orcarouter.ai), và hosted trở thành thêm một provider trong chuỗi định tuyến — bao phủ các mô hình mà khoá local của bạn không có:
+
+```bash
+# .env
+ORCAROUTER_API_KEY=sk-orca-hosted-abc...
+```
+
+Trường hợp dùng:
+- **Dùng-thử-trước-khi-mua** — không cần khoá provider local
+- **Logging local** — hosted lo định tuyến, Lite lưu các dòng RequestLog cho dashboard
+- **Failover** — provider local hỏng, hosted là lưới an toàn
+
+## Streaming
+
+Định dạng SSE tương thích OpenAI với framing chuẩn `data: ... \n\n` và sentinel kết thúc `[DONE]` — drop-in cho bất kỳ SDK nào đã stream từ OpenAI.
+
+```python
+for chunk in client.chat.completions.create(
+    model="auto",
+    messages=[{"role": "user", "content": "Tell me a story"}],
+    stream=True,
+):
+    print(chunk.choices[0].delta.content or "", end="", flush=True)
+```
+
+## Danh mục mô hình
+
+Hơn 100 mô hình chat được nạp khi khởi động từ [cơ sở dữ liệu giá do cộng đồng duy trì của LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — không có danh sách mô hình nào phải bảo trì thủ công. Mỗi mục cung cấp:
+
+- `id` (ví dụ: `gpt-4o`, `claude-3-5-sonnet-latest`)
+- `provider` (ánh xạ tới các khoá đã cấu hình của bạn)
+- Cờ năng lực: `supports_tools`, `supports_vision`, `supports_json_mode`
+- Chi phí mỗi token đầu vào/đầu ra (chạy widget tiết kiệm + `model="auto"`)
+
+`GET /v1/models` trả về danh mục theo định dạng OpenAI.
+
+## Triển khai ở nơi khác
+
+| Nền tảng | One-click |
+|---|---|
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Fly.io | `fly launch --dockerfile Dockerfile` |
+| Render | Kết nối repo, root dir = `.` |
+| Docker thuần | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...` (image sắp ra mắt) |
+
+## Có gì trong hộp
+
+- `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache prompt liên-provider
+- `GET  /v1/models` — danh mục mô hình có thể khám phá (100+ mô hình từ `litellm.model_cost`)
+- `GET/PUT/DELETE /v1/providers/{provider}` — đặt / liệt kê / thu hồi khoá provider được mã hoá
+- `GET/PUT /v1/routing` — đổi chiến lược (`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` — analytics local, không có telemetry rời khỏi hộp
+- `GET  /v1/hosted` — trạng thái hosted-fallback (chạy thẻ "Get $5 free credit" trên dashboard)
+- `GET/POST/DELETE /v1/keys/...` — liệt kê / xoay vòng / thu hồi khoá API
+- Dashboard single-page tại `/`
+- SQLite mặc định; Postgres tuỳ chọn qua `DATABASE_URL`; Redis tuỳ chọn
+
+### Cache prompt liên-provider
+
+Các request có tính xác định (`temperature=0` hoặc `seed` cố định) được phục vụ từ cache khi lặp lại — hoạt động trên **mọi** provider, không chỉ Anthropic. Backend là Redis nếu `REDIS_URL` được đặt, ngược lại là LRU in-process. Cache hit trả về tức thì với `x-orca-cache: HIT` và chi phí $0.
+
+```bash
+$ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
+HTTP/1.1 200 OK
+x-orca-cache: MISS
+x-orca-resolved-model: gpt-4o-mini
+
+$ curl ...  # cùng payload lần nữa
+HTTP/1.1 200 OK
+x-orca-cache: HIT          ← phục vụ từ cache, không gọi upstream
+```
+
+### Widget tiết kiệm
+
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` báo cáo lưu lượng của bạn sẽ tốn bao nhiêu nếu luôn dùng GPT-4 so với chi phí thực tế. Dashboard hiển thị dưới dạng tile.
+
+### Tích hợp
+
+Cấu hình drop-in cho [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) và bất kỳ công cụ nào nói giao thức OpenAI Chat Completions. Xem [`integrations/`](./integrations/).
+
+## Những gì cố ý không có
+
+Đây là phiên bản **single-workspace**. Theo thiết kế, không có:
+- multi-tenancy, RBAC, SSO
+- billing, ví, điểm thưởng, chương trình đối tác
+- console quản trị, audit log, trust & safety
+- triển khai multi-pod / Kubernetes
+- email / Slack / webhook cho cảnh báo
+
+Cho những thứ đó, xem sản phẩm hosted hoặc bản Teams (sắp ra).
+
+## Kiểm thử
+
+Xây dựng theo test-first. Mỗi hành vi giao ở đây đều có một test fail trước.
+
+```bash
+pip install -e ".[dev]"
+PYTHONPATH=. pytest -v
+# 127 passed
+```
+
+| Slice | Tests | Cái gì |
+|---|---|---|
+| 1. Config | 5 | nạp env, defaults, `env_provider_keys()` |
+| 2. Seed | 3 | bootstrap workspace + khoá API + RoutingConfig, idempotent |
+| 3. Auth middleware | 4 | xác thực bearer-token, 401 khi thiếu/không hợp lệ |
+| 4. App factory | 3 | /health, error envelope, gating /v1/* |
+| 5. CRUD khoá provider | 5 | mã hoá khi nghỉ, plaintext không bao giờ round-trip |
+| 6. Cache router | 13 | lắp ghép deployment env+DB+hosted với thứ tự ưu tiên |
+| 7. Chat completion | 5 | định dạng OpenAI, RequestLog, xác thực |
+| 8. Analytics | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | list/create/revoke + cập nhật chiến lược |
+| 10. Streaming | 4 | định dạng SSE, sentinel `[DONE]`, log writeback |
+| 11. Catalog | 7 | 100+ mô hình, cờ năng lực, pricing |
+| 12. `model="auto"` | 21 | phát hiện năng lực, rẻ-nhất-đáp-ứng (unit + tích hợp) |
+| 13. Tiết kiệm chi phí | 9 | tiết kiệm vs baseline luôn-GPT-4 + so sánh hosted-auto |
+| 14. Cache prompt | 15 | cache khớp chính xác liên-provider + tích hợp chat |
+| 15. Benchmark | 4 | tổng hợp summarize() + render_markdown() |
+| 16. Trạng thái hosted | 7 | `/v1/hosted` config-source + bề mặt URL signup |
+| 17. Tiết kiệm hosted-auto | 3 | trường hợp biên `_hosted_auto_savings` trên catalog tổng hợp |
+| 18. Mô hình không tới được | 7 | tile "mô hình bạn không tới được" rỗng khi hosted bật |
+| **Tổng** | **127** | |
+
+## Kiến trúc
+
+```
+app/
+├── main.py             FastAPI factory + lifespan + SPA mount
+├── config.py           Settings (~15 fields)
+├── deps.py             DI helpers
+├── seed.py             First-run bootstrap
+├── auto_routing.py     model="auto" capability + cost scoring
+├── router_cache.py     Single-workspace router
+├── prompt_cache.py     Cross-provider exact-match cache (Redis or in-memory LRU)
+├── schemas.py          OpenAI-compatible request schema
+├── middleware/auth.py  sk-orca-* validation
+└── routes/
+    ├── chat.py         /v1/chat/completions  (blocking + streaming)
+    ├── models.py       /v1/models
+    ├── providers.py    BYOK CRUD
+    ├── routing.py      strategy config
+    ├── analytics.py    recent / spend / latency / savings / unreachable
+    ├── keys.py         list / rotate / revoke API keys
+    ├── hosted.py       /v1/hosted — hosted-fallback status for the dashboard
+    └── health.py
+
+packages/
+├── litellm_adapter/    Router wrapper + 100+ model catalog
+├── auth/               hashing + AES-256-GCM
+└── db/                 models + engine + session
+```
+
+## Lộ trình
+
+- [x] Chat completions tương thích OpenAI
+- [x] Streaming (SSE)
+- [x] Định tuyến `model="auto"` rẻ-nhất-đáp-ứng
+- [x] Hosted-làm-upstream
+- [x] BYOK mã hoá khi nghỉ
+- [x] Dashboard analytics local
+- [x] CI (GitHub Actions)
+- [x] Cache prompt liên-provider
+- [x] Tích hợp Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK
+- [x] Benchmark công khai + tuyên bố tiết kiệm
+- [ ] Proxy embeddings + tạo ảnh
+
+Xem [DEMO.md](./DEMO.md) để xem demo failover.
+
+## Giấy phép
+
+MIT. Xem [LICENSE](./LICENSE).

--- a/README.zh.md
+++ b/README.zh.md
@@ -1,70 +1,70 @@
 # OrcaRouter Lite
 
-**具有托管安全网的自托管 LLM 路由器。**
-兼容 OpenAI。自带。单一工作区。流媒体。 `型号=“汽车”`。
+**带托管安全网的自托管 LLM 路由器。**
+兼容 OpenAI。BYOK。单工作区。流式传输。`model="auto"`。
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![测试](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
-[![模型](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
-[![许可证](https://img.shields.io/badge/license-MIT-blue)](#license)
+[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
+[![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
 ## 语言
 
-- [英文](./README.md)
-- [日本语](./README.ja.md)
+- [English](./README.md)
+- [日本語](./README.ja.md)
 - [中文](./README.zh.md)
 - [한국어](./README.ko.md)
-- [德语](./README.de.md)
-- [法语](./README.fr.md)
-- [西班牙语](./README.es.md)
-- [意大利语](./README.it.md)
+- [Deutsch](./README.de.md)
+- [Français](./README.fr.md)
+- [Español](./README.es.md)
+- [Italiano](./README.it.md)
 - [Русский](./README.ru.md)
-- [葡萄牙语](./README.pt.md)
+- [Português](./README.pt.md)
 - [Tiếng Việt](./README.vi.md)
 - [हिन्दी](./README.hi.md)
 
-OrcaRouter Lite 是 [OrcaRouter](https://www.orcarouter.ai) 的开源单工作区版本。在您的笔记本电脑上运行它，将其运送到您的产品中，或者直接使用托管的“api.orcarouter.ai”来处理您不想管理密钥的长尾模型。
+OrcaRouter Lite 是 [OrcaRouter](https://www.orcarouter.ai) 的开源单工作区版本。在你的笔记本上运行它，把它打包进你的产品里，或者直接使用托管的 `api.orcarouter.ai` 来覆盖那些你不想自己管理密钥的长尾模型。
 
-> **为什么选择我们？** LiteLLM 是一个图书馆； OpenRouter 是闭源托管的；奥拉马仅限本地。我们是**具有托管回退功能的自托管服务器**——这句话没有人可以说。
+> **为什么选我们？** LiteLLM 是一个库；OpenRouter 是闭源的托管服务；Ollama 仅限本地。我们是**带托管 fallback 的自托管服务器**——这句话其他人都说不出来。
 
-## 60 秒快速入门
+## 60 秒快速开始
 
-OrcaRouter的两种使用方法：
+使用 OrcaRouter 的两种方式：
 
-### 路径 A — 自托管 (BYOK)
+### 路径 A —— 自托管 (BYOK)
 
-在您自己的机器上运行 Lite；带上您自己的提供商密钥。
+在你自己的机器上运行 Lite；自带 provider 密钥。
 
 ```bash
 git clone https://github.com/Continuum-AI-Corp/OrcaRouter-Lite.git
 cd OrcaRouter-Lite
 cp .env.example .env
-# add at least one: OPENAI_API_KEY=sk-...  (or ORCAROUTER_API_KEY=...)
+# 至少添加一个: OPENAI_API_KEY=sk-...  (或 ORCAROUTER_API_KEY=...)
 
 docker compose up
 # logs: ✓ orcarouter-lite ready. API key: sk-orca-abc123...
 ```
 
-基本 URL：“http://localhost:8000/v1”。使用启动时打印的“sk-orca-*”密钥。
+Base URL：`http://localhost:8000/v1`。使用启动时打印出来的 `sk-orca-*` 密钥。
 
-### 路径 B — 托管（需要帐户）
+### 路径 B —— 托管（需要账号）
 
-没有克隆，没有码头工人。注册、获取密钥、将任何 OpenAI SDK 指向托管的。
+无需 clone，无需 docker。注册、获取密钥，将任意 OpenAI SDK 指向托管服务。
 
 ```bash
-# 1. Register at https://www.orcarouter.ai and copy your sk-orca-* key
-# 2. Use https://api.orcarouter.ai/v1 as the base URL
+# 1. 在 https://www.orcarouter.ai 注册并复制你的 sk-orca-* 密钥
+# 2. 使用 https://api.orcarouter.ai/v1 作为 base URL
 ```
 
-**需要帐户。** Hosted 处理路由、计费和提供商的长尾 - 在您的 OrcaRouter 帐户上按令牌计费。请参阅[docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction)。
+**需要账号。** 托管服务负责路由、计费以及 provider 长尾——按 token 在你的 OrcaRouter 账户上计费。详见 [docs.orcarouter.ai/introduction](https://docs.orcarouter.ai/introduction)。
 
-### 然后从任何 OpenAI SDK 调用它
+### 然后从任意 OpenAI SDK 调用
 
-下面的示例使用路径 A 的本地主机基本 URL — 如果您位于路径 B，则交换为“https://api.orcarouter.ai/v1”。
+下面的示例使用路径 A 的 localhost base URL —— 如果你在路径 B，请替换为 `https://api.orcarouter.ai/v1`。
 
-<详情>
-<摘要><b>Python</b></摘要>
+<details>
+<summary><b>Python</b></summary>
 
 ```python
 from openai import OpenAI
@@ -74,14 +74,14 @@ client = OpenAI(
     api_key="sk-orca-abc123...",
 )
 r = client.chat.completions.create(
-    model="auto",  # or "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
+    model="auto",  # 或 "gpt-4o-mini", "claude-3-5-sonnet-latest", ...
     messages=[{"role": "user", "content": "Hello!"}],
 )
 print(r.choices[0].message.content)
 ```
 </details>
 
-<详情>
+<details>
 <summary><b>Node.js</b></summary>
 
 ```js
@@ -100,8 +100,8 @@ console.log(r.choices[0].message.content);
 ```
 </details>
 
-<详情>
-<摘要><b>卷曲</b></摘要>
+<details>
+<summary><b>curl</b></summary>
 
 ```bash
 curl http://localhost:8000/v1/chat/completions \
@@ -111,25 +111,25 @@ curl http://localhost:8000/v1/chat/completions \
 ```
 </details>
 
-打开仪表板的“http://localhost:8000/” — 提供程序、路由、分析、密钥（仅限路径 A）。
+打开 `http://localhost:8000/` 进入仪表板 —— providers、路由、分析、密钥（仅路径 A）。
 
-＃＃ 为什么？
+## 为什么？
 
-| |精简版 | LiteLLM 库 |开放路由器|奥拉玛 |
+| | OrcaRouter Lite | LiteLLM 库 | OpenRouter | Ollama |
 |---|---|---|---|---|
-|自托管服务器| ✓ |作为图书馆| ✗ | ✓ |
-|兼容 OpenAI | ✓ | ✓ | ✓ | ✓ |
-|多提供商（OpenAI/Anthropic/Google/...）| ✓ | ✓ | ✓ | ✗ |
-|内置仪表板| ✓ | ✗ | ✓ | ✗ |
-| `model="auto"`（最便宜的功能）| ✓ | ✗ | ✗ |不适用 |
-|流媒体 | ✓ | ✓ | ✓ | ✓ |
-|自带 | ✓ | ✓ | ✗ |不适用 |
-|托管作为后备| ✓ | ✗ |不适用 | ✗ |
-|无需 Postgres/无需 Redis | ✓ |不适用 |不适用 | ✓ |
+| 自托管服务器 | ✓ | 作为库 | ✗ | ✓ |
+| 兼容 OpenAI | ✓ | ✓ | ✓ | ✓ |
+| 多 provider（OpenAI/Anthropic/Google/…）| ✓ | ✓ | ✓ | ✗ |
+| 内置仪表板 | ✓ | ✗ | ✓ | ✗ |
+| `model="auto"`（最便宜的合适模型）| ✓ | ✗ | ✗ | n/a |
+| 流式传输 | ✓ | ✓ | ✓ | ✓ |
+| BYOK | ✓ | ✓ | ✗ | n/a |
+| 托管作为 fallback | ✓ | ✗ | n/a | ✗ |
+| 不需要 Postgres / 不需要 Redis | ✓ | n/a | n/a | ✓ |
 
-## `model="auto"` — 标题功能
+## `model="auto"` —— 招牌特性
 
-发送 `model="auto"` ，OrcaRouter 会在您配置的提供程序中选择最便宜的模型，以满足请求的功能要求（工具、愿景、JSON 模式）。无需手动路由规则；没有速度限制的体操；代码中没有“if x: ...”成本优化。
+发送 `model="auto"`，OrcaRouter 会在你已配置的 providers 中挑选**最便宜**且能满足请求能力要求（tools、vision、JSON 模式）的模型。无需手写路由规则；无需折腾速率限制；代码里也无需 `if x: ...` 的成本优化。
 
 ```python
 client.chat.completions.create(
@@ -139,28 +139,28 @@ client.chat.completions.create(
         {"type": "image_url", "image_url": {"url": "data:..."}},
     ]}],
 )
-# → routes to the cheapest VISION-capable model your keys cover
+# → 路由到你的密钥所覆盖的、最便宜的支持 VISION 的模型
 ```
 
-解析后的模型通过“x-orca-resolved-model”响应标头暴露给调用者，以便您可以记录/显示实际使用的内容。
+被选中的模型会通过 `x-orca-resolved-model` 响应头回传给调用方，方便你记录或展示实际使用的模型。
 
-## 作为上游托管（Lite + 托管）
+## 托管作为上游（Lite + 托管）
 
-已经运行 Lite 了？将“ORCAROUTER_API_KEY”设置为来自 [www.orcarouter.ai](https://www.orcarouter.ai) 的“sk-orca-*”，托管成为路由链中的又一个提供商 - 涵盖本地密钥不具备的模型：
+已经在跑 Lite 了？把 `ORCAROUTER_API_KEY` 设为来自 [www.orcarouter.ai](https://www.orcarouter.ai) 的 `sk-orca-*`，托管就成了路由链中的另一个 provider —— 覆盖那些你的本地密钥拿不到的模型：
 
 ```bash
 # .env
 ORCAROUTER_API_KEY=sk-orca-hosted-abc...
 ```
 
-使用案例：
-- **先试后买** — 无需本地提供商密钥
-- **本地日志记录** — 托管处理路由，Lite 存储仪表板的 RequestLog 行
-- **故障转移** — 本地提供商失败，托管是安全网
+使用场景：
+- **先试后买** —— 不需要本地 provider 密钥
+- **本地日志** —— 托管负责路由，Lite 把 RequestLog 写入数据库供仪表板使用
+- **故障转移** —— 本地 provider 失败时，托管作为安全网兜底
 
-## 流媒体
+## 流式传输
 
-与 OpenAI 兼容的 SSE 格式，具有标准的“data: ... \n\n” 框架和终端“[DONE]”哨兵 — 适用于已从 OpenAI 流式传输的任何 SDK。
+兼容 OpenAI 的 SSE 格式，使用标准的 `data: ... \n\n` 帧格式以及结尾的 `[DONE]` 标记 —— 任何已经从 OpenAI 流式读取的 SDK 都可以即插即用。
 
 ```python
 for chunk in client.chat.completions.create(
@@ -171,41 +171,41 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
-## 型号目录
+## 模型目录
 
-启动时从 [LiteLLM 社区维护的定价数据库](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) 加载 100 多个聊天模型 - 无需手动维护模型列表。每个条目都公开：
+启动时会从 [LiteLLM 社区维护的定价数据库](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) 加载 100+ 个聊天模型 —— 没有需要手动维护的模型清单。每条记录都包含：
 
-- `id`（例如`gpt-4o`、`claude-3-5-sonnet-latest`）
-- `provider`（映射到您配置的键）
-- 功能标志：`supports_tools`、`supports_vision`、`supports_json_mode`
-- 每个代币的输入/输出成本（驱动储蓄小部件 + `model="auto"`）
+- `id`（如 `gpt-4o`、`claude-3-5-sonnet-latest`）
+- `provider`（映射到你已配置的密钥）
+- 能力标志：`supports_tools`、`supports_vision`、`supports_json_mode`
+- 每 token 的输入/输出成本（驱动节省组件 + `model="auto"`）
 
-`GET /v1/models` returns the OpenAI-format catalogue.
+`GET /v1/models` 返回 OpenAI 格式的目录。
 
-## 部署到其他地方
+## 部署到其他平台
 
-|平台|一键|
+| 平台 | 一键部署 |
 |---|---|
-|铁路| [![在铁路上部署](https://railway.app/button.svg)](https://railway.app/new/template) |
+| Railway | [![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template) |
 | Fly.io | `fly launch --dockerfile Dockerfile` |
-|渲染 |连接存储库，根目录 = `.` |
-|裸 Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...`（图片即将推出）|
+| Render | 连接代码仓库，根目录 = `.` |
+| 裸 Docker | `docker run -p 8000:8000 -e OPENAI_API_KEY=... ghcr.io/...`（镜像即将发布）|
 
-## 盒子里有什么
+## 盒子里都有什么
 
-- `POST /v1/chat/completions` — 代理 + 流 + `model="auto"` + 跨提供商提示缓存
-- `GET /v1/models` — 可发现的模型目录（来自 `litellm.model_cost` 的 100 多个模型）
-- `GET/PUT/DELETE /v1/providers/{provider}` — 设置/列出/撤销加密的提供者密钥
-- `GET/PUT /v1/routing` — 更改策略（`平衡`/`最便宜`/`最快`/`质量`）
-- `GET /v1/analytics/{recent,spend,latency, savings,unreachable}` — 本地分析，没有遥测功能
-- `GET /v1/hosted` — 托管回退状态（驱动仪表板的“获取 5 美元免费信用卡”卡）
-- `GET/POST/DELETE /v1/keys/...` — 列出/旋转/撤销 API 密钥
-- 单页仪表板位于`/`
-- 默认情况下使用 SQLite； Postgres 通过“DATABASE_URL”选择加入； Redis 可选
+- `POST /v1/chat/completions` —— 代理 + 流式传输 + `model="auto"` + 跨 provider 提示缓存
+- `GET  /v1/models` —— 可发现的模型目录（来自 `litellm.model_cost` 的 100+ 模型）
+- `GET/PUT/DELETE /v1/providers/{provider}` —— 设置 / 列出 / 撤销加密的 provider 密钥
+- `GET/PUT /v1/routing` —— 切换策略（`balanced` / `cheapest` / `fastest` / `quality`)
+- `GET  /v1/analytics/{recent,spend,latency,savings,unreachable}` —— 本地分析数据，没有任何遥测离开容器
+- `GET  /v1/hosted` —— 托管 fallback 状态（驱动仪表板上的 "Get $5 free credit" 卡片）
+- `GET/POST/DELETE /v1/keys/...` —— 列出 / 轮换 / 撤销 API 密钥
+- 单页仪表板挂在 `/`
+- 默认 SQLite；可通过 `DATABASE_URL` 切换 Postgres；Redis 可选
 
-### 跨提供商提示缓存
+### 跨 provider 提示缓存
 
-确定性请求（“温度 = 0”或固定的“种子”）由缓存重复提供 - 适用于**每个**提供者，而不仅仅是 Anthropic。当设置“REDIS_URL”时，后端是 Redis，否则是进程内 LRU。缓存命中会立即返回“x-orca-cache: HIT”，成本为 0 美元。
+确定性请求（`temperature=0` 或固定 `seed`）在重复调用时由缓存返回 —— 适用于**所有** provider，不只是 Anthropic。设置了 `REDIS_URL` 时后端是 Redis，否则使用进程内 LRU。命中缓存会即时返回 `x-orca-cache: HIT`，且费用为 $0。
 
 ```bash
 $ curl ... -d '{"model":"auto","messages":[...], "temperature": 0}' -i
@@ -213,33 +213,33 @@ HTTP/1.1 200 OK
 x-orca-cache: MISS
 x-orca-resolved-model: gpt-4o-mini
 
-$ curl ...  # same payload again
+$ curl ...  # 同样的 payload 再来一次
 HTTP/1.1 200 OK
-x-orca-cache: HIT          ← served from cache, no upstream call
+x-orca-cache: HIT          ← 来自缓存，无上游调用
 ```
 
-### 储蓄小部件
+### 节省组件
 
-`GET /v1/analytics/savings?baseline=gpt-4o&days=7` reports what your traffic would have cost on always-GPT-4 vs what it actually cost. The dashboard shows it as a tile.
+`GET /v1/analytics/savings?baseline=gpt-4o&days=7` 报告你的流量在「永远走 GPT-4」时会花多少钱，对比实际花费多少。仪表板会以一张磁贴的形式展示。
 
 ### 集成
 
-[Continue.dev](./integrations/continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel]的直接配置AI SDK](./integrations/vercel_ai.ts)，以及任何使用 OpenAI 聊天完成协议的工具。请参阅[`integrations/`](./integrations/)。
+为 [Continue.dev](./integrations/continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel AI SDK](./integrations/vercel_ai.ts) 以及任何使用 OpenAI Chat Completions 协议的工具提供即插即用的配置。详见 [`integrations/`](./integrations/)。
 
-## 故意不做的事情
+## 刻意不做的事情
 
-这是**单工作区**版本。根据设计，不：
+这是**单工作区**版本。按设计不包含：
 - 多租户、RBAC、SSO
 - 计费、钱包、积分、合作伙伴计划
-- 管理控制台、审核日志、信任和安全
-- 多pod部署/Kubernetes
-- 用于警报的电子邮件/Slack/Webhooks
+- 管理控制台、审计日志、信任与安全
+- 多 pod 部署 / Kubernetes
+- 用于告警的邮件 / Slack / webhook
 
-对于这些，请参阅托管产品或（即将推出的）Teams 版本。
+如需这些，请看托管产品或（即将推出的）Teams 版本。
 
 ## 测试
 
-构建测试优先。这里发布的每个行为都首先经过失败的测试。
+测试先行构建。这里发布的每一个行为都先有一个失败的测试。
 
 ```bash
 pip install -e ".[dev]"
@@ -247,29 +247,29 @@ PYTHONPATH=. pytest -v
 # 127 passed
 ```
 
-|切片 |测试 |什么 |
+| 切片 | 测试数 | 内容 |
 |---|---|---|
-| 1. 配置 | 5 | env 加载，默认值，`env_provider_keys()` |
-| 2. 种子 | 3 |引导工作区 + API 密钥 + RoutingConfig，幂等 |
-| 3. Auth中间件| 4 |不记名令牌验证，丢失/无效时返回 401 |
-| 4.应用工厂| 3 | /health，错误信封，/v1/* 门控 |
-| 5. 提供者密钥 CRUD | 5 |静态加密，明文永不往返 |
-| 6.路由器缓存| 13 | env+DB+托管部署程序集优先 |
-| 7.聊天完成| 5 | OpenAI 格式、RequestLog、验证 |
-| 8. 分析 | 4 |最近/支出/延迟 p50/p99 |
-| 9. /v1/{模型、按键、路由} | 8 |列表/创建/撤销+策略更新 |
-| 10. 流媒体 | 4 | SSE 格式，`[DONE]` 哨兵，日志写回 |
-| 11.目录| 7 | 100 多种型号、功能标志、定价 |
-| 12. `模型=“自动”` | 21 | 21能力检测，最便宜的满足需求（单元+集成）|
-| 13. 节省成本| 9 |节省与始终 GPT-4 基线 + 托管自动比较 |
-| 14.提示缓存| 15 | 15跨提供商精确匹配缓存+聊天集成|
-| 15. 基准 | 4 | Summary() + render_markdown() 聚合 |
-| 16. 托管状态 | 7 | `/v1/hosted` 配置源 + 注册 URL 表面 |
-| 17. 托管自动储蓄 | 3 |综合目录上的“_hosted_auto_ savings”边缘情况 |
-| 18. 无法到达的模型 | 7 |当托管打开时，“您无法访问的模型”磁贴会清除 |
-| **总计** | **127** | |
+| 1. 配置 | 5 | env 加载、默认值、`env_provider_keys()` |
+| 2. Seed | 3 | 引导工作区 + API 密钥 + RoutingConfig，幂等 |
+| 3. 鉴权中间件 | 4 | bearer-token 校验，缺失/无效返回 401 |
+| 4. 应用工厂 | 3 | /health、错误信封、/v1/* 网关 |
+| 5. Provider 密钥 CRUD | 5 | 静态加密，明文不会往返 |
+| 6. 路由器缓存 | 13 | env+DB+托管 deployment 装配，按优先级 |
+| 7. 聊天补全 | 5 | OpenAI 格式、RequestLog、校验 |
+| 8. 分析 | 4 | recent / spend / latency p50/p99 |
+| 9. /v1/{models,keys,routing} | 8 | 列出/创建/撤销 + 策略更新 |
+| 10. 流式传输 | 4 | SSE 格式、`[DONE]` 标记、日志回写 |
+| 11. 目录 | 7 | 100+ 模型、能力标志、定价 |
+| 12. `model="auto"` | 21 | 能力检测、最便宜且满足需求（单元 + 集成）|
+| 13. 成本节省 | 9 | 节省 vs 永远 GPT-4 基线 + 托管自动对比 |
+| 14. 提示缓存 | 15 | 跨 provider 精确匹配缓存 + 聊天集成 |
+| 15. 基准测试 | 4 | summarize() + render_markdown() 聚合 |
+| 16. 托管状态 | 7 | `/v1/hosted` 配置来源 + 注册 URL |
+| 17. 托管自动节省 | 3 | 合成目录上的 `_hosted_auto_savings` 边界用例 |
+| 18. 不可达模型 | 7 | 当托管开启时，「你够不到的模型」磁贴会清空 |
+| **合计** | **127** | |
 
-＃＃ 建筑学
+## 架构
 
 ```
 app/
@@ -300,20 +300,20 @@ packages/
 
 ## 路线图
 
-- [x] OpenAI 兼容的聊天完成
-- [x] 流媒体 (SSE)
-- [x] `model="auto"` 最便宜的路由
-- [x] 托管为上游
-- [x] 静态加密 BYOK
+- [x] 兼容 OpenAI 的聊天补全
+- [x] 流式传输 (SSE)
+- [x] `model="auto"` 最便宜且合适的路由
+- [x] 托管作为上游
+- [x] 静态加密的 BYOK
 - [x] 本地分析仪表板
-- [x] CI（GitHub 操作）
-- [x] 跨提供商提示缓存
-- [x]Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK集成
-- [x] 公共基准 + 储蓄索赔
-- [ ] 嵌入 + 图像生成代理
+- [x] CI（GitHub Actions）
+- [x] 跨 provider 提示缓存
+- [x] Continue.dev / Aider / LangChain / Cursor / Vercel AI SDK 集成
+- [x] 公开基准 + 节省说明
+- [ ] Embeddings + 图像生成代理
 
-请参阅 [DEMO.md](./DEMO.md) 了解故障转移演示。
+故障转移演示请见 [DEMO.md](./DEMO.md)。
 
-＃＃ 执照
+## 许可证
 
-麻省理工学院。请参阅[许可证](./许可证)。
+MIT。详见 [LICENSE](./LICENSE)。


### PR DESCRIPTION
## Summary
Rewrites `README.zh.md` to fix several machine-translation errors carried over from earlier passes.

Mistranslations fixed:
- `model="auto"` had been rendered as `型号="汽车"` (literally "car")
- `MIT` rendered as `麻省理工学院` (MIT University), and the link target changed to `./许可证` — broken link
- `Docker` rendered as `码头工人` (dock worker)
- `Railway` rendered as `铁路` (railroad)
- HTML `<details>` / `<summary>` tags translated to `<详情>` / `<摘要>`, breaking the collapsible Python/Node/curl code samples
- Fullwidth `＃＃` used in place of markdown `##` (`＃＃ 为什么？`, `＃＃ 建筑学`, `＃＃ 执照`) — no header rendering
- "credit" rendered as `信用卡` (credit card)
- Function name `summarize()` typoed to `Summary()` in the test matrix
- Table cells double-numbered (`21能力检测`, `15跨提供商…`)
- A few sentences were left in raw English
- `library`, `rotate (keys)`, `savings claim`, `architecture` etc. translated to wrong-domain words (图书馆, 旋转, 储蓄索赔, 建筑学)

Approach matches the pass used for de/es/fr/it/pt/ru/vi/hi: keep code, URLs, model names, HTML tags, and acronyms (BYOK, MIT, Docker, Railway, etc.) untouched; translate prose naturally.

## Test plan
- [ ] Render `README.zh.md` on GitHub and confirm headers, collapsible code blocks, table, and `[LICENSE](./LICENSE)` link work
- [ ] Spot-check that all code blocks, URLs, model names, and HTML tags are intact

https://claude.ai/code/session_01ADnW4Rx6meRPdtQmVaLhMc

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADnW4Rx6meRPdtQmVaLhMc)_