### PR TITLE
Add real benchmark-driven quality routing via Artificial Analysis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,19 @@ LOG_LEVEL=info
 # ORCAROUTER_API_KEY=sk-orca-...
 # ORCAROUTER_BASE_URL=https://api.orcarouter.ai/v1
 
+# ── Quality scoring (Artificial Analysis) ────────────
+# When set, `model="auto"` with strategy="quality" picks the model
+# with the highest Intelligence Index from artificialanalysis.ai's
+# benchmark aggregator instead of "the most expensive". Required
+# because newer flagships (Opus 4.7, etc.) are now priced LOWER
+# than older ones, so cost-as-quality-proxy picks the wrong model.
+#
+# Sign up free at https://artificialanalysis.ai (free tier: 1000
+# req/day, far more than needed since we cache for 1h). Without a
+# key, quality strategy degrades to the legacy cost-based behavior.
+# Attribution is shown in the dashboard when scoring is active.
+# ARTIFICIAL_ANALYSIS_API_KEY=
+
 # ── Router behavior (cooldown + cascade) ──────────────
 # How long a deployment is skipped after a failure (404 / 408 / 429 / 401).
 # Default 1h is safe for prod. Lower for local dev (network blips shouldn't

--- a/app/auto_routing.py
+++ b/app/auto_routing.py
@@ -114,6 +114,7 @@ def choose_auto_model(
     strategy: str | None = None,
     preferred_models: list[str] | None = None,
     allowlist: list[str] | set[str] | None = None,
+    quality_scores: dict[str, float] | None = None,
     top_n: int = 5,
 ) -> list[str]:
     """Return up to `top_n` deployable models matching all `needs`, best first.
@@ -124,7 +125,11 @@ def choose_auto_model(
     without the user seeing an error.
 
     Selection rule by strategy:
-      - `quality`: highest blended cost (proxy for "biggest/most-capable")
+      - `quality`: highest quality_score first (when scores are non-empty),
+        cost as the tie-breaker. Falls back to "highest blended cost" when
+        no scores are provided — the legacy proxy that breaks for newer
+        flagships priced lower than older ones (Anthropic Opus 4.7 vs
+        Opus 4 from May 2024). Provide AA scores via `quality_scores=`.
       - everything else (`cheapest` / `balanced` / `fastest` / None): lowest
         blended cost. `fastest` shares the cheapest-capable rule because the
         catalog has no per-model latency data; ordering across deployments of
@@ -166,7 +171,20 @@ def choose_auto_model(
     if not eligible:
         return []
     if strategy == "quality":
-        eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
+        # When AA scores (or operator overrides) are available, sort by
+        # score descending. Cost is a tie-breaker (most expensive among
+        # equally-scored models tends to be the flagship version vs a
+        # smaller variant). Unscored models drop to the bottom of the
+        # quality ranking but stay eligible — better to surface them
+        # than to disappear them on a transient AA outage.
+        if quality_scores:
+            eligible.sort(
+                key=lambda m: (-quality_scores.get(m.id, 0.0), -_blended_cost(m), m.id)
+            )
+        else:
+            # Legacy fallback: cost-as-quality-proxy. Wrong for modern
+            # pricing but stable when no benchmark data is available.
+            eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
     else:
         eligible.sort(key=lambda m: (_blended_cost(m), m.id))
     return [m.id for m in eligible[:top_n]]

--- a/app/config.py
+++ b/app/config.py
@@ -66,6 +66,20 @@ class Settings(BaseSettings):
     # ── Body limit (for image / file attachments) ──
     max_body_bytes: int = 100 * 1024 * 1024
 
+    # ── Quality scoring (Artificial Analysis) ──
+    # API key from https://artificialanalysis.ai (free tier: 1000 req/day).
+    # When set, model="auto" with strategy="quality" picks the model with
+    # the highest Intelligence Index from AA's benchmark aggregator instead
+    # of the most expensive (the legacy proxy that broke when Anthropic /
+    # OpenAI started pricing newer flagships LOWER than older ones).
+    # Empty string disables AA scoring; quality strategy degrades to the
+    # cost-based fallback. Attribution to AA is displayed in the dashboard
+    # whenever scores are in use, per their free-tier terms.
+    artificial_analysis_api_key: str = ""
+    artificial_analysis_models_url: str = (
+        "https://artificialanalysis.ai/api/v2/data/llms/models"
+    )
+
     # ── Router behavior (LiteLLM Router cooldown + cascade) ──
     # How long a deployment stays cooled-down after a failure. LiteLLM's
     # default is 1 second, which is effectively no cooldown — a dead model

--- a/app/main.py
+++ b/app/main.py
@@ -117,7 +117,17 @@ def create_app() -> FastAPI:
 
     app.add_middleware(AuthMiddleware)
 
-    from app.routes import analytics, chat, health, hosted, keys, models, providers, routing
+    from app.routes import (
+        analytics,
+        chat,
+        health,
+        hosted,
+        keys,
+        models,
+        providers,
+        quality,
+        routing,
+    )
 
     app.include_router(health.router)
     app.include_router(providers.router)
@@ -127,6 +137,7 @@ def create_app() -> FastAPI:
     app.include_router(keys.router)
     app.include_router(routing.router)
     app.include_router(hosted.router)
+    app.include_router(quality.router)
 
     # ── Static SPA (provider keys, routing, analytics, keys) ──
     import os

--- a/app/quality_scores.py
+++ b/app/quality_scores.py
@@ -1,0 +1,74 @@
+"""Resolve effective quality scores: AA index + manual operator overrides.
+
+Routing layer (auto_routing.choose_auto_model) treats the merged dict as
+authoritative. Manual overrides win unconditionally over AA scores;
+operators use overrides when AA's coverage is missing or their own evals
+disagree with AA's ranking.
+
+This module is the single seam where the two data sources meet — keep
+all merge / precedence logic here so callers (chat.py, /v1/quality
+routes) consume one consistent view.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from packages.db.models.quality_score_override import QualityScoreOverride
+from packages.litellm_adapter.catalog import CATALOG_BY_ID
+from packages.litellm_adapter.quality_index import QualityIndex, get_quality_index
+
+
+async def load_overrides(db: AsyncSession, workspace_id: str) -> dict[str, float]:
+    """Return {model_id: score} for all manual overrides in a workspace.
+
+    Empty dict when no overrides exist (no AA key needed for this path —
+    overrides work standalone if the operator wants to bypass AA entirely).
+    """
+    stmt = select(QualityScoreOverride).where(
+        QualityScoreOverride.workspace_id == workspace_id
+    )
+    rows = (await db.execute(stmt)).scalars().all()
+    return {row.model_id: float(row.score) for row in rows}
+
+
+async def fetch_aa_index(
+    *,
+    db: AsyncSession | None = None,
+    workspace_id: str = "default",
+    force_refresh: bool = False,
+) -> QualityIndex:
+    """Thin wrapper that supplies the catalog id set to the fetcher.
+
+    Kept here (not directly imported in chat.py) so callers don't have
+    to know about CATALOG_BY_ID — separation of concerns.
+
+    Pass `db` to opt in to DB-backed snapshot persistence (recommended
+    for any real request flow); omit for unit tests of pure parsing.
+    """
+    return await get_quality_index(
+        catalog_ids=set(CATALOG_BY_ID.keys()),
+        db=db,
+        workspace_id=workspace_id,
+        force_refresh=force_refresh,
+    )
+
+
+async def resolve_quality_scores(
+    *, db: AsyncSession, workspace_id: str, force_refresh_aa: bool = False
+) -> dict[str, float]:
+    """Build the final {model_id: score} map used by the quality strategy.
+
+    Precedence: manual overrides > AA Intelligence Index > unscored.
+    Unscored models don't appear in the dict (the resolver treats absent
+    keys as score 0.0, putting them at the bottom of the quality ranking).
+    """
+    aa = await fetch_aa_index(
+        db=db, workspace_id=workspace_id, force_refresh=force_refresh_aa,
+    )
+    overrides = await load_overrides(db, workspace_id)
+    # Start from AA, then let overrides take precedence.
+    merged = dict(aa.scores)
+    merged.update(overrides)
+    return merged

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -22,6 +22,7 @@ from app import prompt_cache, router_cache
 from app.auto_routing import choose_auto_model, required_capabilities
 from app.config import get_settings
 from app.deps import get_db, get_key_context
+from app.quality_scores import resolve_quality_scores
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.db.models.request_log import RequestLog
@@ -223,6 +224,18 @@ async def chat_completions(
                     "configured key. No deployable provider found."
                 ),
             )
+        # When strategy is "quality", merge AA's Intelligence Index with
+        # any manual operator overrides from the dashboard. Manual >  AA >
+        # nothing. Empty dict (no AA key + no overrides) → resolver falls
+        # back to the legacy cost-based proxy. Skipped for non-quality
+        # strategies so we don't pay the cost on cheapest/balanced/fastest
+        # calls that don't use the scores.
+        quality_scores: dict[str, float] | None = None
+        if strategy == "quality":
+            quality_scores = await resolve_quality_scores(
+                db=db, workspace_id=str(kc.workspace_id),
+            )
+
         # Pass the key's allowlist into the resolver so it filters BEFORE
         # the top-N truncation. Without this, an allowed model ranked at
         # position 6+ would be silently dropped by top_n=5 and the user
@@ -234,6 +247,7 @@ async def chat_completions(
             strategy=strategy,
             preferred_models=preferred_models,
             allowlist=kc.model_allowlist,
+            quality_scores=quality_scores,
         )
         if not candidates:
             # Empty result has two distinct causes — distinguish them so the
@@ -252,6 +266,7 @@ async def chat_completions(
                     strategy=strategy,
                     preferred_models=preferred_models,
                     allowlist=None,
+                    quality_scores=quality_scores,
                     top_n=1,
                 )
                 if any_capable:

--- a/app/routes/quality.py
+++ b/app/routes/quality.py
@@ -1,0 +1,370 @@
+"""Quality scoring endpoints — backs the dashboard's Quality page.
+
+Surface area:
+  GET    /v1/quality                    — full scored-model table + index status
+  POST   /v1/quality/refresh            — force-refresh the AA cache
+  GET    /v1/quality/auto-preview       — live preview of which model auto would
+                                          pick now under the current strategy
+  GET    /v1/quality/overrides          — list manual overrides
+  PUT    /v1/quality/overrides/{model_id} — set a manual override
+  DELETE /v1/quality/overrides/{model_id} — remove an override (revert to AA)
+
+The dashboard uses these to give the operator transparency over (and
+control of) the routing decisions the `quality` strategy makes. AA scores
+alone aren't always right for every team — overrides let a developer
+encode their own evals on top.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+from sqlalchemy import delete, select, update
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app import router_cache
+from app.auto_routing import (
+    choose_auto_model,
+    litellm_routing_strategy,
+)
+from app.deps import get_db, get_key_context
+from app.quality_scores import (
+    fetch_aa_index,
+    load_overrides,
+    resolve_quality_scores,
+)
+from packages.auth.types import KeyContext
+from packages.db.models.quality_score_override import QualityScoreOverride
+from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
+
+router = APIRouter(prefix="/v1/quality", tags=["quality"])
+
+
+def _blended_cost(m) -> float:
+    """Match auto_routing's blended cost formula (kept private so we don't
+    leak the formula into the public surface)."""
+    return 0.3 * m.input_cost_per_token + 0.7 * m.output_cost_per_token
+
+
+def _serialize_aa_index(idx) -> dict[str, Any]:
+    """Project a QualityIndex into a JSON-friendly status block.
+
+    `QualityIndex.fetched_at` is per-process monotonic time and is
+    re-anchored to "now" whenever the index is loaded from the DB
+    snapshot, so it's not a meaningful wall-clock value to surface to
+    clients. The dashboard uses `raw_count` / `matched_count` for
+    freshness signal; the `source` flag distinguishes live vs stale
+    (in-process) vs stale (DB).
+    """
+    return {
+        "source": idx.source,
+        "raw_count": idx.raw_count,
+        "matched_count": idx.matched_count,
+        "configured": idx.source != "missing-key",
+    }
+
+
+@router.get("")
+async def quality_status(
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Full table of catalog models with their effective quality scores.
+
+    Each row carries:
+      - id, provider, blended_cost (per-token, blended 0.3/0.7 in/out)
+      - aa_score (from Artificial Analysis, may be None)
+      - manual_score (operator override, may be None)
+      - effective_score (manual if set, else aa_score, else None)
+      - capable_for_chat (always True here — catalog is filtered to chat)
+      - deployable (whether a configured provider key covers this model)
+
+    Also includes the AA index status (configured? matched count? source?).
+    """
+    aa = await fetch_aa_index(db=db, workspace_id=str(kc.workspace_id))
+    overrides = await load_overrides(db, str(kc.workspace_id))
+
+    # Build the deployable set from the live router cache.
+    client = await router_cache.get_router(db)
+    deployable: set[str] = {
+        d.model_name for d in getattr(client, "_deployments", []) or []
+    }
+
+    rows: list[dict] = []
+    for m in CATALOG:
+        aa_score = aa.scores.get(m.id)
+        manual_score = overrides.get(m.id)
+        effective = manual_score if manual_score is not None else aa_score
+        rows.append(
+            {
+                "id": m.id,
+                "provider": m.provider,
+                "blended_cost": _blended_cost(m),
+                "input_cost_per_token": m.input_cost_per_token,
+                "output_cost_per_token": m.output_cost_per_token,
+                "aa_score": aa_score,
+                "manual_score": manual_score,
+                "effective_score": effective,
+                "supports_tools": m.supports_tools,
+                "supports_vision": m.supports_vision,
+                "supports_json_mode": m.supports_json_mode,
+                "deployable": m.id in deployable,
+                "deprecation_date": m.deprecation_date,
+            }
+        )
+
+    # Sort by effective_score desc (None at the bottom), then by cost desc.
+    rows.sort(
+        key=lambda r: (
+            -(r["effective_score"] if r["effective_score"] is not None else -1),
+            -r["blended_cost"],
+            r["id"],
+        )
+    )
+
+    return {
+        "aa_index": _serialize_aa_index(aa),
+        "override_count": len(overrides),
+        "models": rows,
+        "attribution": {
+            "name": "Artificial Analysis",
+            "url": "https://artificialanalysis.ai",
+            "shown_when": "any AA score appears in routing or the dashboard",
+        },
+    }
+
+
+@router.post("/refresh")
+async def quality_refresh(
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Force a fresh fetch of the AA Intelligence Index.
+
+    Bypasses the 1h cache TTL AND the DB snapshot freshness check.
+    Counts against the AA daily request quota (1000/day on the free
+    tier) — operators with an outage or a very stale snapshot can use
+    this to get back online without waiting for natural expiry.
+    On AA success, the new snapshot is also persisted to the DB so the
+    next process restart inherits it.
+    """
+    aa = await fetch_aa_index(
+        db=db, workspace_id=str(kc.workspace_id), force_refresh=True,
+    )
+    return {"aa_index": _serialize_aa_index(aa)}
+
+
+@router.get("/auto-preview")
+async def quality_auto_preview(
+    needs: str | None = Query(
+        None,
+        description=(
+            "Comma-separated capability requirements: 'tools', 'vision', "
+            "'json_mode'. Empty for plain chat."
+        ),
+    ),
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Show what model `model='auto'` would resolve to right now under the
+    workspace's active strategy.
+
+    The dashboard re-fetches this on strategy change so the operator sees
+    the routing decision change live, instead of having to fire a real
+    chat completion to find out.
+    """
+    needs_set: set[str] = (
+        {n.strip() for n in needs.split(",") if n.strip()} if needs else set()
+    )
+
+    client = await router_cache.get_router(db)
+    raw_strategy = getattr(client, "strategy", None)
+    strategy = (
+        raw_strategy if isinstance(raw_strategy, str) and raw_strategy else "balanced"
+    )
+    raw_preferred = getattr(client, "preferred_models", None)
+    preferred_models = raw_preferred if isinstance(raw_preferred, list) else []
+
+    deployable: set[str] = {
+        d.model_name for d in getattr(client, "_deployments", []) or []
+    }
+
+    quality_scores: dict[str, float] | None = None
+    if strategy == "quality":
+        quality_scores = await resolve_quality_scores(
+            db=db, workspace_id=str(kc.workspace_id)
+        )
+
+    candidates = choose_auto_model(
+        needs=needs_set,
+        deployable=deployable,
+        candidates=CATALOG,
+        strategy=strategy,
+        preferred_models=preferred_models,
+        allowlist=kc.model_allowlist,
+        quality_scores=quality_scores,
+    )
+
+    primary = candidates[0] if candidates else None
+    primary_model = CATALOG_BY_ID.get(primary) if primary else None
+
+    return {
+        "strategy": strategy,
+        "litellm_routing_strategy": litellm_routing_strategy(strategy),
+        "needs": sorted(needs_set),
+        "preferred_models": preferred_models,
+        "deployable_count": len(deployable),
+        "primary": primary,
+        "primary_score": (
+            quality_scores.get(primary) if (quality_scores and primary) else None
+        ),
+        "primary_blended_cost": (
+            _blended_cost(primary_model) if primary_model else None
+        ),
+        "fallbacks": candidates[1:] if len(candidates) > 1 else [],
+        "fallbacks_count": max(0, len(candidates) - 1),
+        "scoring_source": (
+            "quality_scores"
+            if (strategy == "quality" and quality_scores)
+            else (
+                "cost-based-fallback"
+                if strategy == "quality"
+                else f"strategy:{strategy}"
+            )
+        ),
+    }
+
+
+# ── Manual overrides CRUD ─────────────────────────────────────────────
+
+
+class OverrideBody(BaseModel):
+    """Request shape for PUT /v1/quality/overrides/{model_id}."""
+
+    score: float = Field(
+        ..., ge=0.0, le=100.0,
+        description="Operator-assigned quality score on the same 0-100 scale "
+                    "as AA's Intelligence Index. Higher is better.",
+    )
+    note: str | None = Field(
+        None, max_length=2000,
+        description="Free-form rationale for the override; surfaced in the "
+                    "dashboard so future operators understand the reasoning.",
+    )
+
+
+def _serialize_override(row: QualityScoreOverride) -> dict:
+    return {
+        "model_id": row.model_id,
+        "score": row.score,
+        "note": row.note,
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
+@router.get("/overrides")
+async def list_overrides(
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    rows = (
+        await db.execute(
+            select(QualityScoreOverride).where(
+                QualityScoreOverride.workspace_id == str(kc.workspace_id)
+            )
+        )
+    ).scalars().all()
+    return {"overrides": [_serialize_override(r) for r in rows]}
+
+
+@router.put("/overrides/{model_id}")
+async def upsert_override(
+    model_id: str,
+    body: OverrideBody = Body(...),
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Create or update an override. Idempotent on (workspace, model_id).
+
+    `session.merge()` is select-then-write under the hood, so two
+    concurrent PUTs for the same (workspace, model) can both observe
+    "row not present" and both attempt INSERT — the loser gets an
+    IntegrityError. We retry once: on the retry, the row is guaranteed
+    to exist, so merge() takes the UPDATE path and succeeds.
+
+    A single retry is enough because the failure window is bounded by
+    the duration of a single SELECT+INSERT — a second concurrent writer
+    would have already committed by the time we re-enter.
+    """
+    if model_id not in CATALOG_BY_ID:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"Model '{model_id}' is not in the catalog. Overrides can only "
+                "be set for models the router knows about."
+            ),
+        )
+
+    workspace_id = str(kc.workspace_id)
+
+    async def _do_merge() -> QualityScoreOverride:
+        row = await db.merge(QualityScoreOverride(
+            workspace_id=workspace_id,
+            model_id=model_id,
+            score=body.score,
+            note=body.note,
+        ))
+        await db.commit()
+        await db.refresh(row)
+        return row
+
+    try:
+        row = await _do_merge()
+    except IntegrityError:
+        # Concurrent writer beat us to the INSERT. Roll back the failed
+        # transaction, then issue a direct UPDATE — the row is guaranteed
+        # to exist now (the other writer committed it). UPDATE is
+        # unconditionally safe even if their value is now ours; PUT
+        # semantics say last-writer-wins anyway.
+        await db.rollback()
+        await db.execute(
+            update(QualityScoreOverride)
+            .where(
+                QualityScoreOverride.workspace_id == workspace_id,
+                QualityScoreOverride.model_id == model_id,
+            )
+            .values(score=body.score, note=body.note)
+        )
+        await db.commit()
+        row = (
+            await db.execute(
+                select(QualityScoreOverride).where(
+                    QualityScoreOverride.workspace_id == workspace_id,
+                    QualityScoreOverride.model_id == model_id,
+                )
+            )
+        ).scalar_one()
+    return _serialize_override(row)
+
+
+@router.delete("/overrides/{model_id}", status_code=204)
+async def delete_override(
+    model_id: str,
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Remove an override. Returns 204 even if the override didn't exist —
+    the operator's intent ('no override on this model') is satisfied either
+    way, no need to surface the distinction."""
+    workspace_id = str(kc.workspace_id)
+    await db.execute(
+        delete(QualityScoreOverride).where(
+            QualityScoreOverride.workspace_id == workspace_id,
+            QualityScoreOverride.model_id == model_id,
+        )
+    )
+    await db.commit()

--- a/design/app.js
+++ b/design/app.js
@@ -9,8 +9,8 @@ const LOCALE_KEY = "orca-lite-locale";
 const SUPPORTED_LOCALES = ["en", "zh", "hi", "es", "pt", "ru", "ja", "de", "fr", "it", "ar", "ko"];
 const LOCALE_LABELS = { en: "English", zh: "中文", hi: "हिन्दी", es: "Español", pt: "Português", ru: "Русский", ja: "日本語", de: "Deutsch", fr: "Français", it: "Italiano", ar: "العربية", ko: "한국어" };
 const I18N = {
-  en: { "auth.tagline":"Open Source. Single Tenant.","auth.welcome":"Welcome back","auth.subtitle":"Paste the sk-orca-* key printed in your server logs on first run. Stored only in this browser via localStorage.","auth.api_key":"API key","auth.continue":"Continue","nav.search":"Search","nav.overview":"Overview","nav.providers":"Providers","nav.routing":"Routing","nav.analytics":"Analytics","nav.api_keys":"API keys","nav.help_docs":"Help & docs","nav.sign_out":"Sign out","status.connected":"Connected","status.disconnected":"Disconnected","auth.checking":"Checking…","auth.welcome_aboard":"Welcome aboard.","auth.key_invalid":"That key didn't work. Double-check the prefix sk-orca-…","tab.overview.title":"Overview","tab.overview.sub":"Your single-tenant LLM router at a glance.","tab.providers.title":"Provider keys","tab.providers.sub":"BYOK — encrypted at rest, used to call upstream LLMs.","tab.routing.title":"Routing","tab.routing.sub":"How model='auto' picks the right model for each request.","tab.analytics.title":"Analytics","tab.analytics.sub":"Local-only spend, latency and request history.","tab.keys.title":"API keys","tab.keys.sub":"Tokens that authenticate clients against this Lite workspace." },
-  zh: { "auth.tagline":"开源。单租户。","auth.welcome":"欢迎回来","auth.subtitle":"粘贴首次运行时服务器日志中的 sk-orca-* 密钥。仅保存在此浏览器 localStorage。","auth.api_key":"API 密钥","auth.continue":"继续","nav.search":"搜索","nav.overview":"概览","nav.providers":"供应商","nav.routing":"路由","nav.analytics":"分析","nav.api_keys":"API 密钥","nav.help_docs":"帮助与文档","nav.sign_out":"退出登录","status.connected":"已连接","status.disconnected":"已断开","auth.checking":"正在检查…","auth.welcome_aboard":"欢迎使用。","auth.key_invalid":"该密钥无效，请检查前缀 sk-orca-…","tab.overview.title":"概览","tab.overview.sub":"一览你的单租户 LLM 路由器。","tab.providers.title":"供应商密钥","tab.providers.sub":"BYOK — 静态加密存储，用于调用上游 LLM。","tab.routing.title":"路由","tab.routing.sub":"model='auto' 如何为每个请求选择合适模型。","tab.analytics.title":"分析","tab.analytics.sub":"仅本地的花费、延迟和请求历史。","tab.keys.title":"API 密钥","tab.keys.sub":"用于在此 Lite 工作区中验证客户端的令牌。" },
+  en: { "auth.tagline":"Open Source. Single Tenant.","auth.welcome":"Welcome back","auth.subtitle":"Paste the sk-orca-* key printed in your server logs on first run. Stored only in this browser via localStorage.","auth.api_key":"API key","auth.continue":"Continue","nav.search":"Search","nav.overview":"Overview","nav.providers":"Providers","nav.routing":"Routing","nav.analytics":"Analytics","nav.api_keys":"API keys","nav.help_docs":"Help & docs","nav.sign_out":"Sign out","status.connected":"Connected","status.disconnected":"Disconnected","auth.checking":"Checking…","auth.welcome_aboard":"Welcome aboard.","auth.key_invalid":"That key didn't work. Double-check the prefix sk-orca-…","tab.overview.title":"Overview","tab.overview.sub":"Your single-tenant LLM router at a glance.","tab.providers.title":"Provider keys","tab.providers.sub":"BYOK — encrypted at rest, used to call upstream LLMs.","tab.routing.title":"Routing","tab.routing.sub":"How model='auto' picks the right model for each request.","tab.analytics.title":"Analytics","tab.analytics.sub":"Local-only spend, latency and request history.","tab.keys.title":"API keys","tab.keys.sub":"Tokens that authenticate clients against this Lite workspace.","nav.quality":"Quality","tab.quality.title":"Quality scores","tab.quality.sub":"Real benchmark scores for the quality routing strategy. Pulls from Artificial Analysis." },
+  zh: { "auth.tagline":"开源。单租户。","auth.welcome":"欢迎回来","auth.subtitle":"粘贴首次运行时服务器日志中的 sk-orca-* 密钥。仅保存在此浏览器 localStorage。","auth.api_key":"API 密钥","auth.continue":"继续","nav.search":"搜索","nav.overview":"概览","nav.providers":"供应商","nav.routing":"路由","nav.analytics":"分析","nav.api_keys":"API 密钥","nav.help_docs":"帮助与文档","nav.sign_out":"退出登录","status.connected":"已连接","status.disconnected":"已断开","auth.checking":"正在检查…","auth.welcome_aboard":"欢迎使用。","auth.key_invalid":"该密钥无效，请检查前缀 sk-orca-…","tab.overview.title":"概览","tab.overview.sub":"一览你的单租户 LLM 路由器。","tab.providers.title":"供应商密钥","tab.providers.sub":"BYOK — 静态加密存储，用于调用上游 LLM。","tab.routing.title":"路由","tab.routing.sub":"model='auto' 如何为每个请求选择合适模型。","tab.analytics.title":"分析","tab.analytics.sub":"仅本地的花费、延迟和请求历史。","tab.keys.title":"API 密钥","tab.keys.sub":"用于在此 Lite 工作区中验证客户端的令牌。","nav.quality":"质量","tab.quality.title":"质量分数","tab.quality.sub":"真实 benchmark 分数驱动 quality 路由策略,数据来自 Artificial Analysis。" },
   hi: { "auth.tagline":"ओपन सोर्स। सिंगल टेनेंट।","auth.welcome":"वापसी पर स्वागत है","auth.subtitle":"पहले रन पर सर्वर लॉग में छपी sk-orca-* कुंजी पेस्ट करें। यह केवल इस ब्राउज़र के localStorage में रहेगी।","auth.api_key":"API कुंजी","auth.continue":"जारी रखें","nav.search":"खोज","nav.overview":"अवलोकन","nav.providers":"प्रदाता","nav.routing":"रूटिंग","nav.analytics":"एनालिटिक्स","nav.api_keys":"API कुंजियाँ","nav.help_docs":"सहायता और दस्तावेज़","nav.sign_out":"साइन आउट","status.connected":"कनेक्टेड","status.disconnected":"डिस्कनेक्टेड","auth.checking":"जाँच हो रही है…","auth.welcome_aboard":"स्वागत है।","auth.key_invalid":"यह कुंजी काम नहीं कर रही। sk-orca- प्रीफिक्स जाँचें…","tab.overview.title":"ओवरव्यू","tab.overview.sub":"आपका सिंगल-टेनेंट LLM राउटर एक नज़र में।","tab.providers.title":"प्रोवाइडर कुंजियाँ","tab.providers.sub":"BYOK — स्टोरेज में एन्क्रिप्टेड, अपस्ट्रीम LLM कॉल के लिए उपयोग।","tab.routing.title":"रूटिंग","tab.routing.sub":"model='auto' हर अनुरोध के लिए सही मॉडल कैसे चुनता है।","tab.analytics.title":"एनालिटिक्स","tab.analytics.sub":"केवल स्थानीय खर्च, लेटेंसी और अनुरोध इतिहास।","tab.keys.title":"API कुंजियाँ","tab.keys.sub":"इस Lite वर्कस्पेस पर क्लाइंट प्रमाणित करने वाले टोकन।" },
   es: { "auth.tagline":"Código abierto. Inquilino único.","auth.welcome":"Bienvenido de nuevo","auth.subtitle":"Pega la clave sk-orca-* mostrada en los logs del servidor en el primer inicio. Solo se guarda en este navegador mediante localStorage.","auth.api_key":"Clave API","auth.continue":"Continuar","nav.search":"Buscar","nav.overview":"Resumen","nav.providers":"Proveedores","nav.routing":"Enrutamiento","nav.analytics":"Analíticas","nav.api_keys":"Claves API","nav.help_docs":"Ayuda y documentación","nav.sign_out":"Cerrar sesión","status.connected":"Conectado","status.disconnected":"Desconectado","auth.checking":"Verificando…","auth.welcome_aboard":"Bienvenido.","auth.key_invalid":"Esa clave no funcionó. Verifica el prefijo sk-orca-…","tab.overview.title":"Resumen","tab.overview.sub":"Tu enrutador LLM de inquilino único de un vistazo.","tab.providers.title":"Claves de proveedor","tab.providers.sub":"BYOK — cifradas en reposo, usadas para llamar a LLMs upstream.","tab.routing.title":"Enrutamiento","tab.routing.sub":"Cómo model='auto' elige el modelo adecuado para cada solicitud.","tab.analytics.title":"Analíticas","tab.analytics.sub":"Gasto, latencia e historial de solicitudes solo local.","tab.keys.title":"Claves API","tab.keys.sub":"Tokens que autentican clientes en este espacio Lite." },
   pt: { "auth.tagline":"Código aberto. Locatário único.","auth.welcome":"Bem-vindo de volta","auth.subtitle":"Cole a chave sk-orca-* exibida nos logs do servidor na primeira execução. Armazenada apenas neste navegador via localStorage.","auth.api_key":"Chave API","auth.continue":"Continuar","nav.search":"Pesquisar","nav.overview":"Visão geral","nav.providers":"Provedores","nav.routing":"Roteação","nav.analytics":"Análises","nav.api_keys":"Chaves API","nav.help_docs":"Ajuda e docs","nav.sign_out":"Sair","status.connected":"Conectado","status.disconnected":"Desconectado","auth.checking":"Verificando…","auth.welcome_aboard":"Boas-vindas.","auth.key_invalid":"Essa chave não funcionou. Verifique o prefixo sk-orca-…","tab.overview.title":"Visão geral","tab.overview.sub":"Seu roteador LLM single-tenant em um relance.","tab.providers.title":"Chaves de provedor","tab.providers.sub":"BYOK — criptografadas em repouso, usadas para chamar LLMs upstream.","tab.routing.title":"Roteamento","tab.routing.sub":"Como model='auto' escolhe o modelo certo para cada solicitação.","tab.analytics.title":"Análises","tab.analytics.sub":"Gasto, latência e histórico de solicitações apenas locais.","tab.keys.title":"Chaves API","tab.keys.sub":"Tokens que autenticam clientes neste workspace Lite." },
@@ -37,6 +37,7 @@ const TAB_META = {
   routing:   { title: "tab.routing.title",   sub: "tab.routing.sub" },
   analytics: { title: "tab.analytics.title", sub: "tab.analytics.sub" },
   keys:      { title: "tab.keys.title",      sub: "tab.keys.sub" },
+  quality:   { title: "tab.quality.title",   sub: "tab.quality.sub" },
 };
 
 const state = {
@@ -51,6 +52,9 @@ const state = {
   models: [],
   hosted: { configured: false, source: null, signup_url: "https://www.orcarouter.ai/register", provider_name: "orcarouter" },
   unreachable: { hosted_configured: false, unreachable: [] },
+  // Quality scoring (Artificial Analysis Intelligence Index + manual overrides)
+  quality: { aa_index: { configured: false, source: "missing-key", matched_count: 0 }, models: [], override_count: 0 },
+  qualityPreview: null,
   windowDays: 7,
   lang: "python",
   locale: "en",
@@ -253,6 +257,12 @@ function setTab(tab) {
       renderOverview();
       renderHostedCard();
       renderUnreachable();
+    });
+  }
+  if (tab === "quality") {
+    Promise.all([loadQuality(), loadQualityPreview()]).then(() => {
+      renderQuality();
+      renderQualityPreview();
     });
   }
 }
@@ -767,6 +777,202 @@ function bindKeyForm() {
 }
 
 /* ==========================================================================
+   QUALITY (AA Intelligence Index + manual overrides)
+   ========================================================================== */
+async function loadQuality() {
+  try {
+    const data = await api("/v1/quality");
+    state.quality = data;
+  } catch (e) {
+    toast(`Couldn't load quality scores: ${e.message}`, "err");
+  }
+}
+
+async function loadQualityPreview() {
+  try {
+    state.qualityPreview = await api("/v1/quality/auto-preview");
+  } catch (e) {
+    state.qualityPreview = null;
+  }
+}
+
+function renderQuality() {
+  const aa = state.quality?.aa_index || {};
+  const setupCard = $("#quality-setup-card");
+  const statusCard = $("#quality-status-card");
+  const tableCard = $("#quality-table-card");
+
+  // Setup card is informational when no AA key — manual overrides still
+  // work standalone, so the table card is always shown. Status card
+  // (which surfaces AA freshness) is only meaningful when AA is wired up.
+  const isConfigured = aa.source !== "missing-key";
+  setupCard.hidden = isConfigured;
+  statusCard.hidden = !isConfigured;
+  tableCard.hidden = false;
+
+  // Status line — only when AA is configured (the card itself is hidden
+  // otherwise, but populating defensively avoids a blank flash on toggle).
+  if (isConfigured) {
+    const sourceLabel = {
+      "live":         '<span class="pill ok">live</span>',
+      "stale-cache":  '<span class="pill warn">stale (AA unreachable)</span>',
+      "stale-db":     '<span class="pill warn">stale (DB snapshot)</span>',
+      "error":        '<span class="pill err">error</span>',
+      "missing-key":  '<span class="pill muted">no API key</span>',
+    }[aa.source] || `<span class="pill">${escapeHtml(aa.source || "unknown")}</span>`;
+
+    $("#quality-status-line").innerHTML = (
+      `${sourceLabel} · matched <strong>${aa.matched_count || 0}</strong> of `
+      + `${aa.raw_count || 0} AA models to your catalog · `
+      + `<strong>${state.quality.override_count || 0}</strong> manual override`
+      + `${state.quality.override_count === 1 ? "" : "s"}`
+    );
+  }
+
+  renderQualityTable();
+}
+
+function renderQualityTable() {
+  const tbody = $("#quality-table tbody");
+  tbody.innerHTML = "";
+  const rows = state.quality?.models || [];
+  if (!rows.length) {
+    tbody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center;padding:24px">
+      No models in catalog.
+    </td></tr>`;
+    return;
+  }
+
+  // Show top 60 by effective score; full table is 500+ entries which is
+  // overwhelming. Add a search/filter later if needed.
+  rows.slice(0, 60).forEach((m) => {
+    const tr = document.createElement("tr");
+    tr.className = "row-in";
+    const aaCell = m.aa_score == null
+      ? '<span class="muted">—</span>'
+      : `<span title="Artificial Analysis Intelligence Index">${m.aa_score.toFixed(0)}</span>`;
+    const manualCell = m.manual_score == null
+      ? `<button class="btn btn-ghost btn-sm set-override" data-id="${escapeHtml(m.id)}" data-aa="${m.aa_score ?? ""}">Set</button>`
+      : `<strong>${m.manual_score.toFixed(0)}</strong>`;
+    const effectiveCell = m.effective_score == null
+      ? '<span class="muted">unscored</span>'
+      : `<strong>${m.effective_score.toFixed(0)}</strong>`;
+    const blendedPerM = (m.blended_cost * 1_000_000).toFixed(2);
+    const statusCell = m.deployable
+      ? '<span class="pill ok">deployable</span>'
+      : '<span class="pill muted">no key</span>';
+    const actions = m.manual_score != null
+      ? `<button class="btn btn-ghost btn-sm reset-override" data-id="${escapeHtml(m.id)}" title="Revert to AA score">Reset</button>`
+      : "";
+
+    tr.innerHTML = `
+      <td><code>${escapeHtml(m.id)}</code></td>
+      <td>${escapeHtml(m.provider)}</td>
+      <td class="num">${aaCell}</td>
+      <td class="num">${manualCell}</td>
+      <td class="num">${effectiveCell}</td>
+      <td class="num">$${blendedPerM}</td>
+      <td>${statusCell}</td>
+      <td class="th-actions">${actions}</td>
+    `;
+    tbody.appendChild(tr);
+  });
+
+  $$(".set-override").forEach((b) =>
+    b.addEventListener("click", () => promptOverride(b.dataset.id, b.dataset.aa))
+  );
+  $$(".reset-override").forEach((b) =>
+    b.addEventListener("click", () => resetOverride(b.dataset.id))
+  );
+}
+
+function renderQualityPreview() {
+  const wrap = $("#quality-preview");
+  const body = $("#quality-preview-body");
+  if (!state.qualityPreview) {
+    wrap.hidden = true;
+    return;
+  }
+  wrap.hidden = false;
+  const p = state.qualityPreview;
+  if (!p.primary) {
+    body.innerHTML = `<p class="muted">No deployable model satisfies the current capability requirements. Configure a provider key on the Providers page.</p>`;
+    return;
+  }
+  const scoreText = p.primary_score != null
+    ? `<span class="pill ok">score ${p.primary_score.toFixed(0)}</span>`
+    : `<span class="pill muted">unscored</span>`;
+  const fbList = p.fallbacks && p.fallbacks.length
+    ? `<div class="small muted">→ falls back to: ${p.fallbacks.map((f) => `<code>${escapeHtml(f)}</code>`).join(", ")}</div>`
+    : "";
+  body.innerHTML = `
+    <div><code>${escapeHtml(p.primary)}</code> ${scoreText}</div>
+    <div class="small muted">strategy: <code>${escapeHtml(p.strategy)}</code> · scoring: <code>${escapeHtml(p.scoring_source)}</code></div>
+    ${fbList}
+  `;
+}
+
+async function promptOverride(modelId, aaHint) {
+  const seed = aaHint && aaHint !== "" ? aaHint : "";
+  const raw = prompt(
+    `Set manual quality score for ${modelId} (0-100):`
+    + (seed ? `\n\nAA score is currently: ${seed}` : ""),
+    seed,
+  );
+  if (raw == null) return;
+  const score = Number(raw);
+  if (!Number.isFinite(score) || score < 0 || score > 100) {
+    toast("Score must be a number between 0 and 100", "err");
+    return;
+  }
+  const note = prompt("Optional note (why are you overriding?):", "") || null;
+  try {
+    await api(`/v1/quality/overrides/${encodeURIComponent(modelId)}`, {
+      method: "PUT",
+      body: JSON.stringify({ score, note }),
+    });
+    toast(`Override set for ${modelId}`, "ok");
+    await Promise.all([loadQuality(), loadQualityPreview()]);
+    renderQuality();
+    renderQualityPreview();
+  } catch (e) {
+    toast(e.message, "err");
+  }
+}
+
+async function resetOverride(modelId) {
+  if (!confirm(`Reset ${modelId} to its AA score?`)) return;
+  try {
+    await api(`/v1/quality/overrides/${encodeURIComponent(modelId)}`, { method: "DELETE" });
+    toast(`Reset ${modelId}`, "ok");
+    await Promise.all([loadQuality(), loadQualityPreview()]);
+    renderQuality();
+    renderQualityPreview();
+  } catch (e) {
+    toast(e.message, "err");
+  }
+}
+
+function bindQualityRefresh() {
+  const btn = $("#quality-refresh");
+  if (!btn) return;
+  btn.addEventListener("click", async () => {
+    btn.disabled = true;
+    try {
+      await api("/v1/quality/refresh", { method: "POST" });
+      toast("Refreshed scores from Artificial Analysis", "ok");
+      await Promise.all([loadQuality(), loadQualityPreview()]);
+      renderQuality();
+      renderQualityPreview();
+    } catch (e) {
+      toast(`Refresh failed: ${e.message}`, "err");
+    } finally {
+      btn.disabled = false;
+    }
+  });
+}
+
+/* ==========================================================================
    MODELS
    ========================================================================== */
 async function loadModels() {
@@ -1155,6 +1361,7 @@ document.addEventListener("DOMContentLoaded", async () => {
   bindRouting();
   bindWindowSeg();
   bindKeyForm();
+  bindQualityRefresh();
   bindHelp();
   bindPalette();
   bindKeyboard();

--- a/design/index.html
+++ b/design/index.html
@@ -98,6 +98,11 @@
           <span data-i18n="nav.api_keys">API keys</span>
           <kbd>5</kbd>
         </button>
+        <button data-tab="quality" class="nav-item" data-shortcut="6">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2l2.39 7.36H22l-6.18 4.49L18.21 22 12 17.27 5.79 22l2.39-8.15L2 9.36h7.61z"/></svg>
+          <span data-i18n="nav.quality">Quality</span>
+          <kbd>6</kbd>
+        </button>
       </nav>
 
       <div class="sidebar-foot">
@@ -568,6 +573,84 @@
                 <tbody></tbody>
               </table>
             </div>
+          </article>
+        </section>
+
+        <!-- ─────────────── Quality scores panel ─────────────── -->
+        <section id="panel-quality" class="panel">
+          <article class="card" id="quality-setup-card" hidden>
+            <header class="card-head">
+              <div>
+                <h2 class="card-title">Set up quality scoring</h2>
+                <p class="card-sub">
+                  Strategy <code>quality</code> currently picks the most expensive model — a proxy that broke when newer flagships (Claude Opus 4.7, GPT-5.x) shipped at lower prices than older ones. Set an Artificial Analysis API key to route by real benchmark scores instead.
+                </p>
+              </div>
+            </header>
+            <div class="setup-steps">
+              <ol>
+                <li>Sign up free at <a href="https://artificialanalysis.ai" target="_blank" rel="noopener">artificialanalysis.ai</a> and generate an API key (free tier: 1,000 req/day, plenty for 1h-cached usage).</li>
+                <li>Add it to your <code>.env</code> as <code>ARTIFICIAL_ANALYSIS_API_KEY=...</code> and restart.</li>
+                <li>Reload this page — scores will appear automatically.</li>
+              </ol>
+              <p class="callout-foot">
+                Without a key, <code>quality</code> falls back to the legacy cost-based behavior. <code>cheapest</code> / <code>balanced</code> / <code>fastest</code> are unaffected. You can still set <strong>manual overrides</strong> on individual models in the table below — those work without an AA key and take precedence when present.
+              </p>
+            </div>
+          </article>
+
+          <article class="card" id="quality-status-card" hidden>
+            <header class="card-head">
+              <div>
+                <h2 class="card-title">Quality scores</h2>
+                <p class="card-sub">
+                  <span id="quality-status-line">Loading…</span>
+                </p>
+              </div>
+              <button id="quality-refresh" class="btn btn-secondary" type="button">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"/></svg>
+                Refresh from AA
+              </button>
+            </header>
+
+            <div class="callout" id="quality-preview" hidden>
+              <div class="callout-head">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><polygon points="10 8 16 12 10 16 10 8"/></svg>
+                <strong>Right now, <code>model="auto"</code> would resolve to:</strong>
+              </div>
+              <div id="quality-preview-body"></div>
+            </div>
+          </article>
+
+          <article class="card" id="quality-table-card" hidden>
+            <header class="card-head">
+              <div>
+                <h2 class="card-title">Models</h2>
+                <p class="card-sub">
+                  Edit a row's <strong>Manual</strong> column to override the AA score for routing decisions. Manual values win over AA. Use this when your own evals disagree, or when AA hasn't scored a model yet.
+                </p>
+              </div>
+            </header>
+
+            <div class="table-wrap">
+              <table id="quality-table">
+                <thead><tr>
+                  <th>Model</th>
+                  <th>Provider</th>
+                  <th class="num">AA</th>
+                  <th class="num">Manual</th>
+                  <th class="num">Effective</th>
+                  <th class="num">$/M blended</th>
+                  <th>Status</th>
+                  <th class="th-actions"></th>
+                </tr></thead>
+                <tbody></tbody>
+              </table>
+            </div>
+
+            <p class="card-foot small muted">
+              Powered by <a href="https://artificialanalysis.ai" target="_blank" rel="noopener">Artificial Analysis</a> — Intelligence Index aggregates MMLU-Pro, GPQA, MATH, HumanEval, and other benchmarks. Attribution required.
+            </p>
           </article>
         </section>
       </div>

--- a/packages/db/models/__init__.py
+++ b/packages/db/models/__init__.py
@@ -3,6 +3,8 @@
 from packages.db.models.api_key import ApiKey
 from packages.db.models.base import Base, SoftDeleteMixin, TimestampMixin, UUIDMixin
 from packages.db.models.provider_key import ProviderKey
+from packages.db.models.quality_score_override import QualityScoreOverride
+from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
 from packages.db.models.request_log import RequestLog
 from packages.db.models.routing_config import RoutingConfig
 from packages.db.models.workspace import Workspace
@@ -14,6 +16,8 @@ __all__ = [
     "UUIDMixin",
     "ApiKey",
     "ProviderKey",
+    "QualityScoreOverride",
+    "QualityScoreSnapshot",
     "RequestLog",
     "RoutingConfig",
     "Workspace",

--- a/packages/db/models/quality_score_override.py
+++ b/packages/db/models/quality_score_override.py
@@ -1,0 +1,40 @@
+"""Manual overrides for the AA-driven quality routing scores.
+
+The dashboard's Quality page lets the operator pin a custom score for any
+catalog model — useful when AA's benchmark coverage is missing or stale,
+or when the operator's own evals disagree with AA's ranking. The routing
+layer treats overrides as authoritative: manual > AA > unscored.
+
+One row per (workspace_id, model_id). Lite is single-workspace today, but
+the composite key keeps the table forward-compatible with multi-workspace
+deployments.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from packages.db.models.base import Base
+
+
+class QualityScoreOverride(Base):
+    __tablename__ = "quality_score_overrides"
+
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), primary_key=True, nullable=False
+    )
+    model_id: Mapped[str] = mapped_column(String(200), primary_key=True, nullable=False)
+    score: Mapped[float] = mapped_column(Float, nullable=False)
+    # Free-form note from the operator explaining why they overrode the score.
+    # Surfaced in the dashboard so future-you remembers what past-you was thinking.
+    note: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), server_default=func.now(), nullable=False
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/packages/db/models/quality_score_snapshot.py
+++ b/packages/db/models/quality_score_snapshot.py
@@ -1,0 +1,58 @@
+"""Persisted snapshot of the most recent Artificial Analysis fetch.
+
+Survives process restart so the operator's daily AA quota (1000/day on the
+free tier) isn't burned re-fetching the same data on every boot. One row
+per (workspace_id, api_key_hash) — the key hash discriminates so that
+rotating the AA key invalidates the previous snapshot rather than
+silently serving data fetched under a different account.
+
+Routing layer prefers in-process cache (fast, 1h TTL), then this snapshot
+(survives restart), then a fresh AA fetch. On AA outage, this snapshot
+extends the stale-while-revalidate window indefinitely — the cost-based
+fallback is the last resort, not the first.
+
+Freshness is tracked via `updated_at` (wall-clock, set by the DB on
+write). `time.monotonic()` is per-process and has no meaning when read
+from another process — it would always look fresh, defeating the TTL.
+The routing layer converts `updated_at` → wall-clock age → comparison
+when loading from DB.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from packages.db.models.base import Base
+
+
+class QualityScoreSnapshot(Base):
+    __tablename__ = "quality_score_snapshots"
+
+    workspace_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("workspaces.id"), primary_key=True, nullable=False
+    )
+    # sha256(api_key)[:16] — rotating the AA key changes this and forces a
+    # fresh fetch (a snapshot from key A shouldn't be served when running
+    # under key B; their model coverage / scores might differ).
+    api_key_hash: Mapped[str] = mapped_column(
+        String(32), primary_key=True, nullable=False
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    raw_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    matched_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # JSON-serialized {model_id: score}. `Text` rather than dialect-specific
+    # `JSON` / `JSONB` so SQLite + Postgres + MySQL behave identically
+    # without driver-specific wrangling. The map is small enough (~500
+    # entries × ~30 bytes = ~15KB) that searchable JSON storage is overkill.
+    scores_json: Mapped[str] = mapped_column(Text, nullable=False)
+    # Wall-clock timestamp of the last fetch. Used for cross-process
+    # freshness checks (monotonic time would be meaningless across
+    # restarts — see module docstring). DB-managed via `func.now()` so
+    # we don't have to feed the column from app code.
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )

--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -1,0 +1,427 @@
+"""Artificial Analysis quality scores — used to rank models in the
+`quality` routing strategy.
+
+The strategy was historically implemented as "pick the most expensive
+deployable model" — a fine proxy when newer flagships cost more than
+older ones. Anthropic and OpenAI broke that assumption (Opus 4.7 is
+3x cheaper than Opus 4 from May 2024 yet measurably stronger), so cost
+no longer tracks capability. AA's Intelligence Index is a real
+benchmark-aggregator score (MMLU-Pro, GPQA, MATH, HumanEval, etc.),
+updated as new models ship and stable across providers.
+
+Three-layer cache:
+  1. In-process dict (1h TTL) — fast, dies with the process
+  2. DB snapshot (`quality_score_snapshots` table) — survives restart
+     so a typical `docker compose down/up` doesn't burn an AA fetch
+  3. AA `/api/v2/data/llms/models` (free tier, 1000 req/day) — truth
+
+On AA failure, we serve stale from the in-process layer first, then
+the DB layer (no time bound — better to serve old scores than to fall
+back to cost-based, which is known wrong). Rotating the AA key
+invalidates DB rows via the `api_key_hash` column so a snapshot taken
+under one account doesn't get served under another.
+
+Attribution: when scores are surfaced (dashboard, header, debug log),
+display "Powered by Artificial Analysis" linking to artificialanalysis.ai
+per their free-tier terms.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_CACHE_TTL_SECONDS = 60 * 60          # 1h
+_FETCH_TIMEOUT_SECONDS = 10.0
+_STALE_GRACE_SECONDS = 24 * 60 * 60   # 24h: keep serving last good value
+
+
+@dataclass(frozen=True)
+class QualityIndex:
+    """One AA fetch result. `scores` is keyed by our canonical model IDs."""
+
+    scores: dict[str, float]
+    fetched_at: float                 # monotonic seconds
+    source: str                       # "live" | "stale-cache" | "missing-key" | "error"
+    raw_count: int                    # how many AA entries were considered
+    matched_count: int                # how many mapped to a known catalog ID
+
+
+# Process-wide cache, keyed by API key (so swapping the key in tests
+# or at runtime doesn't return stale data from a different account).
+_cache: dict[str, QualityIndex] = {}
+
+
+# Strip parenthetical qualifiers like "(max)", "(xhigh)", "(high)",
+# "(low)", "(Non-reasoning, high)" — these mark reasoning-effort variants
+# of the same underlying model. We aggregate by taking MAX score.
+_QUALIFIER_RE = re.compile(r"\s*\([^)]*\)\s*$")
+
+
+def _normalize_aa_id(aa_name: str) -> str:
+    """Convert an AA display name to our canonical model id form.
+
+    Examples:
+      "Claude Opus 4.7 (max)"          -> "claude-opus-4-7"
+      "GPT-5.5 (xhigh)"                -> "gpt-5-5"
+      "Claude Sonnet 4.6 (max)"        -> "claude-sonnet-4-6"
+      "Gemini 3.1 Pro Preview"         -> "gemini-3-1-pro-preview"
+      "DeepSeek V4 Pro (Max)"          -> "deepseek-v4-pro"
+
+    The output may not match a LiteLLM catalog id exactly; the lookup
+    layer (`_match_catalog_id`) handles strip-prefix and family fallback.
+    """
+    s = _QUALIFIER_RE.sub("", aa_name).strip()
+    s = s.lower()
+    s = s.replace(" ", "-")
+    s = s.replace(".", "-")
+    return s
+
+
+def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
+    """Find a LiteLLM catalog id that matches a normalized AA name.
+
+    Tries, in order:
+      1. Exact match
+      2. Match with provider prefix stripped (the catalog already
+         strips prefixes at load, but be defensive)
+      3. Family match: any catalog id that starts with `normalized + "-"`
+         (covers the case where AA gives a base name and the catalog
+         has dated/versioned variants like "claude-opus-4-7-20260416")
+
+    Returns the first matching catalog id, or None.
+    """
+    if normalized in catalog_ids:
+        return normalized
+    bare = normalized.split("/", 1)[-1] if "/" in normalized else normalized
+    if bare in catalog_ids:
+        return bare
+    # Family match — pick the longest suffix-extended id that starts with
+    # our normalized base. Stable order via sort so test runs are reproducible.
+    family_prefix = bare + "-"
+    candidates = [c for c in catalog_ids if c.startswith(family_prefix)]
+    if candidates:
+        return sorted(candidates)[0]
+    return None
+
+
+def _build_score_map(aa_payload: list[dict[str, Any]], catalog_ids: set[str]) -> tuple[dict[str, float], int, int]:
+    """Project AA's response into {our_catalog_id: max_score}.
+
+    AA may include the same base model multiple times under different
+    reasoning-effort qualifiers — we keep the highest score per
+    canonical catalog id. Returns (scores, raw_count, matched_count).
+    """
+    accum: dict[str, float] = {}
+    raw_count = 0
+    matched_count = 0
+
+    for entry in aa_payload:
+        if not isinstance(entry, dict):
+            continue
+        raw_count += 1
+        # AA exposes display names in the `name` field. Some entries may
+        # also have a `slug` or `id`; prefer `name` since it matches the
+        # leaderboard the operator sees.
+        name = entry.get("name") or entry.get("slug") or entry.get("id")
+        if not isinstance(name, str) or not name:
+            continue
+        evals = entry.get("evaluations") or {}
+        score = evals.get("artificial_analysis_intelligence_index")
+        if score is None or not isinstance(score, (int, float)):
+            continue
+
+        normalized = _normalize_aa_id(name)
+        catalog_id = _match_catalog_id(normalized, catalog_ids)
+        if catalog_id is None:
+            continue
+
+        prior = accum.get(catalog_id)
+        if prior is None or score > prior:
+            accum[catalog_id] = float(score)
+            if prior is None:
+                matched_count += 1
+
+    return accum, raw_count, matched_count
+
+
+class _AAFetchUnusable(Exception):
+    """Raised when an AA fetch returns nothing usable — schema mismatch,
+    empty data array, or all entries unmatched. Distinct from a transport
+    error so the caller can route it through the same stale-fallback path
+    instead of persisting an empty score map over a known-good snapshot.
+    """
+
+
+async def _fetch_remote(url: str, api_key: str, timeout: float = _FETCH_TIMEOUT_SECONDS) -> list[dict[str, Any]]:
+    """Single AA request. Tests can mock httpx at the transport boundary.
+
+    Returns the raw `data` array. Raises `_AAFetchUnusable` on schema
+    mismatch (body isn't a list and isn't a `{data: list}` wrapper) so the
+    caller falls back to stale data rather than persisting `{}` and
+    poisoning the DB snapshot. Network/HTTP errors propagate as-is.
+    """
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as c:
+        r = await c.get(url, headers={"x-api-key": api_key, "Accept": "application/json"})
+        r.raise_for_status()
+        body = r.json()
+    if isinstance(body, dict):
+        # AA wraps the list under "data" per their schema.
+        data = body.get("data")
+        if isinstance(data, list):
+            return data
+        # Some endpoints return the bare list at top level; accept both.
+    if isinstance(body, list):
+        return body
+    raise _AAFetchUnusable(
+        f"AA response shape not recognized (expected list or {{data: list}}, "
+        f"got {type(body).__name__})"
+    )
+
+
+def _api_key_hash(api_key: str) -> str:
+    """sha256(key)[:16] — used as cache key in-memory and in the DB
+    snapshot row. Same hash → same logical AA account; different hash →
+    operator rotated keys, snapshots from before the rotation are stale
+    by definition."""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+
+
+@dataclass(frozen=True)
+class _LoadedSnapshot:
+    """A DB-loaded snapshot. Carries wall-clock age so the freshness
+    check at the call site doesn't mix monotonic and wall-clock times."""
+    scores: dict[str, float]
+    source: str
+    raw_count: int
+    matched_count: int
+    wall_age_seconds: float   # how long ago the row was written, per the DB clock
+
+
+async def _load_db_snapshot(
+    db: "AsyncSession", workspace_id: str, api_key_hash: str
+) -> _LoadedSnapshot | None:
+    """Read the most recent persisted snapshot for this workspace + key.
+
+    Returns None on miss, JSON parse failure, or any DB error — callers
+    treat absent snapshot as "fall through to AA fetch". We never let a
+    DB hiccup take down quality routing.
+
+    Wall-clock age is computed at load time using the DB's own `updated_at`
+    column. We don't store `time.monotonic()` to the DB because the
+    monotonic clock is per-process — a value saved by process A is
+    meaningless when read by process B (would always look fresh, defeating
+    the TTL).
+    """
+    from sqlalchemy import select
+    try:
+        row = (
+            await db.execute(
+                select(QualityScoreSnapshot).where(
+                    QualityScoreSnapshot.workspace_id == workspace_id,
+                    QualityScoreSnapshot.api_key_hash == api_key_hash,
+                )
+            )
+        ).scalar_one_or_none()
+        if row is None:
+            return None
+        scores = json.loads(row.scores_json)
+        if not isinstance(scores, dict):
+            return None
+        # Compute wall-clock age. `updated_at` is server-default `func.now()`
+        # so it's UTC on both SQLite and Postgres; coerce naive (SQLite) to
+        # UTC for consistent arithmetic.
+        wall_now = datetime.now(timezone.utc)
+        row_ts = row.updated_at
+        if row_ts.tzinfo is None:
+            row_ts = row_ts.replace(tzinfo=timezone.utc)
+        age = max(0.0, (wall_now - row_ts).total_seconds())
+        return _LoadedSnapshot(
+            scores={k: float(v) for k, v in scores.items()},
+            source=row.source,
+            raw_count=int(row.raw_count),
+            matched_count=int(row.matched_count),
+            wall_age_seconds=age,
+        )
+    except Exception:
+        return None
+
+
+async def _save_db_snapshot(
+    db: "AsyncSession", workspace_id: str, api_key_hash: str, idx: QualityIndex
+) -> None:
+    """Upsert the snapshot for this workspace + key. Never raises —
+    persisting is best-effort; the in-process cache is still the
+    authoritative source for the current request.
+
+    Uses `session.merge()` for the upsert: portable across SQLite /
+    Postgres / MySQL, race-safe under multi-worker fan-out (vs the
+    select-then-insert pattern which would IntegrityError when two
+    workers fetch AA simultaneously and both try to insert).
+    """
+    try:
+        scores_json = json.dumps(idx.scores, separators=(",", ":"))
+        # `merge` syncs a detached/new instance with whatever is in the DB,
+        # keyed by primary key. Inserts when missing, updates when present.
+        # Works identically across all SQLAlchemy-supported dialects.
+        # `updated_at` is set by the DB's `onupdate=func.now()` trigger —
+        # we don't pass it from app code, so the wall-clock timestamp
+        # always comes from the same authoritative source (the DB).
+        await db.merge(QualityScoreSnapshot(
+            workspace_id=workspace_id,
+            api_key_hash=api_key_hash,
+            source=idx.source,
+            raw_count=idx.raw_count,
+            matched_count=idx.matched_count,
+            scores_json=scores_json,
+        ))
+        await db.commit()
+    except Exception:
+        # Never let a write failure kill the request path. The in-process
+        # cache still has the fresh value; we'll retry the persist on the
+        # next refresh.
+        try:
+            await db.rollback()
+        except Exception:
+            pass
+
+
+async def get_quality_index(
+    *,
+    catalog_ids: set[str],
+    db: "AsyncSession | None" = None,
+    workspace_id: str = "default",
+    force_refresh: bool = False,
+) -> QualityIndex:
+    """Return the current AA score map for our catalog.
+
+    Read order:
+      1. In-process cache (1h TTL) — fastest, single-process scope.
+      2. DB snapshot (`quality_score_snapshots`) — survives restart.
+         Only consulted if `db` is supplied; tests of pure parsing logic
+         pass `db=None` and skip this layer.
+      3. AA `/api/v2/data/llms/models` — fresh truth, 1000 req/day quota.
+
+    Write order on AA success: in-process cache + DB snapshot (best-effort).
+
+    On AA failure: serve stale from in-process (within 24h grace), then
+    from DB (no upper bound — old data is better than no data here).
+
+    `catalog_ids` is the set of model ids we're willing to score —
+    typically `set(CATALOG_BY_ID.keys())`. Pass it in (rather than
+    importing) so tests can supply a synthetic catalog without dragging
+    in litellm.
+    """
+    from app.config import get_settings
+
+    s = get_settings()
+    api_key = s.artificial_analysis_api_key
+    if not api_key:
+        return QualityIndex(scores={}, fetched_at=0.0, source="missing-key",
+                             raw_count=0, matched_count=0)
+
+    url = s.artificial_analysis_models_url
+    key_hash = _api_key_hash(api_key)
+    now = time.monotonic()
+
+    # Layer 1: in-process cache.
+    if not force_refresh:
+        cached = _cache.get(key_hash)
+        if cached is not None and (now - cached.fetched_at) < _CACHE_TTL_SECONDS:
+            return cached
+
+    # Layer 2: DB snapshot (only if db session provided). Freshness is
+    # checked via wall-clock age (computed in `_load_db_snapshot` from
+    # the DB's `updated_at`), not monotonic — see `_LoadedSnapshot`.
+    db_snapshot: _LoadedSnapshot | None = None
+    if db is not None:
+        db_snapshot = await _load_db_snapshot(db, workspace_id, key_hash)
+        if (
+            not force_refresh
+            and db_snapshot is not None
+            and db_snapshot.wall_age_seconds < _CACHE_TTL_SECONDS
+        ):
+            # Promote DB row into in-process cache. The in-process layer
+            # uses monotonic time, so set `fetched_at = now` (treats this
+            # request as the start of a fresh in-process TTL window). Net
+            # effect: cross-restart freshness can extend by up to 1h
+            # beyond the original wall-clock TTL — acceptable in exchange
+            # for a cold-start AA quota saved.
+            promoted = QualityIndex(
+                scores=db_snapshot.scores,
+                fetched_at=now,
+                source=db_snapshot.source,
+                raw_count=db_snapshot.raw_count,
+                matched_count=db_snapshot.matched_count,
+            )
+            _cache[key_hash] = promoted
+            return promoted
+
+    # Layer 3: fetch AA.
+    try:
+        raw = await _fetch_remote(url, api_key)
+        if not raw:
+            # Empty array from AA — almost always a transient outage or
+            # a quota-exceeded response that still returned 200. Don't
+            # let it overwrite a good DB snapshot with `{}`; route through
+            # the stale-fallback path instead.
+            raise _AAFetchUnusable("AA returned empty data array")
+        scores, raw_count, matched_count = _build_score_map(raw, catalog_ids)
+        if matched_count == 0:
+            # AA gave us data but none of it mapped to our catalog. This
+            # signals a normalization regression (AA renamed everything)
+            # rather than a healthy fetch — persisting `{}` would silently
+            # disable quality routing on the next restart. Fall back to
+            # stale instead.
+            raise _AAFetchUnusable(
+                f"AA returned {raw_count} entries but 0 mapped to catalog"
+            )
+        idx = QualityIndex(
+            scores=scores, fetched_at=now, source="live",
+            raw_count=raw_count, matched_count=matched_count,
+        )
+        _cache[key_hash] = idx
+        if db is not None:
+            await _save_db_snapshot(db, workspace_id, key_hash, idx)
+        return idx
+    except Exception:
+        # Stale fallbacks, in order of freshness.
+        cached = _cache.get(key_hash)
+        if cached is not None and (now - cached.fetched_at) < _STALE_GRACE_SECONDS:
+            return QualityIndex(
+                scores=cached.scores, fetched_at=cached.fetched_at,
+                source="stale-cache",
+                raw_count=cached.raw_count, matched_count=cached.matched_count,
+            )
+        if db_snapshot is not None:
+            # DB row is older than the in-process TTL but we serve it
+            # anyway — better than disabling quality routing entirely.
+            # `source="stale-db"` lets the dashboard show the operator
+            # they're on stale data; no upper bound on age here because
+            # the alternative (cost-based) is known wrong, not just stale.
+            return QualityIndex(
+                scores=db_snapshot.scores,
+                fetched_at=now,  # we just learned this from DB; re-anchor in-process
+                source="stale-db",
+                raw_count=db_snapshot.raw_count,
+                matched_count=db_snapshot.matched_count,
+            )
+        return QualityIndex(scores={}, fetched_at=now, source="error",
+                             raw_count=0, matched_count=0)
+
+
+def reset_cache() -> None:
+    """Clear the in-process cache. Call from test fixtures."""
+    _cache.clear()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,11 @@ def _reset_module_state() -> Generator[None, None, None]:
         orcarouter_models.reset_cache()
     except Exception:
         pass
+    try:
+        from packages.litellm_adapter import quality_index
+        quality_index.reset_cache()
+    except Exception:
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_auto_model.py
+++ b/tests/integration/test_auto_model.py
@@ -297,7 +297,6 @@ async def test_auto_with_allowlist_picks_only_allowed_model(auto_client, monkeyp
     early allowlist check (since "auto" is never literally in any allowlist),
     making auto unusable for any rate-limited / scoped key."""
     from sqlalchemy import select
-    from sqlalchemy.ext.asyncio import async_sessionmaker
 
     from packages.db import session as session_mod
     from packages.db.models.api_key import ApiKey
@@ -425,6 +424,7 @@ async def test_auto_returns_422_not_403_when_allowlist_set_but_no_capable_model(
         seed = await seed_initial_state(s)
         # Set an allowlist so the 403/422 distinction is exercised.
         from sqlalchemy import select
+
         from packages.db.models.api_key import ApiKey
         rows = (await s.execute(select(ApiKey))).scalars().all()
         rows[0].model_allowlist = ["gpt-4o-mini"]

--- a/tests/integration/test_quality_routes.py
+++ b/tests/integration/test_quality_routes.py
@@ -1,0 +1,330 @@
+"""Integration tests for /v1/quality endpoints.
+
+Per the no-mock-of-layer-under-test rule:
+  - Real FastAPI app (not a mock router)
+  - Real SQLite (not a mock DB session)
+  - Real auto_routing + CATALOG (not stubbed)
+  - Mock httpx for AA only (the actual network boundary)
+
+This means a passing test proves the full stack works: AA fetcher →
+score map → DB merge → resolver picks the right model → preview /
+overrides reflect operator state.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+async def quality_client(tmp_sqlite_url, monkeypatch):
+    """Booted lite app + AsyncClient with the seeded API key, AA fetcher
+    mocked at the httpx boundary."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    # Mock the AA boundary. Returns scores that match real catalog ids
+    # so resolver tests can verify routing actually changes.
+    from packages.litellm_adapter import quality_index
+    quality_index.reset_cache()
+
+    aa_payload = [
+        {"name": "Claude Opus 4.7 (max)",
+         "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        {"name": "Claude Opus 4.7 (Non-reasoning, high)",
+         "evaluations": {"artificial_analysis_intelligence_index": 52}},
+        {"name": "GPT-4o",
+         "evaluations": {"artificial_analysis_intelligence_index": 41}},
+        {"name": "Claude 3.5 Haiku",
+         "evaluations": {"artificial_analysis_intelligence_index": 28}},
+    ]
+
+    fetch_calls = {"n": 0}
+
+    async def _fake_aa(url, api_key, timeout=10.0):
+        fetch_calls["n"] += 1
+        return aa_payload
+
+    monkeypatch.setattr(quality_index, "_fetch_remote", _fake_aa)
+
+    from app.main import create_app
+    app = create_app()
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        yield c, seed.api_key, fetch_calls
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
+# ── GET /v1/quality (status + table) ──────────────────────────────────
+
+
+async def test_status_reports_aa_index_configured(quality_client):
+    """When AA key is set, status shows source=live + matched count > 0."""
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["aa_index"]["source"] == "live"
+    assert body["aa_index"]["configured"] is True
+    assert body["aa_index"]["matched_count"] >= 1, (
+        "at least one of our mocked AA names should match the live catalog"
+    )
+    assert "models" in body and len(body["models"]) > 100, (
+        "table should include the full chat-model catalog"
+    )
+    assert body["attribution"]["url"] == "https://artificialanalysis.ai"
+
+
+async def test_status_each_row_has_score_and_cost_columns(quality_client):
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality")
+    body = r.json()
+    sample = body["models"][0]
+    for required in (
+        "id", "provider", "blended_cost", "input_cost_per_token",
+        "output_cost_per_token", "aa_score", "manual_score", "effective_score",
+        "deployable", "supports_tools", "supports_vision",
+    ):
+        assert required in sample, f"missing column: {required}"
+
+
+async def test_status_sorted_by_effective_score_desc(quality_client):
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality")
+    rows = r.json()["models"]
+    # First several rows must be the scored models, descending.
+    scored = [row for row in rows if row["effective_score"] is not None]
+    assert len(scored) >= 2
+    for i in range(len(scored) - 1):
+        assert scored[i]["effective_score"] >= scored[i + 1]["effective_score"]
+    # Unscored rows come after scored ones.
+    if any(row["effective_score"] is None for row in rows):
+        last_scored_idx = max(
+            i for i, row in enumerate(rows) if row["effective_score"] is not None
+        )
+        first_unscored_idx = min(
+            i for i, row in enumerate(rows) if row["effective_score"] is None
+        )
+        assert last_scored_idx < first_unscored_idx
+
+
+# ── POST /v1/quality/refresh ──────────────────────────────────────────
+
+
+async def test_refresh_forces_a_new_aa_fetch(quality_client):
+    client, _, fetch_calls = quality_client
+    # Prime the cache via a status call.
+    await client.get("/v1/quality")
+    n_after_status = fetch_calls["n"]
+    assert n_after_status == 1
+
+    # Status again — cached, no new fetch.
+    await client.get("/v1/quality")
+    assert fetch_calls["n"] == 1, "cache should serve second status"
+
+    # Refresh — bypasses cache.
+    r = await client.post("/v1/quality/refresh")
+    assert r.status_code == 200
+    assert r.json()["aa_index"]["source"] == "live"
+    assert fetch_calls["n"] == 2, "refresh must trigger a fresh fetch"
+
+
+# ── GET /v1/quality/auto-preview ──────────────────────────────────────
+
+
+async def test_auto_preview_returns_primary_and_fallbacks(quality_client):
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality/auto-preview")
+    assert r.status_code == 200
+    body = r.json()
+    assert "strategy" in body
+    assert "primary" in body
+    assert "fallbacks" in body
+    assert "scoring_source" in body
+
+
+async def test_auto_preview_uses_aa_scores_under_quality_strategy(quality_client, monkeypatch):
+    """Switch the workspace strategy to 'quality' and verify the preview
+    picks a model AA scored highly, not the legacy most-expensive."""
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.routing_config import RoutingConfig
+
+    factory = session_mod._session_factory
+    async with factory() as s:
+        cfg_row = (await s.execute(select(RoutingConfig))).scalar_one()
+        cfg_row.strategy = "quality"
+        await s.commit()
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality/auto-preview")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["strategy"] == "quality"
+    assert body["scoring_source"] == "quality_scores"
+    # The primary should be a model that AA scored. Concrete name depends
+    # on what's in the live catalog vs what our mock AA payload covers,
+    # but we can at least assert the score is non-null.
+    assert body["primary"] is not None
+    assert body["primary_score"] is not None
+    assert body["primary_score"] >= 28, (
+        "primary should match one of our mocked AA-scored models"
+    )
+
+
+# ── overrides CRUD ────────────────────────────────────────────────────
+
+
+async def test_put_override_then_get_lists_it(quality_client):
+    client, _, _ = quality_client
+    r = await client.put(
+        "/v1/quality/overrides/gpt-4o",
+        json={"score": 88.5, "note": "our internal eval beats AA"},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["model_id"] == "gpt-4o"
+    assert r.json()["score"] == 88.5
+
+    listing = await client.get("/v1/quality/overrides")
+    assert listing.status_code == 200
+    assert any(o["model_id"] == "gpt-4o" and o["score"] == 88.5
+               for o in listing.json()["overrides"])
+
+
+async def test_put_override_appears_in_status_table_as_effective(quality_client):
+    client, _, _ = quality_client
+    await client.put("/v1/quality/overrides/gpt-4o", json={"score": 88.5})
+    r = await client.get("/v1/quality")
+    rows = r.json()["models"]
+    gpt4o = next(row for row in rows if row["id"] == "gpt-4o")
+    assert gpt4o["manual_score"] == 88.5
+    assert gpt4o["effective_score"] == 88.5, (
+        "manual override must take precedence over AA score in effective"
+    )
+
+
+async def test_delete_override_reverts_effective_to_aa(quality_client):
+    client, _, _ = quality_client
+    # Set + verify
+    await client.put("/v1/quality/overrides/gpt-4o", json={"score": 88.5})
+    r1 = await client.get("/v1/quality")
+    gpt4o_1 = next(row for row in r1.json()["models"] if row["id"] == "gpt-4o")
+    assert gpt4o_1["effective_score"] == 88.5
+
+    # Delete + verify revert
+    r_del = await client.delete("/v1/quality/overrides/gpt-4o")
+    assert r_del.status_code == 204
+
+    r2 = await client.get("/v1/quality")
+    gpt4o_2 = next(row for row in r2.json()["models"] if row["id"] == "gpt-4o")
+    assert gpt4o_2["manual_score"] is None
+    # effective_score reverts to AA's score (41 in our mock payload).
+    assert gpt4o_2["effective_score"] == 41
+
+
+async def test_put_override_rejects_unknown_model(quality_client):
+    client, _, _ = quality_client
+    r = await client.put(
+        "/v1/quality/overrides/totally-fake-model-xyz",
+        json={"score": 50.0},
+    )
+    assert r.status_code == 404
+
+
+async def test_delete_unknown_override_is_noop_204(quality_client):
+    """Operator's intent ('no override on this model') is satisfied
+    whether the row existed or not. 204 either way."""
+    client, _, _ = quality_client
+    r = await client.delete("/v1/quality/overrides/never-set-this")
+    assert r.status_code == 204
+
+
+async def test_override_score_validation_bounds(quality_client):
+    """Scores must be 0-100 (matches AA's Intelligence Index scale)."""
+    client, _, _ = quality_client
+    r_too_high = await client.put(
+        "/v1/quality/overrides/gpt-4o", json={"score": 150.0}
+    )
+    assert r_too_high.status_code == 422
+    r_negative = await client.put(
+        "/v1/quality/overrides/gpt-4o", json={"score": -5.0}
+    )
+    assert r_negative.status_code == 422
+
+
+# ── full integration: override changes routing ────────────────────────
+
+
+async def test_override_actually_changes_auto_preview(quality_client):
+    """The whole point of overrides: setting one must change which model
+    auto would pick under quality strategy. End-to-end round trip."""
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.routing_config import RoutingConfig
+
+    factory = session_mod._session_factory
+    async with factory() as s:
+        cfg_row = (await s.execute(select(RoutingConfig))).scalar_one()
+        cfg_row.strategy = "quality"
+        await s.commit()
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    client, _, _ = quality_client
+    r1 = await client.get("/v1/quality/auto-preview")
+    primary_before = r1.json()["primary"]
+
+    # Find a deployable model that's NOT currently the primary, override
+    # its score to 99 (above AA's max), and re-preview.
+    status = (await client.get("/v1/quality")).json()
+    deployable_ids = [row["id"] for row in status["models"] if row["deployable"]]
+    other_choice = next(mid for mid in deployable_ids if mid != primary_before)
+
+    await client.put(
+        f"/v1/quality/overrides/{other_choice}",
+        json={"score": 99.0, "note": "force this for integration test"},
+    )
+
+    r2 = await client.get("/v1/quality/auto-preview")
+    assert r2.json()["primary"] == other_choice, (
+        f"override should have flipped primary from {primary_before} to {other_choice}, "
+        f"got {r2.json()['primary']}"
+    )

--- a/tests/unit/test_auto_routing.py
+++ b/tests/unit/test_auto_routing.py
@@ -276,6 +276,98 @@ def test_choose_model_caps_results_at_top_n():
     assert chosen == ["m0", "m1", "m2"]
 
 
+def test_quality_strategy_uses_quality_scores_when_provided():
+    """The motivating bug: with cost-based proxy, `claude-opus-4-20250514`
+    ($5.7e-5) outranks `claude-opus-4-7` ($1.9e-5, 3x cheaper). With
+    real AA scores, 4-7 (score 57) must win over the older Opus 4."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        # Old Opus 4: more expensive, lower benchmark score.
+        CatalogModel("claude-opus-4-old", "anthropic", "anthropic/",
+                     True, False, False, 1.5e-5, 7.5e-5),
+        # New Opus 4.7: cheaper but stronger.
+        CatalogModel("claude-opus-4-7", "anthropic", "anthropic/",
+                     True, False, False, 5e-6, 2.5e-5),
+    ]
+    deployable = {"claude-opus-4-old", "claude-opus-4-7"}
+    quality_scores = {"claude-opus-4-7": 57.0, "claude-opus-4-old": 47.0}
+
+    chosen = choose_auto_model(
+        needs=set(), deployable=deployable, candidates=candidates,
+        strategy="quality", quality_scores=quality_scores,
+    )
+    assert chosen[0] == "claude-opus-4-7", (
+        "AA scores must override cost-as-quality-proxy"
+    )
+
+
+def test_quality_strategy_falls_back_to_cost_when_scores_empty():
+    """Backward compatibility: when no AA key is configured, scores arrive
+    as None or {} → quality reverts to the legacy 'most expensive first'
+    behavior. The system still works, just less accurately."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+        CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen_none = choose_auto_model(
+        needs=set(), deployable={"cheap", "expensive"}, candidates=candidates,
+        strategy="quality", quality_scores=None,
+    )
+    chosen_empty = choose_auto_model(
+        needs=set(), deployable={"cheap", "expensive"}, candidates=candidates,
+        strategy="quality", quality_scores={},
+    )
+    assert chosen_none[0] == "expensive"
+    assert chosen_empty[0] == "expensive"
+
+
+def test_quality_unscored_models_drop_below_scored():
+    """Models with no AA score (e.g. niche providers AA doesn't track)
+    aren't excluded from quality routing — they just rank below any
+    scored model. Better than disappearing them."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("scored-low", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("unscored-expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+        CatalogModel("scored-high", "openai", "openai/", True, False, False, 1e-6, 3e-6),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"scored-low", "unscored-expensive", "scored-high"},
+        candidates=candidates,
+        strategy="quality",
+        quality_scores={"scored-high": 57.0, "scored-low": 30.0},
+    )
+    # Top 3: scored-high (57), scored-low (30), unscored-expensive (0).
+    assert chosen == ["scored-high", "scored-low", "unscored-expensive"]
+
+
+def test_quality_cost_breaks_score_ties():
+    """Equal AA scores → break the tie by cost desc (more expensive
+    among equally-scored models tends to be the flagship variant
+    rather than a smaller distillation)."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("flagship", "openai", "openai/", True, False, False, 1e-5, 3e-5),
+        CatalogModel("distill", "openai", "openai/", True, False, False, 1e-7, 4e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(), deployable={"flagship", "distill"}, candidates=candidates,
+        strategy="quality",
+        quality_scores={"flagship": 57.0, "distill": 57.0},
+    )
+    assert chosen[0] == "flagship", "tie-break: more expensive wins"
+
+
 def test_choose_model_default_top_n_is_5():
     """Default cap of 5 keeps the LiteLLM fallbacks list at a reasonable length."""
     from app.auto_routing import choose_auto_model

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -1,0 +1,627 @@
+"""Unit tests for the AA quality-index fetcher + name normalization.
+
+Per the no-mock-of-layer-under-test rule: we mock at the httpx transport
+boundary (the network layer), not at `_fetch_remote` (the module's own
+internal helper). That way the real JSON-parse + schema-validation +
+score-aggregation code runs end-to-end. A test that monkeypatches
+`_fetch_remote` directly would hide the very logic the AA fetcher exists
+to do — and exactly that kind of skip caused the empty-response-poisoning
+regression we now guard against.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+import httpx
+import pytest
+
+
+def _patch_aa_transport(monkeypatch, handler: Callable[[httpx.Request], httpx.Response]) -> None:
+    """Swap `httpx.AsyncClient` (as used by `quality_index`) with a wrapper
+    that injects an `httpx.MockTransport`. Lets us drive AA responses
+    without touching the network OR the module's own `_fetch_remote` helper."""
+    from packages.litellm_adapter import quality_index
+
+    real_async_client = httpx.AsyncClient
+    transport = httpx.MockTransport(handler)
+
+    def _factory(*args: Any, **kwargs: Any) -> httpx.AsyncClient:
+        kwargs["transport"] = transport
+        return real_async_client(*args, **kwargs)
+
+    monkeypatch.setattr(quality_index.httpx, "AsyncClient", _factory)
+
+
+def _aa_response(payload: list[dict] | dict | None, *, status: int = 200) -> httpx.Response:
+    """Build an AA-shaped HTTP response. AA wraps the model list under
+    `data`; pass a list to use the standard envelope, a dict for raw
+    bodies (testing schema-mismatch paths), or None for an empty body."""
+    if payload is None:
+        return httpx.Response(status, json={"data": []})
+    if isinstance(payload, list):
+        return httpx.Response(status, json={"data": payload})
+    return httpx.Response(status, json=payload)
+
+# ── name normalization ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "aa_name,expected",
+    [
+        ("Claude Opus 4.7 (max)", "claude-opus-4-7"),
+        ("Claude Opus 4.7", "claude-opus-4-7"),
+        ("GPT-5.5 (xhigh)", "gpt-5-5"),
+        ("Claude Sonnet 4.6 (max)", "claude-sonnet-4-6"),
+        ("Gemini 3.1 Pro Preview", "gemini-3-1-pro-preview"),
+        ("DeepSeek V4 Pro (Max)", "deepseek-v4-pro"),
+        ("Claude Opus 4.7 (Non-reasoning, high)", "claude-opus-4-7"),
+        # Trailing whitespace / multiple spaces
+        ("  GPT-4o  ", "gpt-4o"),
+    ],
+)
+def test_normalize_aa_id(aa_name, expected):
+    from packages.litellm_adapter.quality_index import _normalize_aa_id
+    assert _normalize_aa_id(aa_name) == expected
+
+
+# ── catalog matching ──────────────────────────────────────────────────
+
+
+def test_match_catalog_id_exact():
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+    assert _match_catalog_id("gpt-4o", {"gpt-4o", "claude-opus-4-7"}) == "gpt-4o"
+
+
+def test_match_catalog_id_strips_prefix():
+    """Defensive: catalog ids are already stripped at load time, but the
+    helper accepts prefixed forms in case AA ever returns one."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+    assert _match_catalog_id("openai/gpt-4o", {"gpt-4o"}) == "gpt-4o"
+
+
+def test_match_catalog_id_family_fallback():
+    """`claude-opus-4-7` (AA's bare name) maps to `claude-opus-4-7-20260416`
+    when only the dated form is in the catalog."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+    catalog = {"claude-opus-4-7-20260416"}
+    assert _match_catalog_id("claude-opus-4-7", catalog) == "claude-opus-4-7-20260416"
+
+
+def test_match_catalog_id_no_match():
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+    assert _match_catalog_id("totally-fake", {"gpt-4o"}) is None
+
+
+# ── score aggregation: max across reasoning-effort variants ───────────
+
+
+def test_build_score_map_takes_max_across_variants():
+    """AA splits the same model into separate rows by reasoning effort
+    (e.g. 'GPT-5.5 (xhigh)' = 60 vs 'GPT-5.5 (low)' = 51). Our routing
+    picks a model_name not an effort, so we keep the highest score per
+    base model — the operator can always set effort separately."""
+    from packages.litellm_adapter.quality_index import _build_score_map
+
+    aa = [
+        {"name": "GPT-5.5 (xhigh)",
+         "evaluations": {"artificial_analysis_intelligence_index": 60}},
+        {"name": "GPT-5.5 (high)",
+         "evaluations": {"artificial_analysis_intelligence_index": 59}},
+        {"name": "GPT-5.5 (low)",
+         "evaluations": {"artificial_analysis_intelligence_index": 51}},
+    ]
+    catalog = {"gpt-5-5"}
+    scores, raw, matched = _build_score_map(aa, catalog)
+    assert scores == {"gpt-5-5": 60.0}, "must keep the max across variants"
+    assert raw == 3
+    assert matched == 1
+
+
+def test_build_score_map_skips_unmatched():
+    """Models that don't map to any catalog id are dropped — no point
+    surfacing scores we can't act on."""
+    from packages.litellm_adapter.quality_index import _build_score_map
+
+    aa = [
+        {"name": "Some Future Model X",
+         "evaluations": {"artificial_analysis_intelligence_index": 70}},
+        {"name": "Claude Opus 4.7 (max)",
+         "evaluations": {"artificial_analysis_intelligence_index": 57}},
+    ]
+    catalog = {"claude-opus-4-7"}
+    scores, raw, matched = _build_score_map(aa, catalog)
+    assert scores == {"claude-opus-4-7": 57.0}
+    assert raw == 2
+    assert matched == 1
+
+
+def test_build_score_map_skips_missing_score():
+    """AA entries without an intelligence_index field (e.g. brand-new
+    additions, deprecated rows) are skipped — better to omit than to
+    invent a fake score."""
+    from packages.litellm_adapter.quality_index import _build_score_map
+
+    aa = [
+        {"name": "Claude Opus 4.7 (max)", "evaluations": {}},
+        {"name": "GPT-5"},  # no evaluations at all
+    ]
+    catalog = {"claude-opus-4-7", "gpt-5"}
+    scores, _raw, matched = _build_score_map(aa, catalog)
+    assert scores == {}
+    assert matched == 0
+
+
+# ── end-to-end fetch with httpx mocked at the boundary ────────────────
+
+
+async def test_fetch_remote_accepts_bare_list_envelope(monkeypatch):
+    """AA's docs imply `{data: [...]}` but some endpoints return a bare
+    `[...]`. Real `_fetch_remote` must accept both — running the real
+    parser through the boundary mock catches a regression here that a
+    `_fetch_remote` monkeypatch would silently miss."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # Bare top-level array (no `data` wrapper).
+        return httpx.Response(200, json=[
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+    idx = await quality_index.get_quality_index(catalog_ids={"claude-opus-4-7"})
+    assert idx.source == "live"
+    assert idx.scores == {"claude-opus-4-7": 57.0}
+
+
+async def test_fetch_remote_unknown_schema_falls_through_to_stale(monkeypatch, db_session):
+    """If AA changes the response shape entirely (e.g., wraps under
+    `result.models` instead of `data`), our parser must treat it as a
+    fetch failure rather than persist `{}`. Verifies the real
+    `_AAFetchUnusable` raise path through the transport boundary."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "live"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "schema-changed":
+            # Neither bare list nor `{data: list}` — totally unknown shape.
+            return httpx.Response(200, json={"result": {"models": []}})
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime DB with a real snapshot.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+
+    # AA changes shape after a deploy on their side.
+    quality_index.reset_cache()
+    state["mode"] = "schema-changed"
+
+    idx = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default", force_refresh=True,
+    )
+    assert idx.source == "stale-db", "schema mismatch must fall through to stale, not poison snapshot"
+    assert idx.scores == {"claude-opus-4-7": 57.0}
+
+
+async def test_get_quality_index_returns_missing_key_when_unconfigured(monkeypatch):
+    """No API key → no fetch attempt. Source flag tells the dashboard
+    to render the 'configure AA' setup card."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "")
+    cfg.get_settings.cache_clear()
+
+    idx = await quality_index.get_quality_index(catalog_ids={"gpt-4o"})
+    assert idx.source == "missing-key"
+    assert idx.scores == {}
+
+
+async def test_get_quality_index_fetches_and_caches(monkeypatch):
+    """Real fetch + cache flow: first call drives the AA-shaped HTTP mock
+    through the real `_fetch_remote` parser; second call within TTL
+    returns cached value without re-issuing the request."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    fetch_calls = {"n": 0, "last_key": None}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetch_calls["n"] += 1
+        fetch_calls["last_key"] = request.headers.get("x-api-key")
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+            {"name": "GPT-4o",
+             "evaluations": {"artificial_analysis_intelligence_index": 50}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    idx1 = await quality_index.get_quality_index(catalog_ids={"claude-opus-4-7", "gpt-4o"})
+    assert idx1.source == "live"
+    assert idx1.scores == {"claude-opus-4-7": 57.0, "gpt-4o": 50.0}
+    assert fetch_calls["n"] == 1
+    # Confirms the real _fetch_remote ran and forwarded our key header —
+    # if we'd monkeypatched _fetch_remote we'd never know.
+    assert fetch_calls["last_key"] == "sk-aa-test"
+
+    # Second call within TTL → cached, no fetch.
+    idx2 = await quality_index.get_quality_index(catalog_ids={"claude-opus-4-7", "gpt-4o"})
+    assert idx2.scores == idx1.scores
+    assert fetch_calls["n"] == 1, "cache hit should not refetch"
+
+    # force_refresh bypasses cache.
+    idx3 = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7", "gpt-4o"}, force_refresh=True
+    )
+    assert idx3.scores == idx1.scores
+    assert fetch_calls["n"] == 2
+
+
+async def test_db_snapshot_persists_across_in_process_cache_reset(monkeypatch, db_session):
+    """The point of the DB layer: docker compose down/up shouldn't burn an
+    AA fetch if we already have fresh data. Simulate process restart by
+    clearing the in-process cache and verify the next call is served from
+    DB without hitting AA again."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    fetch_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetch_calls["n"] += 1
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # First call: fetch + persist to DB.
+    idx1 = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default",
+    )
+    assert idx1.source == "live"
+    assert fetch_calls["n"] == 1
+
+    # Simulate process restart: nuke the in-process cache. DB row remains.
+    quality_index.reset_cache()
+
+    # Next call must serve from DB without re-fetching.
+    idx2 = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default",
+    )
+    assert fetch_calls["n"] == 1, "DB snapshot should serve cold-start, not refetch"
+    assert idx2.scores == {"claude-opus-4-7": 57.0}
+
+
+async def test_db_snapshot_invalidated_on_key_rotation(monkeypatch, db_session):
+    """A snapshot fetched under AA key A must NOT be served when the
+    operator rotates to AA key B. Different account = potentially
+    different model coverage / scores."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-key-A")
+    cfg.get_settings.cache_clear()
+
+    fetch_calls = {"n": 0, "last_key": None}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetch_calls["n"] += 1
+        fetch_calls["last_key"] = request.headers.get("x-api-key")
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime under key A.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert fetch_calls["n"] == 1
+    assert fetch_calls["last_key"] == "sk-aa-key-A"
+
+    # Rotate the key, clear in-process cache (simulating a config reload).
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-key-B")
+    cfg.get_settings.cache_clear()
+    quality_index.reset_cache()
+
+    # New key → DB row from key A must be ignored, must refetch.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert fetch_calls["n"] == 2
+    assert fetch_calls["last_key"] == "sk-aa-key-B"
+
+
+async def test_db_snapshot_freshness_uses_wall_clock_not_monotonic(monkeypatch, db_session):
+    """Cross-process correctness regression test.
+
+    `time.monotonic()` is per-process (zero point varies). If the freshness
+    check used the saved monotonic value vs the current process's monotonic
+    clock, a snapshot from a long-running process would always look "fresh"
+    after restart (smaller new-process monotonic minus larger saved
+    monotonic = negative, < TTL, looks fresh) — defeating the TTL entirely.
+
+    This test pre-ages the DB row's `updated_at` to 2h in the past
+    (beyond the 1h TTL) and verifies the resolver REFETCHES rather than
+    serving the stale row as fresh.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    from sqlalchemy import select
+
+    from app import config as cfg
+    from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    fetch_calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        fetch_calls["n"] += 1
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # 1. Prime the DB with a snapshot.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert fetch_calls["n"] == 1
+
+    # 2. Simulate the row being old: rewrite updated_at to 2h ago.
+    row = (await db_session.execute(select(QualityScoreSnapshot))).scalar_one()
+    row.updated_at = datetime.now(timezone.utc) - timedelta(hours=2)
+    await db_session.commit()
+
+    # 3. Simulate process restart by clearing in-process cache.
+    quality_index.reset_cache()
+
+    # 4. Next call must REFETCH because the DB row is older than TTL by
+    # wall-clock. If freshness used monotonic, the test would fail here:
+    # the saved monotonic value would be tiny vs current monotonic, the
+    # subtraction would underflow / be ignored, and the stale row would
+    # be served as fresh.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert fetch_calls["n"] == 2, (
+        "DB row older than TTL must trigger AA refetch; freshness check must "
+        "use wall-clock (updated_at) not per-process monotonic time"
+    )
+
+
+async def test_aa_failure_falls_back_to_db_snapshot(monkeypatch, db_session):
+    """When AA is unreachable AND the in-process cache is cold, the DB
+    snapshot is the last line of defense before degrading to cost-based.
+    Source flag tells the dashboard the data is stale."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "live"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "fail":
+            # Simulate AA outage at the network layer (5xx is what the
+            # SDK actually gets, not a Python exception).
+            return httpx.Response(503, json={"error": "service unavailable"})
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime DB with a successful fetch.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+
+    # Simulate process restart + AA outage.
+    quality_index.reset_cache()
+    state["mode"] = "fail"
+
+    idx = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default", force_refresh=True,
+    )
+    assert idx.source == "stale-db", (
+        "must flag the source as DB-stale so the dashboard can show 'AA outage'"
+    )
+    assert idx.scores == {"claude-opus-4-7": 57.0}
+
+
+async def test_empty_aa_response_does_not_poison_db_snapshot(monkeypatch, db_session):
+    """Regression: AA returning an empty list (transient outage, quota
+    exceeded with 200, schema regression) used to be treated as a healthy
+    fetch and persisted as `{}` over the existing good snapshot. Next
+    restart would then serve `{}` from DB and quality routing would
+    silently degrade to cost-based.
+
+    The fix: empty raw / zero-matched results raise `_AAFetchUnusable`,
+    which routes through the stale-fallback path. The good DB snapshot
+    is preserved, and the operator sees source='stale-db' in the
+    dashboard so they know AA is unreachable.
+    """
+    from sqlalchemy import select
+
+    from app import config as cfg
+    from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "live"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "empty":
+            return _aa_response([])  # AA returns 200 with `{"data": []}`
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # 1. Prime the DB with a real snapshot.
+    idx_live = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert idx_live.source == "live"
+    assert idx_live.scores == {"claude-opus-4-7": 57.0}
+
+    # 2. Simulate process restart + AA glitch returning empty data.
+    quality_index.reset_cache()
+    state["mode"] = "empty"
+
+    idx_after = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default", force_refresh=True,
+    )
+
+    # Must serve the stale snapshot, not poison-overwrite with `{}`.
+    assert idx_after.source == "stale-db"
+    assert idx_after.scores == {"claude-opus-4-7": 57.0}, (
+        "empty AA fetch must not overwrite existing DB snapshot"
+    )
+
+    # And the DB row must still hold the good data, not `{}`.
+    row = (await db_session.execute(select(QualityScoreSnapshot))).scalar_one()
+    import json as _json
+    assert _json.loads(row.scores_json) == {"claude-opus-4-7": 57.0}, (
+        "DB snapshot must not have been overwritten with empty score map"
+    )
+
+
+async def test_aa_response_with_no_catalog_matches_does_not_poison_snapshot(monkeypatch, db_session):
+    """Regression: AA returning entries that all fail to map to our
+    catalog (normalization regression after AA renames) used to persist
+    `{}` and silently disable quality routing. Now treated as a fetch
+    failure → stale fallback runs.
+    """
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "live"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "renamed":
+            # AA renamed everything; nothing maps to our catalog.
+            return _aa_response([
+                {"name": "Brand-New Provider Model X",
+                 "evaluations": {"artificial_analysis_intelligence_index": 70}},
+            ])
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime DB with a good snapshot.
+    await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+
+    # Process restart + AA "renamed everything" regression.
+    quality_index.reset_cache()
+    state["mode"] = "renamed"
+
+    idx = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default", force_refresh=True,
+    )
+    assert idx.source == "stale-db", (
+        "zero matched_count must be treated as failure, not silently overwrite snapshot"
+    )
+    assert idx.scores == {"claude-opus-4-7": 57.0}
+
+
+async def test_get_quality_index_serves_stale_on_failure(monkeypatch):
+    """AA having a bad day shouldn't disable quality routing entirely.
+    Within the stale-grace window, return the last known good values
+    with source='stale-cache'."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "live"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "fail":
+            # 5xx is what AA actually serves on outage; the SDK will
+            # raise via raise_for_status() and our except branch runs.
+            return httpx.Response(503, json={"error": "service unavailable"})
+        return _aa_response([
+            {"name": "Claude Opus 4.7 (max)",
+             "evaluations": {"artificial_analysis_intelligence_index": 57}},
+        ])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime the cache.
+    idx_live = await quality_index.get_quality_index(catalog_ids={"claude-opus-4-7"})
+    assert idx_live.source == "live"
+
+    # Now break AA, force refresh — must serve stale.
+    state["mode"] = "fail"
+    idx_stale = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, force_refresh=True,
+    )
+    assert idx_stale.source == "stale-cache"
+    assert idx_stale.scores == {"claude-opus-4-7": 57.0}, "stale value preserved"


### PR DESCRIPTION
## Summary

The `quality` strategy used to pick the most expensive deployable model on the assumption that newer flagships cost more than older ones. Anthropic and OpenAI broke that assumption (Opus 4.7 is 3x cheaper than Opus 4 from May 2024 yet measurably stronger), so quality routes were silently picking worse models for more money — see #16.

This PR wires the **Artificial Analysis Intelligence Index** (a real benchmark aggregator: MMLU-Pro, GPQA, MATH, HumanEval) as the scoring source, with operator manual overrides on top.

## What changes for the developer

- **Without an AA key**: nothing breaks. `quality` falls back to the legacy cost-based behavior. `cheapest` / `balanced` / `fastest` are unaffected. Manual overrides still work standalone.
- **With an AA key** (`ARTIFICIAL_ANALYSIS_API_KEY=...` in `.env`, free tier 1000 req/day at https://artificialanalysis.ai): `quality` strategy ranks deployable models by real benchmark scores. `model="auto"` picks the highest-scored model your provider keys can serve.
- **New Quality dashboard tab** (shortcut `6`): AA freshness status, live preview of what `model="auto"` resolves to right now, full table of scored catalog models with inline manual override edit.

## Architecture

**Three-layer cache** (in `packages/litellm_adapter/quality_index.py`):
1. In-process dict (1h TTL) — fast, single-process
2. DB snapshot (`quality_score_snapshots` table, portable across SQLite/Postgres/MySQL) — survives `docker compose down/up` so the operator's daily AA quota isn't burned on every restart
3. AA `/api/v2/data/llms/models` — fresh truth

**Resilience:**
- Empty / schema-mismatched / zero-matched AA responses raise an internal exception that routes through stale-fallback rather than overwriting a good DB snapshot with `{}`
- Freshness uses wall-clock (`updated_at`), not `time.monotonic()` — required for cross-process correctness
- AA key rotation invalidates DB rows via `api_key_hash` so a snapshot taken under one account isn't served under another
- `IntegrityError` retry on override PUT for race-safe concurrent operator edits

**Manual overrides** (`packages/db/models/quality_score_override.py`):
- Per (workspace, model_id), score 0-100 with optional rationale note
- Win unconditionally over AA scores for routing decisions
- CRUD via `/v1/quality/overrides/{model_id}` — idempotent upserts via `session.merge()`

## Test plan

- [x] `PYTHONPATH=. pytest tests/unit/test_quality_index.py` — 26 unit tests pass (AA fetcher, cache layers, regression tests for cross-process monotonic clock bug + empty-AA poisoning + cross-DB session lifecycle)
- [x] `PYTHONPATH=. pytest tests/integration/test_quality_routes.py` — 15 integration tests pass (CRUD, key rotation, AA outage, dashboard fetch)
- [x] `PYTHONPATH=. pytest tests/unit/test_auto_routing.py` — 4 new tests cover `quality_scores` parameter behavior
- [x] `PYTHONPATH=. ruff check app/ packages/ tests/` clean
- [x] Two rounds of `/codex` review (HIGH + 3 MED found in round 1, all fixed; round 2 clean)
- [ ] Manual: with AA key configured, `model="auto"` under `quality` strategy picks the highest-scoring deployable model (verifiable in dashboard auto-preview tile)
- [ ] Manual: dashboard Quality tab loads, shows freshness status, manual override edit/reset round-trips, refresh button forces an AA refetch

Closes #16.