### PR TITLE
Stop leaking DB sessions on auth errors, drop unused max_body_bytes

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -63,8 +63,6 @@ class Settings(BaseSettings):
     # fallback if the remote is unreachable.
     orcarouter_models_url: str = "https://www.orcarouter.ai/models"
 
-    # ── Body limit (for image / file attachments) ──
-    max_body_bytes: int = 100 * 1024 * 1024
 
     # ── Quality scoring (Artificial Analysis) ──
     # API key from https://artificialanalysis.ai (free tier: 1000 req/day).

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import json
 
 from packages.auth.key_validator import AuthError, validate_api_key
-from packages.db.session import get_session
+from packages.db import session as session_mod
 
 SKIP_AUTH_PATHS: set[str] = {
     "/health",
@@ -76,12 +76,21 @@ class AuthMiddleware:
 
         raw_key = auth_header[7:]
 
+        # Use the session factory directly with `async with` so the
+        # session is GUARANTEED to close on every exit path (success,
+        # AuthError, generic Exception). The previous
+        # `async for s in get_session(): break` pattern relied on
+        # Python's implicit generator cleanup, which is timing-fragile:
+        # in error paths the session could linger until GC and slowly
+        # exhaust the connection pool under load.
+        if session_mod._session_factory is None:
+            from app.config import get_settings
+            session_mod.init_session_factory(get_settings().database_url)
         try:
-            async for session in get_session():
+            async with session_mod._session_factory() as session:
                 key_context = await validate_api_key(raw_key, session)
-                scope.setdefault("state", {})["key_context"] = key_context
-                scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id
-                break
+            scope.setdefault("state", {})["key_context"] = key_context
+            scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id
         except AuthError as e:
             await _send_error(send, e.status_code, e.message, "auth_error")
             return

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -14,15 +14,23 @@ async def app_with_auth(db_session, monkeypatch):
     monkeypatch.setenv("DATABASE_URL", str(db_session.bind.url))
     from fastapi import FastAPI, Request
 
-    # The middleware imports get_session at module load — patch the binding it
-    # actually uses (app.middleware.auth.get_session), not packages.db.session.
-    from app.middleware import auth as auth_mod
+    # Middleware now opens its own session via `session_mod._session_factory()`
+    # instead of consuming a `get_session()` async generator (the previous
+    # `async for s in get_session(): break` pattern was timing-fragile in
+    # error paths). Substitute a factory that hands back the test's
+    # already-open `db_session` and is a no-op on close — the fixture
+    # owns the session lifecycle.
     from app.middleware.auth import AuthMiddleware
+    from packages.db import session as session_mod
 
-    async def _get_session_override():
-        yield db_session
+    class _PassthroughFactory:
+        async def __aenter__(self):
+            return db_session
 
-    monkeypatch.setattr(auth_mod, "get_session", _get_session_override)
+        async def __aexit__(self, *exc):
+            return False  # propagate any exception, don't close
+
+    monkeypatch.setattr(session_mod, "_session_factory", lambda: _PassthroughFactory())
 
     app = FastAPI()
     app.add_middleware(AuthMiddleware)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -15,8 +15,6 @@ def test_settings_load_with_defaults(isolated_env):
     assert s.orcarouter_base_url == "https://api.orcarouter.ai/v1"
     assert s.orcarouter_api_key is None
     assert s.openai_api_key is None
-    # ~100 MiB body limit for file attachments
-    assert s.max_body_bytes == 100 * 1024 * 1024
 
 
 def test_settings_reads_env_provider_keys(isolated_env, monkeypatch):


### PR DESCRIPTION
## Summary

Fix a real connection-pool leak in the auth middleware, plus drop a config knob that was declared but never wired up.

## Why this matters

The middleware consumed `get_session()` with `async for s in get_session(): break`. When `validate_api_key` raised (bad key, network blip, anything), Python deferred the generator's cleanup to GC. Each failed auth left an open SQLAlchemy session loitering until GC ran.

SQLAlchemy's default pool size is 5. Hammer the server with bad-key requests and the pool gets exhausted; subsequent legitimate auth attempts block waiting for a connection that won't come back until GC.

## What changed

`async with _session_factory() as session:` directly. The context manager's `__aexit__` runs synchronously on every exit path before the exception propagates, so the session is back in the pool within microseconds — no GC dependency.

Also dropped `max_body_bytes` and its test. It was declared in #15 but no middleware ever read it. We're a single-tenant tool — the operator picks the clients sending payloads, so a server-side cap is solving a SaaS problem we don't have. A reverse proxy (nginx, Caddy) is the right place to enforce a hard cap when an operator does need one.

## Test plan

- [x] `pytest tests/integration/test_auth_middleware.py` — 4 existing tests pass after fixture update (patch target moved from removed `get_session` import to `session_mod._session_factory`)
- [x] Full suite: 242 passing (excluding 4 pre-existing `test_unreachable.py` failures unrelated to this PR)
- [x] `ruff check` clean
- [x] Manual: 5 functional curl checks (no auth / bad scheme / invalid key / valid key / `/health` bypass) — all expected status codes
- [x] Manual leak verification: 200 parallel invalid-bearer requests against the running server hold `lsof` orca.db handles at **5** (pool cap). Without the fix this would have climbed past 5 as sessions piled up waiting for GC.

## Notes

- Followup to #22 (PR 3 in the rolling cleanup list).
- Fixture refactor is the only test churn — production behavior on success paths is unchanged.