### PR TITLE
Stop test_unreachable.py from flaking on dev machines with .env keys

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,14 @@ def _isolate_orcarouter_remote(request, monkeypatch):
 
 @pytest.fixture
 def isolated_env(monkeypatch) -> Generator[None, None, None]:
-    """Strip every ORCA_*/OPENAI_*/ANTHROPIC_*/etc env var before a test."""
+    """Strip every ORCA_*/OPENAI_*/ANTHROPIC_*/etc env var before a test.
+
+    Also blocks pydantic-settings from re-reading them out of `.env`
+    on the next `Settings()` instantiation. Without this guard, tests
+    asserting "no providers configured" silently pull whatever is in
+    the developer's local `.env` (which usually has real keys for
+    manual testing) and flake under those configurations.
+    """
     drop = [
         k for k in os.environ
         if k.startswith(("OPENAI_", "ANTHROPIC_", "GOOGLE_", "GROQ_",
@@ -75,6 +82,17 @@ def isolated_env(monkeypatch) -> Generator[None, None, None]:
     ]
     for k in drop:
         monkeypatch.delenv(k, raising=False)
+
+    # Stop pydantic-settings from re-reading `.env` and undoing the
+    # delenv work above. The class-level model_config dict is shared
+    # across every Settings() call, so monkeypatch.setitem (which
+    # restores on teardown) is the right scope.
+    try:
+        from app.config import Settings
+        monkeypatch.setitem(Settings.model_config, "env_file", None)
+    except Exception:
+        pass
+
     yield
 
 

--- a/tests/integration/test_unreachable.py
+++ b/tests/integration/test_unreachable.py
@@ -54,7 +54,7 @@ async def fresh_client(tmp_sqlite_url, monkeypatch):
     session_mod._session_factory = None
 
 
-async def test_unreachable_backfills_from_static_when_remote_ids_unknown(tmp_sqlite_url, monkeypatch):
+async def test_unreachable_backfills_from_static_when_remote_ids_unknown(tmp_sqlite_url, monkeypatch, isolated_env):
     """Codex P2: when orcarouter.ai promotes IDs that this Lite build's
     catalog doesn't know (newer model names, vendor-specific aliases),
     every entry would be filtered out in the catalog lookup loop and
@@ -127,7 +127,7 @@ async def test_unreachable_backfills_from_static_when_remote_ids_unknown(tmp_sql
     orcarouter_models.reset_cache()
 
 
-async def test_unreachable_uses_remote_top_n_list(tmp_sqlite_url, monkeypatch):
+async def test_unreachable_uses_remote_top_n_list(tmp_sqlite_url, monkeypatch, isolated_env):
     """The unreachable tile must reflect what orcarouter.ai actually
     promotes (top-N from /models), not a list compiled into the source.
     Stub the fetcher and verify the endpoint surfaces THOSE IDs."""
@@ -193,7 +193,7 @@ async def test_unreachable_uses_remote_top_n_list(tmp_sqlite_url, monkeypatch):
     orcarouter_models.reset_cache()
 
 
-async def test_unreachable_with_no_keys_lists_flagship_models(fresh_client):
+async def test_unreachable_with_no_keys_lists_flagship_models(isolated_env, fresh_client):
     """A bare-bones Lite install with no provider keys can't reach any
     flagship model — the endpoint should return a non-empty list to power
     the conversion CTA."""
@@ -263,7 +263,7 @@ async def test_unreachable_respects_limit(fresh_client):
     assert len(body["unreachable"]) <= 3
 
 
-async def test_unreachable_excludes_undecryptable_provider_keys(tmp_sqlite_url, monkeypatch):
+async def test_unreachable_excludes_undecryptable_provider_keys(tmp_sqlite_url, monkeypatch, isolated_env):
     """Codex P2: an enabled DB row with a corrupt encrypted_key isn't
     actually deployable (build_deployments drops it). The unreachable
     endpoint must not silently treat that provider as 'covered' — those


### PR DESCRIPTION
## Summary

Four `test_unreachable.py` cases were silently leaking the developer machine's `.env` file into setup. CI passes because CI's `.env` is empty; on any laptop with real provider keys (every developer doing manual chat testing), the suite shows 4 spurious red lines that mask real regressions in subsequent PRs.

## Root cause

`isolated_env` fixture cleared `os.environ` but pydantic-settings also reads `.env`. The fixture's `monkeypatch.delenv` did nothing against that path — every `get_settings()` call re-loaded the same keys from `.env` and the test's "no providers configured" assertion blew up.

## Fix

1. `isolated_env` now also patches `Settings.model_config["env_file"] = None` for the fixture's scope, so pydantic-settings can't undo the cleanup via the .env back-door.
2. Four failing tests request `isolated_env` in their signatures. Tests that intentionally exercise env-key behavior (`_excludes_models_for_configured_providers`, `_counts_env_provider_keys`) keep using the real env on purpose — `isolated_env` stays opt-in rather than autouse.
3. For the test using `fresh_client`, fixture argument order matters (pytest sets up positional fixtures left-to-right when there's no explicit dependency edge). Listed `isolated_env` first so it patches `Settings` before `fresh_client` instantiates the FastAPI app.

## Test plan

- [x] `pytest tests/integration/test_unreachable.py` — 9/9 pass on local dev machine (was 5/9)
- [x] Full suite: 251 passing, 0 failing (was 247 + 4 red)
- [x] `ruff check` clean
- [x] CI should still pass (CI's empty `.env` means the fixture change is a no-op for CI; the local-only failures are what we're fixing)

## Why this matters

CI baseline is now actionable. Before this PR, anyone running tests locally had to mentally subtract these 4 known-red lines, which made it easy to miss when a real regression added a 5th red line. After: any red line is a real signal.