### PR TITLE
Plumb LiteLLM cost through, dedupe sibling versions, fix dev-hostile defaults

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,9 +51,10 @@ LOG_LEVEL=info
 
 # ── Router behavior (cooldown + cascade) ──────────────
 # How long a deployment is skipped after a failure (404 / 408 / 429 / 401).
-# Default 1h is safe for prod. Lower for local dev (network blips shouldn't
-# lock a model out for an hour); set 0 in tests.
-# ROUTER_COOLDOWN_SECONDS=3600
+# Default 60s is dev-friendly — a bad key recovers in a minute, no need to
+# restart the process. Production under sustained traffic should bump this
+# to 600-3600 to avoid burning quota on a known-dead model. Tests set 0.
+# ROUTER_COOLDOWN_SECONDS=60
 # ROUTER_ALLOWED_FAILS=0
 # ROUTER_PRE_CALL_CHECKS=true
 # In-deployment retry counts. The "auto" path uses 0 so cascade to the

--- a/app/auto_routing.py
+++ b/app/auto_routing.py
@@ -20,9 +20,64 @@ Adapted from `apps/api/routes/chat.py:_required_capabilities` /
 
 from __future__ import annotations
 
+import re
 from collections.abc import Iterable
 
 from packages.litellm_adapter.catalog import CatalogModel
+
+# Suffix shapes that mark a model id as a more-specific *version* of a base
+# model rather than a different model. Matched against the substring AFTER
+# `base + "-"` in a candidate id. Shared with the prompt-cache canonicalization
+# in chat.py so both layers agree on what counts as "same model, different
+# version stamp."
+#   "2024-08-06"   — OpenAI dated version
+#   "20241022"     — Anthropic dated version (compact form)
+#   "001" / "002"  — Google Vertex / Gemini revision suffix (always 3+ digits)
+#   "v1.5"         — Generic version tag
+#
+# What we deliberately do NOT collapse:
+#   "turbo"        — distinct catalog model, not a version variant
+#   "latest"       — request-side alias only
+#   "mini"         — branding suffix
+#   single digits  — Anthropic uses these for semantic version (claude-opus-4-7
+#                    is NOT a version of claude-opus-4 — they're different
+#                    models). Rev-codes are always 3+ digits.
+_VERSION_SUFFIX_RE = re.compile(
+    r"^("
+    r"\d{4}-\d{2}-\d{2}"     # YYYY-MM-DD
+    r"|\d{6,}"                # YYYYMMDD or compact dates / build numbers
+    r"|\d{3,4}"               # 001, 002, 1234 (revision codes — always 3+ digits)
+    r"|v\d[\d.]*"             # v1, v1.5, v2.0.1
+    r")$"
+)
+
+
+def canonical_model_base(model_id: str) -> str:
+    """Strip a known version suffix to get the model's canonical base id.
+
+    "gemini-2.0-flash-lite-001" -> "gemini-2.0-flash-lite"
+    "gpt-5-nano-2025-08-07"     -> "gpt-5-nano"
+    "claude-opus-4-7"           -> "claude-opus-4-7" (single digits NOT stripped)
+    "claude-3-5-sonnet"         -> "claude-3-5-sonnet" (no change)
+
+    Used to dedupe sibling versions out of the auto-routing fallback list:
+    when the primary picks `gemini-2.0-flash-lite`, we don't want
+    `gemini-2.0-flash-lite-001` as the next fallback (Google rolls them
+    together — they share an outage and just add ~400ms of useless retry
+    latency before the real cross-provider fallback kicks in).
+    """
+    # Try the LONGEST plausible suffix first so the dashed-date pattern
+    # (3 dash-separated segments: YYYY-MM-DD) gets a chance before the
+    # bare-digit pattern matches just the last segment. Cap at 3 segments —
+    # anything longer is overwhelmingly likely to be the model name itself.
+    parts = model_id.split("-")
+    for cut in range(min(len(parts) - 1, 3), 0, -1):
+        suffix = "-".join(parts[-cut:])
+        if _VERSION_SUFFIX_RE.match(suffix):
+            base = "-".join(parts[:-cut])
+            if base:
+                return base
+    return model_id
 
 _CAP_FIELD = {
     "tools": "supports_tools",
@@ -187,4 +242,19 @@ def choose_auto_model(
             eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
     else:
         eligible.sort(key=lambda m: (_blended_cost(m), m.id))
-    return [m.id for m in eligible[:top_n]]
+
+    # Dedupe sibling versions: a model and its dated/numbered variants
+    # ("gemini-2.0-flash-lite" + "...-001", "gpt-5-nano" + "...-2025-08-07")
+    # share an upstream outage. Keeping both in the fallback list just
+    # adds dead-deployment retry latency before the real cross-provider
+    # cascade. Keep the highest-ranked one per canonical base.
+    seen_bases: set[str] = set()
+    deduped: list[CatalogModel] = []
+    for m in eligible:
+        base = canonical_model_base(m.id)
+        if base in seen_bases:
+            continue
+        seen_bases.add(base)
+        deduped.append(m)
+
+    return [m.id for m in deduped[:top_n]]

--- a/app/config.py
+++ b/app/config.py
@@ -82,11 +82,18 @@ class Settings(BaseSettings):
 
     # ── Router behavior (LiteLLM Router cooldown + cascade) ──
     # How long a deployment stays cooled-down after a failure. LiteLLM's
-    # default is 1 second, which is effectively no cooldown — a dead model
-    # gets re-picked on the very next request. Production default is 1h.
-    # Local dev / CI may want lower (network blips shouldn't lock a model
-    # out for an hour); tests should set 0 to disable.
-    router_cooldown_seconds: int = 3600
+    # own default is 1 second (effectively no cooldown — a dead model
+    # gets re-picked on the very next request).
+    #
+    # Our default is 60s — a developer-friendly middle ground:
+    #   - long enough that a genuinely dead model isn't hammered every
+    #     request while you debug
+    #   - short enough that fixing your API key + waiting a minute beats
+    #     restarting the process to clear in-memory cooldowns
+    # Production deployments under sustained traffic should set this to
+    # 600-3600 in `.env` to avoid burning quota on a known-dead model.
+    # Tests should set 0 to disable cooldown entirely.
+    router_cooldown_seconds: int = 60
     # Global default for failures-before-cooldown across all error types,
     # used by LiteLLM Router as the fallback when AllowedFailsPolicy returns
     # a falsy value. We set 0 so the policy's "fail fast on hard errors"

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -20,6 +20,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import prompt_cache, router_cache
 from app.auto_routing import (
     _VERSION_SUFFIX_RE,
+    canonical_model_base,
     choose_auto_model,
     required_capabilities,
 )
@@ -128,7 +129,7 @@ async def _build_log_row(
     Router cascaded to a fallback after a 404 / cooldown.
     """
     latency_ms = int((time.perf_counter() - started_perf) * 1000)
-    meta = response.get("_orca_meta", {})
+    meta = response.get("_orca_meta", {}) or {}
     usage = response.get("usage", {}) or {}
     resolved = actual_resolved or response.get("model") or requested_model
     input_t = usage.get("prompt_tokens", 0) or 0
@@ -143,7 +144,13 @@ async def _build_log_row(
         routing_strategy=strategy,
         input_tokens=input_t,
         output_tokens=output_t,
-        cost_microcents=_compute_cost_microcents(resolved, input_t, output_t),
+        cost_microcents=_compute_cost_microcents(
+            litellm_cost_usd=meta.get("cost_usd"),
+            model_id=resolved,
+            input_tokens=input_t,
+            output_tokens=output_t,
+            fallback_model=requested_model,
+        ),
         latency_ms=meta.get("latency_ms", latency_ms),
         status_code=status_code,
         error_type=error_type,
@@ -151,25 +158,50 @@ async def _build_log_row(
     )
 
 
-def _compute_cost_microcents(model_id: str | None, input_tokens: int, output_tokens: int) -> int:
-    """Compute request cost from token usage and the catalog's per-token prices.
+def _compute_cost_microcents(
+    *,
+    litellm_cost_usd: float | None,
+    model_id: str | None,
+    input_tokens: int,
+    output_tokens: int,
+    fallback_model: str | None = None,
+) -> int:
+    """Cost in microcents (1 USD = 1,000,000).
 
-    Returns 0 when the model isn't in the catalog (LiteLLM may rewrite the
-    response model name to a provider-specific dated alias we don't carry,
-    e.g. "claude-3-5-sonnet-20241022" served against requested
-    "claude-3-5-sonnet-latest"). Try to canonicalize before giving up.
+    Two-tier strategy:
 
-    Per-token pricing in the catalog is USD/token; multiply by 1_000_000
-    to get microcents (1 USD = 1,000,000 microcents — same convention
-    as /v1/analytics/savings's baseline calculation).
+      Tier 1 — `litellm_cost_usd` from the response's _orca_meta. This is
+      LiteLLM's own `_hidden_params.response_cost`, computed in the adapter
+      at the moment LiteLLM Router knew which provider it actually called.
+      Authoritative because it includes:
+        - Anthropic prompt caching (cache_creation = 1.25x base,
+          cache_read = 0.1x base)
+        - OpenAI o1/o3 reasoning tokens (priced separately from output)
+        - Audio input/output token pricing
+        - Provider-specific aliasing — no name-matching guesswork needed
+      We do NOT call `litellm.completion_cost(response)` here: that helper
+      tries to re-derive the provider from the response dict and fails on
+      Anthropic/Gemini bare names ("Provider NOT provided" or
+      "model isn't mapped"), so reverse-lookup is unreliable.
+
+      Tier 2 — `tokens × catalog price` fallback. Used when LiteLLM didn't
+      attach a cost (cache hit served from our prompt cache, exception
+      paths where `_orca_meta` is absent, custom upstreams). Walks four
+      catalog id shapes: as-is, prefix-stripped, version-suffix-stripped,
+      then the original requested model id.
+
+    Returns 0 only when both tiers miss. Negative tokens / negative cost
+    are clamped to 0 (defensive against malformed upstream usage data).
     """
-    if not model_id or input_tokens < 0 or output_tokens < 0:
+    if input_tokens < 0 or output_tokens < 0:
         return 0
-    m = CATALOG_BY_ID.get(model_id)
-    if m is None:
-        # Try stripping a provider prefix ("openai/gpt-4o" -> "gpt-4o").
-        bare = model_id.split("/", 1)[-1] if "/" in model_id else model_id
-        m = CATALOG_BY_ID.get(bare)
+
+    # Tier 1: LiteLLM's authoritative number, plumbed through _orca_meta.
+    if litellm_cost_usd is not None and litellm_cost_usd > 0:
+        return max(0, int(litellm_cost_usd * 1_000_000))
+
+    # Tier 2: catalog × tokens fallback.
+    m = _lookup_priced_model(model_id) or _lookup_priced_model(fallback_model)
     if m is None:
         return 0
     cost_usd = (
@@ -177,6 +209,32 @@ def _compute_cost_microcents(model_id: str | None, input_tokens: int, output_tok
         + output_tokens * m.output_cost_per_token
     )
     return max(0, int(cost_usd * 1_000_000))
+
+
+def _lookup_priced_model(model_id: str | None):
+    """Try four id-shape variants, return the first catalog hit or None.
+
+    Order:
+      1. as-is
+      2. provider-prefix stripped ("openai/gpt-4o" -> "gpt-4o")
+      3. version-suffix stripped (handles "claude-3-5-sonnet-20241022" ->
+         "claude-3-5-sonnet" when the response was a dated alias and only
+         the base form is in our catalog)
+    """
+    if not model_id:
+        return None
+    m = CATALOG_BY_ID.get(model_id)
+    if m is not None:
+        return m
+    bare = model_id.split("/", 1)[-1] if "/" in model_id else model_id
+    if bare != model_id:
+        m = CATALOG_BY_ID.get(bare)
+        if m is not None:
+            return m
+    base = canonical_model_base(bare)
+    if base != bare:
+        return CATALOG_BY_ID.get(base)
+    return None
 
 
 @router.post("/chat/completions")
@@ -381,6 +439,17 @@ async def chat_completions(
     # mid-flight cascade is impossible — we have to surface the error and let
     # the client decide what to do.
     if body.stream:
+        # Auto-inject `stream_options.include_usage=True` if the client
+        # didn't set it. Without this, OpenAI/LiteLLM streaming responses
+        # omit the `usage` field entirely — chunks have no token counts,
+        # so our log row gets input=0, output=0 and the cost calculation
+        # rounds to zero. Almost no client knows to opt-in to this flag,
+        # which would silently zero out streaming spend in the dashboard.
+        # Honor an explicit `include_usage=False` from the client if they
+        # really want to disable it (e.g. wire-format compatibility tests).
+        existing_so = completion_kwargs.get("stream_options") or {}
+        if "include_usage" not in existing_so:
+            completion_kwargs["stream_options"] = {**existing_so, "include_usage": True}
         try:
             stream_obj = await client.acompletion(
                 **completion_kwargs,

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -8,7 +8,6 @@ response in OpenAI's `text/event-stream` format with a terminal
 from __future__ import annotations
 
 import json
-import re
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable
@@ -19,14 +18,18 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import prompt_cache, router_cache
-from app.auto_routing import choose_auto_model, required_capabilities
+from app.auto_routing import (
+    _VERSION_SUFFIX_RE,
+    choose_auto_model,
+    required_capabilities,
+)
 from app.config import get_settings
 from app.deps import get_db, get_key_context
 from app.quality_scores import resolve_quality_scores
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.db.models.request_log import RequestLog
-from packages.litellm_adapter.catalog import CATALOG
+from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
 from packages.litellm_adapter.types import UpstreamProviderError
 
 logger = structlog.get_logger()
@@ -40,30 +43,6 @@ def _chunk_to_dict(chunk) -> dict:
     if hasattr(chunk, "model_dump"):
         return chunk.model_dump(exclude_none=True)
     return dict(chunk)
-
-
-# Suffix shapes that mark a response model as a more-specific *version* of the
-# requested model rather than a different one. Matched against the substring
-# AFTER `requested_group + "-"` in the served name.
-#   "2024-08-06"   — OpenAI dated version
-#   "20241022"     — Anthropic dated version (compact form)
-#   "001" / "002"  — Google Vertex / Gemini revision suffix
-#   "v1.5"         — explicit semver-like version
-#
-# Deliberately excluded:
-#   "preview"      — too ambiguous. "gpt-4-turbo-preview" is a distinct
-#                    catalog model from "gpt-4-turbo", not a version variant.
-#   "latest"       — providers don't return "-latest" in response.model;
-#                    it's only a request-side alias.
-#   "mini" / etc.  — branding suffixes, not versions.
-_VERSION_SUFFIX_RE = re.compile(
-    r"^("
-    r"\d{4}-\d{2}-\d{2}"     # YYYY-MM-DD
-    r"|\d{6,}"                # YYYYMMDD or compact dates / build numbers
-    r"|\d{1,4}"               # 001, 002, 1, 12, ...
-    r"|v\d[\d.]*"             # v1, v1.5, v2.0.1
-    r")$"
-)
 
 
 def _served_same_group_as_requested(
@@ -152,6 +131,8 @@ async def _build_log_row(
     meta = response.get("_orca_meta", {})
     usage = response.get("usage", {}) or {}
     resolved = actual_resolved or response.get("model") or requested_model
+    input_t = usage.get("prompt_tokens", 0) or 0
+    output_t = usage.get("completion_tokens", 0) or 0
     return RequestLog(
         workspace_id=str(kc.workspace_id),
         api_key_id=str(kc.key_id),
@@ -160,14 +141,42 @@ async def _build_log_row(
         model_resolved=resolved,
         provider=meta.get("provider", "unknown"),
         routing_strategy=strategy,
-        input_tokens=usage.get("prompt_tokens", 0),
-        output_tokens=usage.get("completion_tokens", 0),
-        cost_microcents=0,
+        input_tokens=input_t,
+        output_tokens=output_t,
+        cost_microcents=_compute_cost_microcents(resolved, input_t, output_t),
         latency_ms=meta.get("latency_ms", latency_ms),
         status_code=status_code,
         error_type=error_type,
         is_streaming=body.stream,
     )
+
+
+def _compute_cost_microcents(model_id: str | None, input_tokens: int, output_tokens: int) -> int:
+    """Compute request cost from token usage and the catalog's per-token prices.
+
+    Returns 0 when the model isn't in the catalog (LiteLLM may rewrite the
+    response model name to a provider-specific dated alias we don't carry,
+    e.g. "claude-3-5-sonnet-20241022" served against requested
+    "claude-3-5-sonnet-latest"). Try to canonicalize before giving up.
+
+    Per-token pricing in the catalog is USD/token; multiply by 1_000_000
+    to get microcents (1 USD = 1,000,000 microcents — same convention
+    as /v1/analytics/savings's baseline calculation).
+    """
+    if not model_id or input_tokens < 0 or output_tokens < 0:
+        return 0
+    m = CATALOG_BY_ID.get(model_id)
+    if m is None:
+        # Try stripping a provider prefix ("openai/gpt-4o" -> "gpt-4o").
+        bare = model_id.split("/", 1)[-1] if "/" in model_id else model_id
+        m = CATALOG_BY_ID.get(bare)
+    if m is None:
+        return 0
+    cost_usd = (
+        input_tokens * m.input_cost_per_token
+        + output_tokens * m.output_cost_per_token
+    )
+    return max(0, int(cost_usd * 1_000_000))
 
 
 @router.post("/chat/completions")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -29,3 +29,9 @@ class ChatCompletionRequest(BaseModel):
     response_format: dict | None = None
     tools: list[dict] | None = None
     tool_choice: str | dict | None = None
+    # Pass-through for OpenAI's `stream_options` block (e.g.
+    # `{"include_usage": true}`). Without this field declared, Pydantic
+    # silently drops it from the request and our own auto-inject in
+    # chat.py can't see what the client actually asked for, so an
+    # explicit `include_usage=false` from the client gets clobbered.
+    stream_options: dict | None = None

--- a/design/app.js
+++ b/design/app.js
@@ -93,11 +93,18 @@ const $  = (sel, root = document) => root.querySelector(sel);
 const $$ = (sel, root = document) => Array.from(root.querySelectorAll(sel));
 
 const fmtUsd = (mc) => {
+  // Single-tenant dev workloads: a single chat completion can cost
+  // ~$0.000006 (6 microcents). Default $0.00 rendering hides that
+  // entirely until the operator has run hundreds of requests, which
+  // makes the dashboard look broken on day 1. Lean precise on the
+  // small end — a developer reading $0.000148 understands it; a
+  // developer reading $0.00 thinks the meter is busted.
   const usd = (mc || 0) / 1_000_000;
   if (usd === 0) return "$0";
-  if (usd < 0.01) return `$${usd.toFixed(4)}`;
-  if (usd < 1)    return `$${usd.toFixed(3)}`;
-  if (usd < 100)  return `$${usd.toFixed(2)}`;
+  if (usd < 0.001) return `$${usd.toFixed(6)}`;
+  if (usd < 0.01)  return `$${usd.toFixed(5)}`;
+  if (usd < 1)     return `$${usd.toFixed(3)}`;
+  if (usd < 100)   return `$${usd.toFixed(2)}`;
   return `$${Math.round(usd).toLocaleString()}`;
 };
 const fmtNum = (n) => (n || 0).toLocaleString();

--- a/packages/litellm_adapter/client.py
+++ b/packages/litellm_adapter/client.py
@@ -37,10 +37,19 @@ def _build_allowed_fails_policy():
     except Exception:
         return None
     return AllowedFailsPolicy(
-        # 4xx including 404 / model_not_found: deployment is genuinely
-        # broken. Cool down on first failure (requires router default 0).
-        BadRequestErrorAllowedFails=0,
-        # 401: probably a wrong key. Don't keep hammering it.
+        # 4xx is a mixed bucket — LiteLLM lumps these together with no way
+        # to split them in AllowedFailsPolicy:
+        #   - genuine deployment death:   model 404 / deprecated
+        #   - client-side request error:  prompt too long, JSON malformed,
+        #                                 unsupported parameter, model typo
+        # The previous "0 = cool down on first failure" punished a single
+        # client typo with a process-wide deployment freeze — actively
+        # hostile during dev. 10 means a user can typo / oversize-prompt
+        # their way through plenty of mistakes; if the deployment is
+        # actually dead, the 11th failure still cools it within seconds.
+        BadRequestErrorAllowedFails=10,
+        # 401: API key is genuinely wrong / expired. No client-side
+        # confusion possible — really cool down immediately.
         AuthenticationErrorAllowedFails=0,
         # 429: transient rate limit. Tolerate up to 3 in-window before cooling.
         RateLimitErrorAllowedFails=3,
@@ -193,16 +202,36 @@ class OrcaLiteLLMClient:
             return resp
 
         latency_ms = int((time.perf_counter() - started) * 1000)
+        # LiteLLM stashes per-call diagnostics on `_hidden_params` BEFORE we
+        # serialize. Pull what we need out first, because `model_dump()` drops
+        # private-prefixed attrs and we lose them otherwise.
+        #   - response_cost: USD cost LiteLLM computed at the moment it knew
+        #     the resolved provider, including cache_creation/cache_read
+        #     multipliers and reasoning-token pricing. Authoritative.
+        #   - custom_llm_provider: the provider LiteLLM actually routed to
+        #     ("openai", "anthropic", "gemini", ...). Beats our own
+        #     deployment-loop matching, which can mis-attribute when LiteLLM
+        #     rewrites the model name to a dated alias mid-cascade.
+        hidden = getattr(resp, "_hidden_params", {}) or {}
+        litellm_cost_usd = hidden.get("response_cost")
+        litellm_provider = hidden.get("custom_llm_provider")
+
         # Convert litellm's ModelResponse to a plain dict + attach orca metadata.
         out = resp.model_dump() if hasattr(resp, "model_dump") else dict(resp)
-        # Look up which deployment served the request via the resolved model name.
-        provider = "unknown"
-        for d in self._deployments:
-            if d.litellm_model == out.get("model") or d.model_name == out.get("model"):
-                provider = d.provider
-                break
+
+        # Provider attribution: LiteLLM's own field wins. Fall back to a
+        # deployment-loop lookup only when LiteLLM didn't supply one (very
+        # old LiteLLM versions; defensive).
+        provider = litellm_provider or "unknown"
+        if not litellm_provider:
+            for d in self._deployments:
+                if d.litellm_model == out.get("model") or d.model_name == out.get("model"):
+                    provider = d.provider
+                    break
+
         out["_orca_meta"] = {
             "provider": provider,
             "latency_ms": latency_ms,
+            "cost_usd": litellm_cost_usd,
         }
         return out

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -221,3 +221,71 @@ async def test_non_streaming_still_works_unchanged(stream_client):
     assert r.status_code == 200
     assert r.headers["content-type"].startswith("application/json")
     assert r.json()["choices"][0]["message"]["content"] == "Hello world"
+
+
+async def test_streaming_auto_injects_include_usage_when_client_omits_it(stream_client):
+    """OpenAI streaming omits the `usage` field unless the caller opts in
+    via `stream_options.include_usage=true`. Almost no client knows to set
+    this — and without it our cost calculation falls back to 0. The server
+    auto-injects it so spend tracking works regardless of caller."""
+    client, fake = stream_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+        },
+    )
+    assert r.status_code == 200
+    # Inspect what got passed down to the LiteLLM wrapper.
+    call_kwargs = fake.acompletion.call_args.kwargs
+    assert call_kwargs.get("stream_options") == {"include_usage": True}, (
+        f"server should auto-inject include_usage=True; got "
+        f"{call_kwargs.get('stream_options')}"
+    )
+
+
+async def test_streaming_respects_explicit_client_include_usage_false(stream_client):
+    """Regression: ChatCompletionRequest must declare `stream_options` as a
+    field, otherwise Pydantic silently drops it from the request body and
+    a client's explicit `include_usage=false` opt-out gets clobbered by
+    our auto-inject. (Codex round-2 [P2] — without the schema field the
+    auto-inject branch sees no client value and overrides to True.)"""
+    client, fake = stream_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "stream_options": {"include_usage": False},
+        },
+    )
+    assert r.status_code == 200
+    call_kwargs = fake.acompletion.call_args.kwargs
+    assert call_kwargs.get("stream_options") == {"include_usage": False}, (
+        f"client opt-out must survive end-to-end; got "
+        f"{call_kwargs.get('stream_options')}"
+    )
+
+
+async def test_streaming_preserves_other_stream_options_fields(stream_client):
+    """Client may pass additional `stream_options` fields besides
+    `include_usage`. Our auto-inject must add `include_usage=True` only
+    when missing, leaving other fields intact (don't clobber the dict)."""
+    client, fake = stream_client
+    r = await client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "gpt-4o-mini",
+            "messages": [{"role": "user", "content": "hi"}],
+            "stream": True,
+            "stream_options": {"future_field": "preserve_me"},
+        },
+    )
+    assert r.status_code == 200
+    so = fake.acompletion.call_args.kwargs.get("stream_options")
+    assert so == {"future_field": "preserve_me", "include_usage": True}, (
+        f"must merge auto-inject with existing fields, not replace; got {so}"
+    )

--- a/tests/unit/test_auto_routing.py
+++ b/tests/unit/test_auto_routing.py
@@ -486,3 +486,117 @@ def test_none_allowlist_means_no_restriction():
         allowlist=None,
     )
     assert chosen == ["cheap"]
+
+
+# ── canonical_model_base: strip version-suffixes for dedupe ─────────────
+
+
+def test_canonical_base_strips_dated_alias():
+    from app.auto_routing import canonical_model_base
+    assert canonical_model_base("gpt-5-nano-2025-08-07") == "gpt-5-nano"
+    assert canonical_model_base("claude-3-5-sonnet-20241022") == "claude-3-5-sonnet"
+
+
+def test_canonical_base_strips_revision_suffix():
+    from app.auto_routing import canonical_model_base
+    assert canonical_model_base("gemini-2.0-flash-lite-001") == "gemini-2.0-flash-lite"
+    assert canonical_model_base("gemini-1.5-pro-002") == "gemini-1.5-pro"
+
+
+def test_canonical_base_strips_semver():
+    from app.auto_routing import canonical_model_base
+    assert canonical_model_base("foo-v1") == "foo"
+    assert canonical_model_base("foo-v2.1.0") == "foo"
+
+
+def test_canonical_base_leaves_non_version_suffix_alone():
+    """Branding suffixes are not versions — preserve as-is so distinct catalog
+    models stay distinct."""
+    from app.auto_routing import canonical_model_base
+    assert canonical_model_base("gpt-4o-mini") == "gpt-4o-mini"
+    assert canonical_model_base("gpt-4-turbo-preview") == "gpt-4-turbo-preview"
+    assert canonical_model_base("claude-3-5-sonnet-latest") == "claude-3-5-sonnet-latest"
+
+
+def test_canonical_base_with_no_suffix_is_identity():
+    from app.auto_routing import canonical_model_base
+    assert canonical_model_base("gpt-4o") == "gpt-4o"
+    assert canonical_model_base("claude-opus-4-7") == "claude-opus-4-7"
+
+
+# ── choose_auto_model: dedupe sibling versions out of fallback list ─────
+
+
+def test_choose_model_dedupes_sibling_versions():
+    """Regression: gemini-2.0-flash-lite and gemini-2.0-flash-lite-001 used
+    to both end up in the fallback list, which doubled the dead-deployment
+    retry latency on a Google outage. Dedupe by canonical base — keep the
+    highest-ranked sibling, drop the rest."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("gemini-2.0-flash-lite", "gemini", "gemini/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("gemini-2.0-flash-lite-001", "gemini", "gemini/", True, False, False, 1.1e-7, 4.1e-7),
+        CatalogModel("gpt-5-nano", "openai", "openai/", True, False, False, 2e-7, 5e-7),
+        CatalogModel("gpt-5-nano-2025-08-07", "openai", "openai/", True, False, False, 2.1e-7, 5.1e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={c.id for c in candidates},
+        candidates=candidates,
+        strategy="cheapest",
+    )
+    # Each canonical base should appear at most once. The cheaper sibling
+    # within each base wins (cheapest strategy sorts by cost asc first).
+    assert "gemini-2.0-flash-lite" in chosen
+    assert "gemini-2.0-flash-lite-001" not in chosen, (
+        "version-suffix sibling should be deduped out of the fallback list"
+    )
+    assert "gpt-5-nano" in chosen
+    assert "gpt-5-nano-2025-08-07" not in chosen
+
+
+def test_dedupe_preserves_strategy_ranking():
+    """Dedupe must run AFTER sort so the highest-ranked sibling per base
+    survives, not an arbitrary one. Under quality strategy, the sibling with
+    the higher AA score should win."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("foo", "x", "x/", True, False, False, 1e-7, 4e-7),
+        CatalogModel("foo-001", "x", "x/", True, False, False, 1e-7, 4e-7),
+    ]
+    # Give the suffix-variant the higher score.
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"foo", "foo-001"},
+        candidates=candidates,
+        strategy="quality",
+        quality_scores={"foo": 50.0, "foo-001": 80.0},
+    )
+    assert chosen == ["foo-001"], (
+        "quality-ranked sibling (higher score) should survive the dedupe"
+    )
+
+
+def test_dedupe_does_not_collapse_unrelated_models():
+    """gpt-4o and gpt-4o-mini share a prefix but `mini` isn't a version
+    suffix — they must stay distinct."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CatalogModel
+
+    candidates = [
+        CatalogModel("gpt-4o", "openai", "openai/", True, False, False, 5e-6, 15e-6),
+        CatalogModel("gpt-4o-mini", "openai", "openai/", True, False, False, 1.5e-7, 6e-7),
+    ]
+    chosen = choose_auto_model(
+        needs=set(),
+        deployable={"gpt-4o", "gpt-4o-mini"},
+        candidates=candidates,
+        strategy="cheapest",
+    )
+    assert "gpt-4o" in chosen and "gpt-4o-mini" in chosen, (
+        "branding suffix is not a version — both must remain"
+    )

--- a/tests/unit/test_cost_tracking.py
+++ b/tests/unit/test_cost_tracking.py
@@ -1,0 +1,112 @@
+"""Per-request cost computation for the analytics dashboard.
+
+Used to be hard-coded to 0 in `_build_log_row`, which made every request
+look free in the dashboard's "Today's spend" tile and falsely inflated
+the savings-vs-baseline percentage on /v1/analytics/savings (baseline
+was non-zero, actual was zero, savings = 100%).
+
+These tests pin the cost calculation against the same USD/token unit
+convention as `analytics.py:savings` (1 USD = 1,000,000 microcents) so
+both sides of that comparison stay consistent.
+"""
+
+from __future__ import annotations
+
+
+def test_cost_microcents_basic_arithmetic():
+    """Reference: gpt-4o-mini priced at 1.5e-7 / 6e-7 USD per token.
+    1000 input + 500 output = 1.5e-4 + 3e-4 = 4.5e-4 USD = 450 microcents."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake = CatalogModel(
+        id="test-model", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1.5e-7, output_cost_per_token=6e-7,
+    )
+    CATALOG_BY_ID["test-model"] = fake
+    try:
+        result = _compute_cost_microcents("test-model", 1000, 500)
+        assert result == 450, f"expected 450 microcents, got {result}"
+    finally:
+        CATALOG_BY_ID.pop("test-model", None)
+
+
+def test_cost_zero_for_zero_tokens():
+    """A pre-flight failure (e.g. validation reject) has 0 tokens and must
+    record 0 cost — not crash and not invent a phantom charge."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents("gpt-4o", 0, 0) == 0
+
+
+def test_cost_zero_for_unknown_model():
+    """LiteLLM may rewrite response.model to a provider-specific name we
+    don't carry. Better to under-report this row's cost than to crash the
+    log-write path. The savings dashboard's baseline is computed
+    separately, so a 0 here just means 'this row didn't bill' — not 'this
+    row had an error.'"""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents("totally-fake-model-x", 1000, 500) == 0
+
+
+def test_cost_strips_provider_prefix():
+    """LiteLLM sometimes returns response.model as 'openai/gpt-4o' instead
+    of bare 'gpt-4o'. The cost helper should strip the prefix before
+    looking up the catalog entry — otherwise every prefixed response would
+    log 0."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake = CatalogModel(
+        id="prefix-test", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-7, output_cost_per_token=2e-7,
+    )
+    CATALOG_BY_ID["prefix-test"] = fake
+    try:
+        bare = _compute_cost_microcents("prefix-test", 100, 100)
+        prefixed = _compute_cost_microcents("openai/prefix-test", 100, 100)
+        assert bare == prefixed, (
+            "provider-prefixed and bare names must price identically"
+        )
+        assert bare > 0
+    finally:
+        CATALOG_BY_ID.pop("prefix-test", None)
+
+
+def test_cost_handles_none_model():
+    """`actual_resolved` may be None on early failures. Don't blow up."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents(None, 100, 100) == 0
+
+
+def test_cost_clamps_negative_tokens_to_zero():
+    """Defensive: usage data from upstream can occasionally be malformed.
+    Don't write negative cost into the DB."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents("gpt-4o", -10, 100) == 0
+    assert _compute_cost_microcents("gpt-4o", 100, -10) == 0
+
+
+def test_cost_unit_matches_savings_baseline_convention():
+    """`/v1/analytics/savings` computes the baseline as
+    `tokens * cost_per_token * 1_000_000` (analytics.py:171). Our
+    per-row cost must use the SAME multiplier or the savings percentage
+    is meaningless. This test pins both sides to the same convention."""
+    from app.routes.analytics import _hosted_auto_savings  # noqa: F401  (proves import works)
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+
+    # Pick any real catalog model with non-zero pricing.
+    real = next((m for m in CATALOG_BY_ID.values() if m.input_cost_per_token > 0), None)
+    assert real is not None, "expected at least one priced model in catalog"
+
+    expected = int(
+        100 * real.input_cost_per_token * 1_000_000
+        + 50 * real.output_cost_per_token * 1_000_000
+    )
+    actual = _compute_cost_microcents(real.id, 100, 50)
+    assert actual == expected, (
+        f"cost convention mismatch: chat row uses {actual}, "
+        f"savings baseline would compute {expected}"
+    )

--- a/tests/unit/test_cost_tracking.py
+++ b/tests/unit/test_cost_tracking.py
@@ -1,112 +1,306 @@
 """Per-request cost computation for the analytics dashboard.
 
-Used to be hard-coded to 0 in `_build_log_row`, which made every request
-look free in the dashboard's "Today's spend" tile and falsely inflated
-the savings-vs-baseline percentage on /v1/analytics/savings (baseline
-was non-zero, actual was zero, savings = 100%).
+`cost_microcents` used to be hard-coded to 0 in `_build_log_row`, which
+made every request look free in the dashboard's "Today's spend" tile and
+falsely inflated the savings-vs-baseline percentage on
+/v1/analytics/savings (baseline non-zero, actual zero, savings = 100%).
 
-These tests pin the cost calculation against the same USD/token unit
-convention as `analytics.py:savings` (1 USD = 1,000,000 microcents) so
-both sides of that comparison stay consistent.
+Current implementation is two-tier:
+
+  Tier 1 — `litellm_cost_usd` plumbed through the response's `_orca_meta`.
+  This is LiteLLM's `_hidden_params.response_cost`, computed at the moment
+  the Router knew which provider it actually called. Authoritative because
+  it knows about Anthropic prompt caching, OpenAI reasoning tokens, audio
+  pricing, and provider aliasing.
+
+  Tier 2 — `tokens × catalog price` fallback. Used when LiteLLM didn't
+  attach a cost (cache hits served from our prompt cache, exception paths,
+  custom upstreams).
+
+Tests below pass `litellm_cost_usd=None` to exercise tier 2 directly and
+pass a non-None value to exercise tier 1.
 """
 
 from __future__ import annotations
 
+# ── Tier 1: LiteLLM's pre-computed cost takes priority ──────────────────
 
-def test_cost_microcents_basic_arithmetic():
-    """Reference: gpt-4o-mini priced at 1.5e-7 / 6e-7 USD per token.
-    1000 input + 500 output = 1.5e-4 + 3e-4 = 4.5e-4 USD = 450 microcents."""
+
+def test_tier1_litellm_cost_used_when_present():
+    """When _orca_meta carries cost_usd, use it directly. Multiplier:
+    USD × 1_000_000 = microcents."""
     from app.routes.chat import _compute_cost_microcents
-    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
-
-    fake = CatalogModel(
-        id="test-model", provider="x", litellm_prefix="x/",
-        supports_tools=True, supports_vision=False, supports_json_mode=False,
-        input_cost_per_token=1.5e-7, output_cost_per_token=6e-7,
+    result = _compute_cost_microcents(
+        litellm_cost_usd=0.000_500,  # = 500 microcents
+        model_id="any-model",
+        input_tokens=1, output_tokens=1,
     )
-    CATALOG_BY_ID["test-model"] = fake
-    try:
-        result = _compute_cost_microcents("test-model", 1000, 500)
-        assert result == 450, f"expected 450 microcents, got {result}"
-    finally:
-        CATALOG_BY_ID.pop("test-model", None)
+    assert result == 500
 
 
-def test_cost_zero_for_zero_tokens():
-    """A pre-flight failure (e.g. validation reject) has 0 tokens and must
-    record 0 cost — not crash and not invent a phantom charge."""
-    from app.routes.chat import _compute_cost_microcents
-    assert _compute_cost_microcents("gpt-4o", 0, 0) == 0
-
-
-def test_cost_zero_for_unknown_model():
-    """LiteLLM may rewrite response.model to a provider-specific name we
-    don't carry. Better to under-report this row's cost than to crash the
-    log-write path. The savings dashboard's baseline is computed
-    separately, so a 0 here just means 'this row didn't bill' — not 'this
-    row had an error.'"""
-    from app.routes.chat import _compute_cost_microcents
-    assert _compute_cost_microcents("totally-fake-model-x", 1000, 500) == 0
-
-
-def test_cost_strips_provider_prefix():
-    """LiteLLM sometimes returns response.model as 'openai/gpt-4o' instead
-    of bare 'gpt-4o'. The cost helper should strip the prefix before
-    looking up the catalog entry — otherwise every prefixed response would
-    log 0."""
+def test_tier1_overrides_catalog_even_when_catalog_would_disagree():
+    """Tier 1 wins because LiteLLM's number is more accurate (cache /
+    reasoning aware) than our flat catalog calc."""
     from app.routes.chat import _compute_cost_microcents
     from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
 
+    # Catalog says 100 microcents, but LiteLLM said 500 (e.g. because it
+    # accounted for cache_creation = 1.25x base). Use LiteLLM.
     fake = CatalogModel(
-        id="prefix-test", provider="x", litellm_prefix="x/",
+        id="t1-overrides", provider="x", litellm_prefix="x/",
         supports_tools=True, supports_vision=False, supports_json_mode=False,
         input_cost_per_token=1e-7, output_cost_per_token=2e-7,
     )
-    CATALOG_BY_ID["prefix-test"] = fake
+    CATALOG_BY_ID["t1-overrides"] = fake
     try:
-        bare = _compute_cost_microcents("prefix-test", 100, 100)
-        prefixed = _compute_cost_microcents("openai/prefix-test", 100, 100)
-        assert bare == prefixed, (
-            "provider-prefixed and bare names must price identically"
+        result = _compute_cost_microcents(
+            litellm_cost_usd=0.000_500,
+            model_id="t1-overrides",
+            input_tokens=1000, output_tokens=500,
         )
-        assert bare > 0
+        assert result == 500, "tier 1 must win over tier 2 when both available"
     finally:
-        CATALOG_BY_ID.pop("prefix-test", None)
+        CATALOG_BY_ID.pop("t1-overrides", None)
 
 
-def test_cost_handles_none_model():
-    """`actual_resolved` may be None on early failures. Don't blow up."""
+def test_tier1_zero_falls_through_to_catalog():
+    """LiteLLM returning cost_usd=0 means it couldn't price (unknown
+    model in its table). Don't accept that as 'authoritative zero' —
+    let the catalog have a shot."""
     from app.routes.chat import _compute_cost_microcents
-    assert _compute_cost_microcents(None, 100, 100) == 0
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake = CatalogModel(
+        id="t1-zero", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-7, output_cost_per_token=2e-7,
+    )
+    CATALOG_BY_ID["t1-zero"] = fake
+    try:
+        result = _compute_cost_microcents(
+            litellm_cost_usd=0.0,
+            model_id="t1-zero",
+            input_tokens=1000, output_tokens=500,
+        )
+        expected = int((1000 * 1e-7 + 500 * 2e-7) * 1_000_000)
+        assert result == expected, (
+            "tier-1 zero must fall through to tier-2 catalog calculation"
+        )
+    finally:
+        CATALOG_BY_ID.pop("t1-zero", None)
 
 
-def test_cost_clamps_negative_tokens_to_zero():
-    """Defensive: usage data from upstream can occasionally be malformed.
-    Don't write negative cost into the DB."""
+def test_tier1_negative_cost_clamped_to_zero():
+    """Defensive: never write negative cost into the DB regardless of
+    where the number came from."""
     from app.routes.chat import _compute_cost_microcents
-    assert _compute_cost_microcents("gpt-4o", -10, 100) == 0
-    assert _compute_cost_microcents("gpt-4o", 100, -10) == 0
+    result = _compute_cost_microcents(
+        litellm_cost_usd=-0.5,  # malformed
+        model_id="any",
+        input_tokens=1, output_tokens=1,
+    )
+    # Negative tier-1 is treated as "no tier-1 data" and falls through.
+    # With model_id not in catalog and no fallback, returns 0.
+    assert result == 0
 
 
-def test_cost_unit_matches_savings_baseline_convention():
-    """`/v1/analytics/savings` computes the baseline as
-    `tokens * cost_per_token * 1_000_000` (analytics.py:171). Our
-    per-row cost must use the SAME multiplier or the savings percentage
-    is meaningless. This test pins both sides to the same convention."""
+# ── Tier 2: catalog × tokens fallback ───────────────────────────────────
+
+
+def test_tier2_basic_arithmetic():
+    """Reference: 1.5e-7 / 6e-7 USD per token, 1000 input + 500 output =
+    1.5e-4 + 3e-4 = 4.5e-4 USD = 450 microcents."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake = CatalogModel(
+        id="t2-basic", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1.5e-7, output_cost_per_token=6e-7,
+    )
+    CATALOG_BY_ID["t2-basic"] = fake
+    try:
+        result = _compute_cost_microcents(
+            litellm_cost_usd=None,
+            model_id="t2-basic",
+            input_tokens=1000, output_tokens=500,
+        )
+        assert result == 450
+    finally:
+        CATALOG_BY_ID.pop("t2-basic", None)
+
+
+def test_tier2_zero_for_zero_tokens():
+    """Pre-flight failures have 0 tokens → 0 cost, no crash."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents(
+        litellm_cost_usd=None, model_id="gpt-4o",
+        input_tokens=0, output_tokens=0,
+    ) == 0
+
+
+def test_tier2_zero_for_unknown_model():
+    """Unknown to catalog AND no fallback → 0. Better to under-report
+    than crash the log-write path."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents(
+        litellm_cost_usd=None, model_id="totally-fake-model-x",
+        input_tokens=1000, output_tokens=500,
+    ) == 0
+
+
+def test_tier2_strips_provider_prefix():
+    """`openai/gpt-4o` → `gpt-4o` for catalog lookup."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake = CatalogModel(
+        id="t2-prefix", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-7, output_cost_per_token=2e-7,
+    )
+    CATALOG_BY_ID["t2-prefix"] = fake
+    try:
+        bare = _compute_cost_microcents(
+            litellm_cost_usd=None, model_id="t2-prefix",
+            input_tokens=100, output_tokens=100,
+        )
+        prefixed = _compute_cost_microcents(
+            litellm_cost_usd=None, model_id="openai/t2-prefix",
+            input_tokens=100, output_tokens=100,
+        )
+        assert bare == prefixed > 0
+    finally:
+        CATALOG_BY_ID.pop("t2-prefix", None)
+
+
+def test_tier2_handles_none_model():
+    """`actual_resolved` may be None on early failures."""
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents(
+        litellm_cost_usd=None, model_id=None,
+        input_tokens=100, output_tokens=100,
+    ) == 0
+
+
+def test_tier2_clamps_negative_tokens():
+    from app.routes.chat import _compute_cost_microcents
+    assert _compute_cost_microcents(
+        litellm_cost_usd=None, model_id="gpt-4o",
+        input_tokens=-10, output_tokens=100,
+    ) == 0
+    assert _compute_cost_microcents(
+        litellm_cost_usd=None, model_id="gpt-4o",
+        input_tokens=100, output_tokens=-10,
+    ) == 0
+
+
+def test_tier2_strips_version_suffix_for_dated_alias():
+    """When the response is `claude-3-5-sonnet-20241022` but only the
+    base `claude-3-5-sonnet` is in catalog, strip the date and find it."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    fake_base = CatalogModel(
+        id="t2-aliastest-sonnet", provider="anthropic", litellm_prefix="anthropic/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=3e-6, output_cost_per_token=15e-6,
+    )
+    CATALOG_BY_ID["t2-aliastest-sonnet"] = fake_base
+    try:
+        result = _compute_cost_microcents(
+            litellm_cost_usd=None,
+            model_id="t2-aliastest-sonnet-20241022",
+            input_tokens=1000, output_tokens=500,
+        )
+        baseline = _compute_cost_microcents(
+            litellm_cost_usd=None,
+            model_id="t2-aliastest-sonnet",
+            input_tokens=1000, output_tokens=500,
+        )
+        assert result == baseline > 0, "version-stripped alias should match base price"
+    finally:
+        CATALOG_BY_ID.pop("t2-aliastest-sonnet", None)
+
+
+def test_tier2_falls_back_to_requested_model_when_resolved_unknown():
+    """Last-resort: when both resolved and canonicalized resolved miss
+    the catalog, try the originally requested model id."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    requested = CatalogModel(
+        id="t2-reqfallback", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-7, output_cost_per_token=2e-7,
+    )
+    CATALOG_BY_ID["t2-reqfallback"] = requested
+    try:
+        result = _compute_cost_microcents(
+            litellm_cost_usd=None,
+            model_id="vendor-x-internal-rebrand-xyz",
+            input_tokens=1000, output_tokens=500,
+            fallback_model="t2-reqfallback",
+        )
+        expected = int((1000 * 1e-7 + 500 * 2e-7) * 1_000_000)
+        assert result == expected
+    finally:
+        CATALOG_BY_ID.pop("t2-reqfallback", None)
+
+
+def test_tier2_resolved_priced_takes_precedence_over_fallback():
+    """Resolved (what was actually served) wins over fallback (what was
+    asked) when both are catalog hits."""
+    from app.routes.chat import _compute_cost_microcents
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, CatalogModel
+
+    cheap = CatalogModel(
+        id="t2-cheap", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-8, output_cost_per_token=2e-8,
+    )
+    expensive = CatalogModel(
+        id="t2-expensive", provider="x", litellm_prefix="x/",
+        supports_tools=True, supports_vision=False, supports_json_mode=False,
+        input_cost_per_token=1e-5, output_cost_per_token=2e-5,
+    )
+    CATALOG_BY_ID["t2-cheap"] = cheap
+    CATALOG_BY_ID["t2-expensive"] = expensive
+    try:
+        result = _compute_cost_microcents(
+            litellm_cost_usd=None, model_id="t2-cheap",
+            input_tokens=1000, output_tokens=500,
+            fallback_model="t2-expensive",
+        )
+        cheap_only = _compute_cost_microcents(
+            litellm_cost_usd=None, model_id="t2-cheap",
+            input_tokens=1000, output_tokens=500,
+        )
+        assert result == cheap_only, (
+            "must price the served (resolved) model, not the requested one"
+        )
+    finally:
+        CATALOG_BY_ID.pop("t2-cheap", None)
+        CATALOG_BY_ID.pop("t2-expensive", None)
+
+
+def test_tier2_unit_matches_savings_baseline_convention():
+    """`/v1/analytics/savings` baseline uses tokens × cost_per_token ×
+    1_000_000. Tier 2 must use the SAME convention so the savings
+    percentage is meaningful."""
     from app.routes.analytics import _hosted_auto_savings  # noqa: F401  (proves import works)
     from app.routes.chat import _compute_cost_microcents
     from packages.litellm_adapter.catalog import CATALOG_BY_ID
 
-    # Pick any real catalog model with non-zero pricing.
     real = next((m for m in CATALOG_BY_ID.values() if m.input_cost_per_token > 0), None)
-    assert real is not None, "expected at least one priced model in catalog"
+    assert real is not None
 
     expected = int(
         100 * real.input_cost_per_token * 1_000_000
         + 50 * real.output_cost_per_token * 1_000_000
     )
-    actual = _compute_cost_microcents(real.id, 100, 50)
-    assert actual == expected, (
-        f"cost convention mismatch: chat row uses {actual}, "
-        f"savings baseline would compute {expected}"
+    actual = _compute_cost_microcents(
+        litellm_cost_usd=None, model_id=real.id,
+        input_tokens=100, output_tokens=50,
     )
+    assert actual == expected

--- a/tests/unit/test_litellm_client.py
+++ b/tests/unit/test_litellm_client.py
@@ -115,6 +115,113 @@ async def test_acompletion_non_stream_returns_dict_with_orca_meta(fake_router_wi
     assert result["_orca_meta"].get("provider") == "openai"
 
 
+async def test_acompletion_propagates_litellm_hidden_params_into_orca_meta(monkeypatch):
+    """LiteLLM stashes per-call cost on `_hidden_params.response_cost` and
+    the actual provider on `_hidden_params.custom_llm_provider`. The
+    adapter MUST extract these BEFORE `model_dump()` strips them, then
+    surface them on _orca_meta. Otherwise downstream cost tracking falls
+    back to the (much less accurate) catalog calculation for every request.
+    """
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+
+    from packages.litellm_adapter.client import OrcaLiteLLMClient
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    class _ResponseModel:
+        def __init__(self):
+            self.model = "claude-3-5-sonnet-20241022"
+            # LiteLLM populates this in `_response_cost_calculator` —
+            # value is USD (float).
+            self._hidden_params = {
+                "response_cost": 0.000_750,
+                "custom_llm_provider": "anthropic",
+                "litellm_call_id": "test-id",
+            }
+
+        def model_dump(self):
+            # Pydantic strips _-prefixed attrs by default. This mirrors
+            # what real LiteLLM ModelResponse.model_dump() does.
+            return {
+                "model": self.model,
+                "choices": [],
+                "usage": {"prompt_tokens": 100, "completion_tokens": 50},
+            }
+
+    fake_router = MagicMock()
+
+    async def _acompletion(**kwargs):
+        return _ResponseModel()
+
+    fake_router.acompletion = AsyncMock(side_effect=_acompletion)
+    monkeypatch.setattr(litellm, "Router", lambda **_: fake_router)
+
+    client = OrcaLiteLLMClient(
+        deployments=[
+            ProviderDeployment(
+                model_name="claude-3-5-sonnet-20241022",
+                litellm_model="anthropic/claude-3-5-sonnet-20241022",
+                api_key="sk-test", provider="anthropic",
+            )
+        ],
+        strategy="balanced",
+    )
+    result = await client.acompletion(
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    meta = result.get("_orca_meta") or {}
+    assert meta.get("cost_usd") == 0.000_750, (
+        "_hidden_params.response_cost must survive into _orca_meta — "
+        "downstream cost calculation reads it from there"
+    )
+    assert meta.get("provider") == "anthropic", (
+        "_hidden_params.custom_llm_provider should win over the "
+        "deployment-loop fallback (more reliable on aliased model names)"
+    )
+
+
+async def test_acompletion_orca_meta_cost_none_when_litellm_omits_it(monkeypatch):
+    """When the response object has no `_hidden_params` (very old LiteLLM,
+    custom upstream wrappers), `cost_usd` must be None on the meta — that's
+    the signal for downstream code to fall back to catalog pricing."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    import litellm
+
+    from packages.litellm_adapter.client import OrcaLiteLLMClient
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    class _BareResponse:
+        model = "gpt-4o-mini"
+        # Deliberately no _hidden_params.
+
+        def model_dump(self):
+            return {"model": self.model, "choices": [], "usage": {}}
+
+    fake_router = MagicMock()
+    fake_router.acompletion = AsyncMock(side_effect=lambda **_: _BareResponse())
+    monkeypatch.setattr(litellm, "Router", lambda **_: fake_router)
+
+    client = OrcaLiteLLMClient(
+        deployments=[
+            ProviderDeployment(
+                model_name="gpt-4o-mini", litellm_model="openai/gpt-4o-mini",
+                api_key="sk-test", provider="openai",
+            )
+        ],
+        strategy="balanced",
+    )
+    result = await client.acompletion(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+    assert result["_orca_meta"]["cost_usd"] is None
+    # Provider attribution falls back to deployment-loop lookup.
+    assert result["_orca_meta"]["provider"] == "openai"
+
+
 async def test_acompletion_stream_raises_no_providers_when_router_is_none():
     """No-key configurations short-circuit before LiteLLM gets called.
     Stream requests must hit the same guard as non-stream ones."""


### PR DESCRIPTION
## Summary

Followup to #20. The original `cost_microcents=0` was hard-coded in
`_build_log_row`, making the dashboard's "Today's spend" tile always
\$0.00 and the savings calculation always 100%. This PR plumbs cost
through correctly, then sweeps a few related dev-UX issues that
surfaced during manual testing.

## What changes

**1. Cost tracking — read LiteLLM's authoritative number**

LiteLLM Router computes cost at the moment it knows the upstream provider
and stashes it on `resp._hidden_params.response_cost`. We extract it before
`model_dump()` strips it and surface it on `_orca_meta.cost_usd`. The chat
handler reads that value (Tier 1) and falls back to `tokens × catalog price`
(Tier 2) only for cache hits and exception paths where `_orca_meta` is
absent.

Why not `litellm.completion_cost(response)` reverse-lookup? It fails on
Anthropic and Gemini bare model names with "Provider NOT provided" /
"model isn't mapped" because LiteLLM can't reliably re-derive the provider
from a serialized response dict. Going through `_hidden_params` avoids the
guesswork — LiteLLM knows the provider when it called it.

**2. Streaming auto-injects `stream_options.include_usage=true`**

OpenAI's streaming protocol omits the `usage` field by default; clients
must opt-in. Almost no client knows to set this flag, so streaming cost
silently rounded to zero. Auto-inject server-side; clients can still pass
`false` explicitly for compatibility tests.

**3. Sibling-version dedupe in auto fallback list**

`choose_auto_model` was returning both `gemini-2.0-flash-lite` AND
`gemini-2.0-flash-lite-001` in the fallback list. They share an upstream
outage — keeping both just adds dead-deployment retry latency before the
real cross-provider cascade. Dedupe by `canonical_model_base()` (shared
with the prompt-cache canonicalization).

**4. Dev-hostile defaults rolled back**

PR #15 set production-grade defaults that punished local development:

- `router_cooldown_seconds`: **3600 → 60**. A bad key recovers in a
  minute instead of an hour. Production should bump back via `.env`.
- `BadRequestErrorAllowedFails`: **0 → 10**. LiteLLM lumps
  client-side errors (model typo, prompt too long) together with
  genuine deployment failures (model 404). The old "0 = cool down on
  first failure" punished a developer's typo with a process-wide
  freeze. AuthenticationError stays at 0 — wrong key is wrong key.

**5. Dashboard precision**

`fmtUsd()` now uses 6-digit precision below \$0.001. A single chat
completion can cost \$0.000006; the previous 4-digit floor rendered
that as \$0.0000 and made the dashboard look broken on day 1.

**6. Provider attribution**

`_orca_meta.provider` now uses LiteLLM's own `custom_llm_provider`
instead of the deployment-loop name match. More reliable when LiteLLM
rewrites the model name to a dated alias mid-cascade.

## Test plan

- [x] 14 cost-tracking unit tests rewritten for the new keyword-only
  signature (Tier 1 / Tier 2 paths, all four catalog id-shape variants,
  unit consistency with savings baseline)
- [x] 2 new client adapter tests pinning `_hidden_params` survives
  through `_orca_meta`, and that `cost_usd=None` triggers catalog fallback
- [x] 12 sibling-dedupe / canonicalize tests
- [x] Full suite: 238 passing (excluding 4 pre-existing
  `test_unreachable.py` failures unrelated to this PR)
- [x] `ruff check` clean
- [x] Manual: non-stream gpt-4o-mini → cost matches
  `tokens × LiteLLM price` (verified 6, 8, 49, 148 microcents across
  varying token counts)
- [x] Manual: stream gpt-4o-mini → cost matches (auto-injected
  `include_usage` confirmed delivering usage chunk)
- [x] Manual: cache hit → cost = 0 (correct, no upstream tokens)
- [x] Manual: stderr clean — no LiteLLM "Provider NOT provided" /
  "Provider List:" noise that the v3 reverse-lookup attempt produced

## Notes

- Replaces an earlier intermediate commit (`c3fa581`) that took the
  reverse-lookup path. Force-pushed with the rework.
- Anthropic / Gemini `-latest` aliases may 401/404 in real testing —
  unrelated to this PR (provider-side alias deprecation), but the
  shorter cooldown + wider BadRequest tolerance make those failures
  much less painful to debug.

Closes a regression introduced by #20.