### PR TITLE
Stop burning tokens when streaming clients disconnect

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -7,11 +7,13 @@ response in OpenAI's `text/event-stream` format with a terminal
 
 from __future__ import annotations
 
+import asyncio
 import json
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable
 
+import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -478,6 +480,54 @@ async def chat_completions(
             agg_model: str | None = None
             status_code = 200
             error_type: str | None = None
+            log_written = False
+
+            async def _finalize() -> None:
+                """Write the request log row exactly once.
+
+                Called from two places: the cancel branch (so the row lands
+                even if the [DONE] yield fails against a disconnected
+                client), and the `finally` block (the normal path). The
+                `log_written` guard makes the second call a no-op when the
+                cancel path already ran.
+                """
+                nonlocal log_written, agg_provider
+                if log_written:
+                    return
+                log_written = True
+                # Real LiteLLM stream chunks don't carry _orca_meta (the
+                # adapter only injects it on non-stream responses, since
+                # wrapping every chunk would be wasteful). Look up provider
+                # attribution from the served model name against the active
+                # deployments — same lookup the non-stream adapter does.
+                if agg_provider == "unknown" and agg_model:
+                    deployments = getattr(client, "_deployments", []) or []
+                    bare_served = (
+                        agg_model.split("/", 1)[-1] if "/" in agg_model else agg_model
+                    )
+                    for d in deployments:
+                        if agg_model in (d.litellm_model, d.model_name) or bare_served == d.model_name:
+                            agg_provider = d.provider
+                            break
+                synthetic = {
+                    "model": agg_model or resolved_model,
+                    "usage": agg_usage,
+                    "_orca_meta": {"provider": agg_provider, "latency_ms": agg_latency},
+                }
+                log = await _build_log_row(
+                    body=body, kc=kc, response=synthetic,
+                    status_code=status_code, error_type=error_type,
+                    started_perf=started_perf,
+                    strategy=strategy,
+                    requested_model=requested_model,
+                    actual_resolved=agg_model,
+                )
+                db.add(log)
+                try:
+                    await db.commit()
+                except Exception as commit_err:
+                    logger.warning("request_log_commit_failed", error=str(commit_err))
+
             try:
                 async for chunk in _aiter(stream_obj):
                     d = _chunk_to_dict(chunk)
@@ -492,6 +542,50 @@ async def chat_completions(
                     if d.get("model"):
                         agg_model = d["model"]
                     yield f"data: {json.dumps(d, separators=(',', ':'))}\n\n"
+            except (asyncio.CancelledError, GeneratorExit):
+                # Client closed the connection (Ctrl+C, tab closed, browser
+                # navigated away, proxy timeout, ...). Two distinct signals
+                # land here depending on which side noticed first:
+                #   - CancelledError: asyncio task running the generator was
+                #     cancelled (Starlette saw the disconnect first).
+                #   - GeneratorExit: Starlette called aclose() on us during
+                #     its own cleanup pass.
+                # Either way the consumer is gone — no point yielding more
+                # frames, and we MUST stop pulling chunks from upstream so
+                # LiteLLM doesn't keep burning tokens on a response nobody
+                # will read.
+                error_type = "client_disconnect"
+                # 499 Client Closed Request — nginx convention, widely
+                # understood in analytics pipelines for "user bailed".
+                status_code = 499
+                logger.info(
+                    "chat_completion_stream_client_disconnect",
+                    served_model=agg_model,
+                )
+                # Cleanup MUST actually complete before we unwind, not just
+                # be scheduled. `asyncio.shield()` here would NOT wait — the
+                # outer await re-raises CancelledError immediately under
+                # Starlette's anyio task group cancellation, leaving the
+                # inner aclose/finalize racing FastAPI's request-scoped
+                # session teardown.
+                #
+                # `anyio.CancelScope(shield=True)` is the right primitive:
+                # awaits inside the shielded scope ignore outer cancellation
+                # and run to completion. The scope exits normally and we
+                # re-raise the original CancelledError below.
+                aclose = getattr(stream_obj, "aclose", None)
+                with anyio.CancelScope(shield=True):
+                    if aclose is not None:
+                        try:
+                            await aclose()
+                        except Exception:
+                            pass
+                    try:
+                        await _finalize()
+                    except Exception:
+                        pass
+                # Re-raise so asyncio/Starlette see proper cancel propagation.
+                raise
             except Exception as exc:
                 # Translate the underlying LiteLLM exception so the request
                 # log records the meaningful error_type (rate_limit_error,
@@ -526,40 +620,25 @@ async def chat_completions(
                 }
                 yield f"data: {json.dumps(err_body)}\n\n"
             finally:
-                yield "data: [DONE]\n\n"
-                # Real LiteLLM stream chunks don't carry _orca_meta (the
-                # adapter only injects it on non-stream responses, since
-                # wrapping every chunk would be wasteful). Look up provider
-                # attribution from the served model name against the active
-                # deployments — same lookup the non-stream adapter does.
-                if agg_provider == "unknown" and agg_model:
-                    deployments = getattr(client, "_deployments", []) or []
-                    bare_served = (
-                        agg_model.split("/", 1)[-1] if "/" in agg_model else agg_model
-                    )
-                    for d in deployments:
-                        if agg_model in (d.litellm_model, d.model_name) or bare_served == d.model_name:
-                            agg_provider = d.provider
-                            break
-                # Synthesize a response-shaped dict for the log helper.
-                synthetic = {
-                    "model": agg_model or resolved_model,
-                    "usage": agg_usage,
-                    "_orca_meta": {"provider": agg_provider, "latency_ms": agg_latency},
-                }
-                log = await _build_log_row(
-                    body=body, kc=kc, response=synthetic,
-                    status_code=status_code, error_type=error_type,
-                    started_perf=started_perf,
-                    strategy=strategy,
-                    requested_model=requested_model,
-                    actual_resolved=agg_model,
-                )
-                db.add(log)
+                # Try to send the [DONE] sentinel. If the client is still
+                # listening they need it to stop reading. If they're gone
+                # (cancel path already ran), the yield will raise — swallow
+                # silently because there's no consumer to deliver to.
                 try:
-                    await db.commit()
-                except Exception as commit_err:
-                    logger.warning("request_log_commit_failed", error=str(commit_err))
+                    yield "data: [DONE]\n\n"
+                except (asyncio.CancelledError, GeneratorExit):
+                    pass
+                # Same shielding reason as the cancel branch: ensure the
+                # log write actually completes before we unwind, even if
+                # we're inside a cancelled scope. The cancel branch may
+                # have already run _finalize and set log_written=True; the
+                # `if log_written: return` guard inside makes this call a
+                # cheap no-op in that case.
+                with anyio.CancelScope(shield=True):
+                    try:
+                        await _finalize()
+                    except Exception:
+                        pass
 
         return StreamingResponse(
             sse(),

--- a/tests/integration/test_streaming.py
+++ b/tests/integration/test_streaming.py
@@ -270,6 +270,161 @@ async def test_streaming_respects_explicit_client_include_usage_false(stream_cli
     )
 
 
+async def test_streaming_client_disconnect_writes_log_and_closes_upstream(
+    tmp_sqlite_url, monkeypatch,
+):
+    """Client closes the connection mid-stream (Ctrl+C, tab close, proxy
+    timeout). Two things MUST happen:
+      1. The request_log row gets written with status_code=499 and
+         error_type='client_disconnect' (analytics need this signal to
+         tell user-bailed apart from upstream-failed).
+      2. The upstream stream wrapper's aclose() gets called so LiteLLM
+         stops pulling more chunks from the provider — otherwise we keep
+         burning tokens on a response nobody will read.
+
+    We simulate the disconnect by having the consumer break out of the
+    SSE iteration after the first chunk, which causes Starlette to
+    cancel the generator task.
+    """
+    import asyncio
+    import time
+    from unittest.mock import AsyncMock
+
+    from sqlalchemy import select
+
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    # Stream that yields one chunk then raises CancelledError — mirrors
+    # what Starlette's anyio task group does when it sees `http.disconnect`
+    # on the receive channel: it cancels the task running our SSE
+    # generator, which surfaces as CancelledError at the next `await` in
+    # the chunk iteration loop. (We do this instead of relying on
+    # httpx.ASGITransport, which doesn't propagate disconnect events to
+    # the ASGI app — the real-world signal flow only happens behind a
+    # network transport.)
+    class _CancellingStream:
+        def __init__(self):
+            self.closed = False
+            self._yielded = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                return {
+                    "id": "chatcmpl-1",
+                    "object": "chat.completion.chunk",
+                    "model": "gpt-4o-mini",
+                    "created": int(time.time()),
+                    "choices": [{"index": 0, "delta": {"content": "Hi"},
+                                 "finish_reason": None}],
+                }
+            # Simulate Starlette cancelling our task mid-stream.
+            raise asyncio.CancelledError()
+
+        async def aclose(self):
+            self.closed = True
+
+    slow = _CancellingStream()
+    fake_client = AsyncMock()
+
+    async def _acompletion_router(**kwargs):
+        if kwargs.get("stream"):
+            return slow
+        raise AssertionError("test only exercises stream path")
+
+    fake_client.acompletion = AsyncMock(side_effect=_acompletion_router)
+
+    async def _fake_get_router(_session):
+        return fake_client
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    from app.main import create_app
+    app = create_app()
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+        timeout=10.0,
+    ) as c:
+        # The CancelledError raised inside our generator during chunk
+        # iteration propagates up. Starlette's StreamingResponse converts
+        # it back into a normal stream-end (since the cancel originated
+        # inside the generator, not from disconnect). The client just
+        # sees the stream end after one chunk + cleanup yields.
+        try:
+            async with c.stream(
+                "POST", "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+            ) as response:
+                assert response.status_code == 200
+                async for _ in response.aiter_lines():
+                    pass
+        except Exception:
+            # CancelledError in the SSE generator may surface as a
+            # transport-level error to httpx — we don't care, we're
+            # checking server-side state below.
+            pass
+
+    # Give the cancel-handling code a moment to finish background tasks.
+    await asyncio.sleep(0.2)
+
+    # 1. Upstream got closed (no token-burn after the cancel).
+    assert slow.closed is True, (
+        "stream_obj.aclose() must be called when the SSE generator is "
+        "cancelled, otherwise LiteLLM keeps pulling chunks from the provider"
+    )
+
+    # 2. Log row written with the disconnect signal so analytics can
+    # distinguish user-bailed from upstream-failed requests.
+    from packages.db.models.request_log import RequestLog
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    assert len(rows) == 1, "request_log must be written even on cancel"
+    row = rows[0]
+    assert row.status_code == 499, f"expected 499, got {row.status_code}"
+    assert row.error_type == "client_disconnect", (
+        f"expected error_type='client_disconnect', got {row.error_type!r}"
+    )
+    assert row.is_streaming is True
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
 async def test_streaming_preserves_other_stream_options_fields(stream_client):
     """Client may pass additional `stream_options` fields besides
     `include_usage`. Our auto-inject must add `include_usage=True` only


### PR DESCRIPTION
## Summary

When a streaming client closes the connection mid-response (Ctrl+C, tab close, proxy timeout, browser navigated away), the SSE generator used to keep iterating upstream chunks and skip the request_log write. Net effect:

1. **Wasted spend** — LiteLLM kept pulling tokens from the provider for a response nobody would read.
2. **Hidden in analytics** — no log row meant disconnected requests were invisible. Operators couldn't tell user-bailed traffic apart from upstream-failed traffic.

## What changes

Catch the cancellation signal (both `asyncio.CancelledError` and `GeneratorExit`) inside the SSE generator and:

1. Call `await stream_obj.aclose()` on the LiteLLM stream wrapper so the upstream connection is closed and no more tokens are billed.
2. Write the request_log row with `status_code=499` (nginx Client Closed Request) and `error_type='client_disconnect'` so analytics can distinguish user-bailed from upstream-failed.
3. Re-raise so asyncio/Starlette see proper cancel propagation.

## The shield matters

Both cleanup awaits sit inside `anyio.CancelScope(shield=True)`. This is the right primitive for the job. `asyncio.shield()` would NOT actually wait under Starlette's anyio task group cancellation — the outer await re-raises `CancelledError` immediately, leaving the inner work as a detached Task racing FastAPI's request-scoped session teardown.

The first round of this PR used `asyncio.shield()` and codex caught it ([P2]: "asyncio.shield() does not wait for the cleanup; the outer await immediately raises CancelledError, which is swallowed here, leaving aclose() and _finalize() running as detached tasks while the generator unwinds"). Switched to `anyio.CancelScope(shield=True)` which blocks outer cancellation entirely within the `with` block, so cleanup awaits genuinely run to completion before we unwind.

## Refactor

Extracted the existing finally-block log-write into a `_finalize()` closure with a `log_written` guard so it can be called from both the cancel branch and the normal-path finally without double-writing. Symmetric shielding on the finally-block call too.

## Test plan

- [x] Regression test: mock stream raises `CancelledError` from `__anext__` after one chunk. Asserts upstream `aclose()` was called AND log row landed with `status_code=499 + error_type='client_disconnect'`. (httpx's ASGITransport doesn't propagate `http.disconnect`, so simulating the cancel directly is the only way to test the server-side behavior in-process.)
- [x] All 8 streaming integration tests pass
- [x] Full suite: 242 passing (excluding 4 pre-existing `test_unreachable.py` failures unrelated to this PR)
- [x] `ruff check` clean
- [x] Manual via Postman: cancel mid-stream, verified DB row has `status_code=499 + error_type='client_disconnect'` and `tokens=0+0` (disconnect happens before usage chunk arrives)

## Notes

- Followup to #21 (streaming SSE error handling was deferred in PR 1's scope).
- The previous SSE error handling (upstream exceptions → SSE error frame) from #15 is preserved unchanged.
- Cancel-time `tokens=0+0` so cost rounds to 0 — that's expected (usage chunk hasn't arrived yet on disconnect). The `error_type='client_disconnect'` signal is what analytics use to scope this category.