### PR TITLE
Make balanced + fastest routing strategies functionally distinct

### DIFF
--- a/app/auto_routing.py
+++ b/app/auto_routing.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable
+from dataclasses import dataclass
 
 from packages.litellm_adapter.catalog import CatalogModel
 
@@ -93,15 +94,68 @@ _OUTPUT_WEIGHT = 0.7
 
 
 # Map our user-facing strategy names to litellm.Router's `routing_strategy`.
-# `balanced` and `quality` use litellm's default (simple-shuffle, weighted by
-# RPM/TPM) — strategy intent is realised in `choose_auto_model` for `quality`,
-# and is a no-op for `balanced`. `None` means "don't pass routing_strategy".
+# We do the strategy-specific ordering ourselves in `choose_auto_model`
+# (balanced + fastest as of PR 4); litellm only sees the resulting fallback
+# chain. `latency-based-routing` is a no-op when each model has a single
+# deployment, which is our shape — so `fastest` is None too.
 STRATEGY_TO_LITELLM: dict[str, str | None] = {
     "balanced": None,
     "cheapest": "cost-based-routing",
-    "fastest": "latency-based-routing",
+    "fastest": None,
     "quality": None,
 }
+
+
+@dataclass(frozen=True)
+class ScoringDetail:
+    """Per-model scoring breakdown returned alongside ranked candidates.
+
+    Lets `/auto-preview` surface the same numbers the ranker used (no
+    DRY drift from re-implementing normalize / weight in the route).
+
+    `primary_score`:
+      - `None` for `cheapest` (single axis, raw cost has no 0-100 sense)
+      - 0-100 int for `quality` (raw AA intelligence_index, rounded)
+      - 0-100 int for `balanced` / `fastest` (combined × 100, rounded)
+
+    `breakdown`:
+      - `cheapest` → `{"cost": {"raw": float, "normalized": None}}`
+      - `quality`  → `{"quality": {"raw": float, "normalized": None}}`
+      - `balanced` → `{"quality": {raw, normalized}, "cost": {raw, normalized}}`
+      - `fastest`  → `{"tps": {raw, normalized}, "ttft": {raw, normalized}}`
+    """
+    primary_score: int | None
+    breakdown: dict[str, dict[str, float | None]]
+
+
+def _normalize(values: dict[str, float], model_ids: list[str]) -> dict[str, float]:
+    """min-max normalize to [0, 1] over models present in `values`.
+
+    Caller pre-filters: only model_ids that have data in this axis are
+    expected. range collapse (all equal) → all 1.0 so tiebreakers
+    decide. Empty input → empty output (let caller handle the empty
+    candidate set explicitly).
+    """
+    present = [values[mid] for mid in model_ids if mid in values]
+    if not present:
+        return {}
+    lo, hi = min(present), max(present)
+    if hi == lo:
+        return {mid: 1.0 for mid in model_ids if mid in values}
+    span = hi - lo
+    return {
+        mid: (values[mid] - lo) / span
+        for mid in model_ids if mid in values
+    }
+
+
+def _cheapest_breakdown(m: CatalogModel) -> ScoringDetail:
+    """Cheapest has a single raw axis (blended cost). No primary_score
+    because there's no meaningful 0-100 mapping for raw token cost."""
+    return ScoringDetail(
+        primary_score=None,
+        breakdown={"cost": {"raw": _blended_cost(m), "normalized": None}},
+    )
 
 
 def litellm_routing_strategy(strategy: str | None) -> str | None:
@@ -170,25 +224,44 @@ def choose_auto_model(
     preferred_models: list[str] | None = None,
     allowlist: list[str] | set[str] | None = None,
     quality_scores: dict[str, float] | None = None,
+    tps_scores: dict[str, float] | None = None,
+    ttft_scores: dict[str, float] | None = None,
     top_n: int = 5,
-) -> list[str]:
-    """Return up to `top_n` deployable models matching all `needs`, best first.
+) -> tuple[list[str], dict[str, ScoringDetail]]:
+    """Return up to `top_n` deployable models matching all `needs`, best first,
+    plus a per-model scoring breakdown for the survivors.
 
-    Empty list means no candidate satisfies the request. The first element is
-    the primary; subsequent elements are intended as LiteLLM Router fallbacks
-    so a 404 / cooldown on the primary cascades to the next-best candidate
-    without the user seeing an error.
+    Empty `(list, dict)` means no candidate satisfies the request. The first
+    list element is the primary; subsequent elements are intended as LiteLLM
+    Router fallbacks so a 404 / cooldown on the primary cascades to the
+    next-best candidate without the user seeing an error.
+
+    The scoring dict is keyed by **dedupe-survivor model_id** (the same
+    ones in the returned list). `/auto-preview` uses it to render the
+    breakdown without re-implementing the ranker (no DRY drift).
 
     Selection rule by strategy:
       - `quality`: highest quality_score first (when scores are non-empty),
-        cost as the tie-breaker. Falls back to "highest blended cost" when
-        no scores are provided — the legacy proxy that breaks for newer
-        flagships priced lower than older ones (Anthropic Opus 4.7 vs
-        Opus 4 from May 2024). Provide AA scores via `quality_scores=`.
-      - everything else (`cheapest` / `balanced` / `fastest` / None): lowest
-        blended cost. `fastest` shares the cheapest-capable rule because the
-        catalog has no per-model latency data; ordering across deployments of
-        the same model is handled by litellm's `latency-based-routing`.
+        cost as the tie-breaker. Unscored models drop to the bottom of the
+        quality ranking but stay eligible — better to surface them than to
+        disappear them on a transient AA outage. Falls back to
+        "highest blended cost" when no scores are provided (the legacy
+        proxy that breaks for newer flagships priced lower than older ones).
+      - `balanced`: 50/50 weighted normalize of quality (max=better) and
+        inverted cost (min=better). STRICT axis coverage: a model needs
+        BOTH axes to participate in ranking; cost is universal but quality
+        depends on AA + overrides. Models lacking quality data are dropped
+        from the candidate set entirely (NOT re-appended at the end —
+        keeping them in would let LiteLLM's fallback chain serve traffic
+        from a model the operator's strategy says shouldn't be eligible).
+        Operators who need to cover unscored models should use `cheapest`
+        or add a manual quality override.
+      - `fastest`: 50/50 weighted normalize of TPS (max=faster) and inverted
+        TTFT (min=faster). STRICT axis coverage: BOTH TPS and TTFT
+        required, same drop semantics as balanced. Without strict-both,
+        a single-axis model normalizes to 1.0 on its only axis and beats
+        a fully-scored model with mixed performance — reverse bias.
+      - `cheapest` / None: lowest blended cost.
 
     If `preferred_models` is non-empty AND at least one entry is deployable
     + capability-matching, the eligible set is restricted to that list. This
@@ -224,24 +297,137 @@ def choose_auto_model(
         allow_set = set(allowlist)
         eligible = [m for m in eligible if m.id in allow_set]
     if not eligible:
-        return []
+        return [], {}
+
+    # Per-strategy: sort `eligible` (which may shrink under strict-coverage)
+    # AND build a per-model `scoring_per_model` dict keyed by id. Dedupe +
+    # truncate at the end keeps the scoring entries for the survivors.
+    scoring_per_model: dict[str, ScoringDetail] = {}
+
     if strategy == "quality":
-        # When AA scores (or operator overrides) are available, sort by
-        # score descending. Cost is a tie-breaker (most expensive among
-        # equally-scored models tends to be the flagship version vs a
-        # smaller variant). Unscored models drop to the bottom of the
-        # quality ranking but stay eligible — better to surface them
-        # than to disappear them on a transient AA outage.
+        # PR #20 behavior preserved: scored models first by quality desc,
+        # unscored stay eligible at the bottom. NOT strict-coverage (a
+        # `quality` operator with partial AA still wants their unscored
+        # models routable as fallback rather than disappearing).
         if quality_scores:
             eligible.sort(
                 key=lambda m: (-quality_scores.get(m.id, 0.0), -_blended_cost(m), m.id)
             )
+            for m in eligible:
+                raw = quality_scores.get(m.id)
+                scoring_per_model[m.id] = ScoringDetail(
+                    primary_score=int(round(raw)) if raw is not None else None,
+                    breakdown={
+                        "quality": {
+                            "raw": float(raw) if raw is not None else None,
+                            "normalized": None,
+                        }
+                    },
+                )
         else:
-            # Legacy fallback: cost-as-quality-proxy. Wrong for modern
-            # pricing but stable when no benchmark data is available.
+            # Legacy: cost-as-quality-proxy when no benchmark data.
             eligible.sort(key=lambda m: (-_blended_cost(m), m.id))
-    else:
+            for m in eligible:
+                scoring_per_model[m.id] = _cheapest_breakdown(m)
+
+    elif strategy == "balanced":
+        # Strict coverage: model needs BOTH quality and cost. Drop unscored.
+        if quality_scores:
+            scored_models = [m for m in eligible if m.id in quality_scores]
+            if scored_models:
+                scored_ids = [m.id for m in scored_models]
+                cost_inv = {m.id: -_blended_cost(m) for m in scored_models}
+                c_norm = _normalize(cost_inv, scored_ids)
+                q_subset = {mid: quality_scores[mid] for mid in scored_ids}
+                q_norm = _normalize(q_subset, scored_ids)
+
+                def _bal_score(m: CatalogModel) -> float:
+                    return 0.5 * q_norm[m.id] + 0.5 * c_norm[m.id]
+
+                scored_models.sort(key=lambda m: (
+                    -_bal_score(m),
+                    _blended_cost(m),  # tiebreak 1: cheapest wins
+                    m.id,              # tiebreak 2: stable
+                ))
+                eligible = scored_models  # ← strict drop
+                for m in scored_models:
+                    scoring_per_model[m.id] = ScoringDetail(
+                        primary_score=int(round(_bal_score(m) * 100)),
+                        breakdown={
+                            "quality": {
+                                "raw": float(quality_scores[m.id]),
+                                "normalized": q_norm[m.id],
+                            },
+                            "cost": {
+                                "raw": _blended_cost(m),
+                                "normalized": c_norm[m.id],
+                            },
+                        },
+                    )
+            else:
+                # Strict-cov empty: fall back to cheapest within current
+                # eligible (already filtered for deployable / allowlist).
+                eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+                for m in eligible:
+                    scoring_per_model[m.id] = _cheapest_breakdown(m)
+        else:
+            # No AA + no overrides → cheapest within eligible.
+            eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+            for m in eligible:
+                scoring_per_model[m.id] = _cheapest_breakdown(m)
+
+    elif strategy == "fastest":
+        # Strict coverage: model needs BOTH TPS and TTFT.
+        tps_set = set(tps_scores or {})
+        ttft_set = set(ttft_scores or {})
+        both_set = tps_set & ttft_set
+        if both_set:
+            scored_models = [m for m in eligible if m.id in both_set]
+            if scored_models:
+                scored_ids = [m.id for m in scored_models]
+                tps_subset = {mid: tps_scores[mid] for mid in scored_ids}
+                tps_norm = _normalize(tps_subset, scored_ids)
+                # Lower TTFT = faster, so invert before normalizing so the
+                # normalized score points the same way as TPS (higher = better).
+                ttft_inv = {mid: -ttft_scores[mid] for mid in scored_ids}
+                ttft_norm = _normalize(ttft_inv, scored_ids)
+
+                def _fast_score(m: CatalogModel) -> float:
+                    return 0.5 * tps_norm[m.id] + 0.5 * ttft_norm[m.id]
+
+                scored_models.sort(key=lambda m: (
+                    -_fast_score(m),
+                    _blended_cost(m),
+                    m.id,
+                ))
+                eligible = scored_models  # ← strict drop
+                for m in scored_models:
+                    scoring_per_model[m.id] = ScoringDetail(
+                        primary_score=int(round(_fast_score(m) * 100)),
+                        breakdown={
+                            "tps": {
+                                "raw": float(tps_scores[m.id]),
+                                "normalized": tps_norm[m.id],
+                            },
+                            "ttft": {
+                                "raw": float(ttft_scores[m.id]),
+                                "normalized": ttft_norm[m.id],
+                            },
+                        },
+                    )
+            else:
+                eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+                for m in eligible:
+                    scoring_per_model[m.id] = _cheapest_breakdown(m)
+        else:
+            eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+            for m in eligible:
+                scoring_per_model[m.id] = _cheapest_breakdown(m)
+
+    else:  # cheapest / None
         eligible.sort(key=lambda m: (_blended_cost(m), m.id))
+        for m in eligible:
+            scoring_per_model[m.id] = _cheapest_breakdown(m)
 
     # Dedupe sibling versions: a model and its dated/numbered variants
     # ("gemini-2.0-flash-lite" + "...-001", "gpt-5-nano" + "...-2025-08-07")
@@ -257,4 +443,8 @@ def choose_auto_model(
         seen_bases.add(base)
         deduped.append(m)
 
-    return [m.id for m in deduped[:top_n]]
+    final = deduped[:top_n]
+    final_ids = [m.id for m in final]
+    # Filter scoring to survivors only — sibling-deduped models drop out.
+    scoring = {mid: scoring_per_model[mid] for mid in final_ids if mid in scoring_per_model}
+    return final_ids, scoring

--- a/app/quality_scores.py
+++ b/app/quality_scores.py
@@ -1,16 +1,38 @@
-"""Resolve effective quality scores: AA index + manual operator overrides.
+"""Resolve effective quality + latency metrics: AA index + manual operator
+overrides + a 60s in-process cache to keep balanced/fastest off the
+DB-query hot path.
 
-Routing layer (auto_routing.choose_auto_model) treats the merged dict as
-authoritative. Manual overrides win unconditionally over AA scores;
-operators use overrides when AA's coverage is missing or their own evals
-disagree with AA's ranking.
+Routing layer (auto_routing.choose_auto_model) treats the merged maps
+as authoritative. Manual overrides win unconditionally over AA quality
+scores; operators use overrides when AA's coverage is missing or their
+own evals disagree with AA's ranking. TPS / TTFT have no override
+concept (they're benchmark medians, not opinions).
 
-This module is the single seam where the two data sources meet — keep
-all merge / precedence logic here so callers (chat.py, /v1/quality
-routes) consume one consistent view.
+This module is the single seam where data sources meet — keep all
+merge / precedence logic here so callers (chat.py, /v1/quality routes)
+consume one consistent view.
+
+In-process metrics cache: balanced is the default routing strategy, so
+every `model="auto"` request walks this path. Without a cache, each
+request would do a DB lookup for overrides even when the AA payload
+itself is hot. We cache the merged ResolvedMetrics for 60 seconds keyed
+by (workspace_id, AA-key-hash); override PUT/DELETE and quality refresh
+routes invalidate the relevant entries so operator changes are visible
+immediately, not after a TTL.
+
+Multi-worker note: cache is module-local. Multi-worker uvicorn or k8s
+replicas each hold their own — a worker that didn't see the override
+mutation serves stale until its own TTL expires. Acceptable for the
+single-tenant Lite default (1 worker); cross-worker invalidation
+(pubsub / shared cache) belongs to a future PR if multi-worker
+deployment becomes a real use case.
 """
 
 from __future__ import annotations
+
+import hashlib
+import time
+from dataclasses import dataclass
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -72,3 +94,93 @@ async def resolve_quality_scores(
     merged = dict(aa.scores)
     merged.update(overrides)
     return merged
+
+
+@dataclass(frozen=True)
+class ResolvedMetrics:
+    """Effective metrics after merging AA + manual overrides.
+
+    `quality_scores` carries the override-merged map (operator wins).
+    TPS / TTFT are AA passthrough — there's no operator-override concept
+    for benchmark latency medians.
+    """
+    quality_scores: dict[str, float]
+    tps_scores: dict[str, float]
+    ttft_scores: dict[str, float]
+
+
+# Module-level cache, keyed by (workspace_id, aa_key_hash). 60s TTL.
+# Mirrors the router_cache.py pattern (process-local, hot-path).
+_metrics_cache: dict[tuple[str, str], tuple[ResolvedMetrics, float]] = {}
+_METRICS_TTL = 60.0  # seconds
+
+
+def _hash_aa_key(api_key: str) -> str:
+    """sha256(key)[:16] — stable per-account identity. Empty string when
+    no AA key configured (all unconfigured workspaces share that hash,
+    which is fine because workspace_id is also part of the cache key)."""
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()[:16]
+
+
+async def resolve_model_metrics(
+    *,
+    db: AsyncSession,
+    workspace_id: str,
+    force_refresh: bool = False,
+) -> ResolvedMetrics:
+    """Return the merged metrics for the given workspace.
+
+    Cache hit: a single dict lookup, microseconds. Cache miss: at most
+    one AA fetch (often itself cached at the AA layer) + one DB query
+    for overrides. The downstream router calls this on every
+    `model="auto"` request — the cache exists so default `balanced`
+    routing doesn't re-query the DB once per request.
+
+    Cache invalidation: see `invalidate_metrics_cache()`. Hooked from
+    override PUT/DELETE and quality refresh routes so operator
+    mutations are visible without waiting for TTL.
+    """
+    from app.config import get_settings
+
+    aa_key_hash = _hash_aa_key(get_settings().artificial_analysis_api_key or "")
+    cache_key = (workspace_id, aa_key_hash)
+    if not force_refresh:
+        cached = _metrics_cache.get(cache_key)
+        if cached is not None and (time.monotonic() - cached[1]) < _METRICS_TTL:
+            return cached[0]
+
+    aa = await fetch_aa_index(
+        db=db, workspace_id=workspace_id, force_refresh=force_refresh,
+    )
+    overrides = await load_overrides(db, workspace_id)
+    quality = dict(aa.scores)
+    quality.update(overrides)   # override 优先
+    metrics = ResolvedMetrics(
+        quality_scores=quality,
+        tps_scores=dict(aa.tps_scores),
+        ttft_scores=dict(aa.ttft_scores),
+    )
+    _metrics_cache[cache_key] = (metrics, time.monotonic())
+    return metrics
+
+
+def invalidate_metrics_cache(workspace_id: str | None = None) -> None:
+    """Drop cache entries.
+
+    `workspace_id=None` clears everything (use when AA fetch refreshes
+    globally — a new fetch could change scores for any workspace's
+    routing). Otherwise drops only entries for the given workspace
+    across all AA-key-hashes (covers the case where the operator
+    rotated the AA key without us noticing the hash change).
+    """
+    if workspace_id is None:
+        _metrics_cache.clear()
+        return
+    for key in list(_metrics_cache):
+        if key[0] == workspace_id:
+            del _metrics_cache[key]
+
+
+def reset_metrics_cache() -> None:
+    """Clear the in-process metrics cache. Call from test fixtures."""
+    _metrics_cache.clear()

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -28,7 +28,7 @@ from app.auto_routing import (
 )
 from app.config import get_settings
 from app.deps import get_db, get_key_context
-from app.quality_scores import resolve_quality_scores
+from app.quality_scores import resolve_model_metrics
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.db.models.request_log import RequestLog
@@ -293,23 +293,28 @@ async def chat_completions(
                     "configured key. No deployable provider found."
                 ),
             )
-        # When strategy is "quality", merge AA's Intelligence Index with
-        # any manual operator overrides from the dashboard. Manual >  AA >
-        # nothing. Empty dict (no AA key + no overrides) → resolver falls
-        # back to the legacy cost-based proxy. Skipped for non-quality
-        # strategies so we don't pay the cost on cheapest/balanced/fastest
-        # calls that don't use the scores.
+        # `quality`, `balanced`, `fastest` all want AA-derived metrics.
+        # `resolve_model_metrics` does the AA fetch + merges manual
+        # overrides for the quality axis (TPS / TTFT have no override
+        # concept) and is cached at the resolver layer for 60s, so the
+        # default `balanced` strategy doesn't pay a DB hit per request.
+        # Skipped for `cheapest` / None where the metrics aren't used.
         quality_scores: dict[str, float] | None = None
-        if strategy == "quality":
-            quality_scores = await resolve_quality_scores(
+        tps_scores: dict[str, float] | None = None
+        ttft_scores: dict[str, float] | None = None
+        if strategy in ("quality", "balanced", "fastest"):
+            metrics = await resolve_model_metrics(
                 db=db, workspace_id=str(kc.workspace_id),
             )
+            quality_scores = metrics.quality_scores
+            tps_scores = metrics.tps_scores
+            ttft_scores = metrics.ttft_scores
 
         # Pass the key's allowlist into the resolver so it filters BEFORE
         # the top-N truncation. Without this, an allowed model ranked at
         # position 6+ would be silently dropped by top_n=5 and the user
         # would see a false 403 even though they have a valid candidate.
-        candidates = choose_auto_model(
+        candidates, _scoring = choose_auto_model(
             needs=needs,
             deployable=deployable,
             candidates=CATALOG,
@@ -317,6 +322,8 @@ async def chat_completions(
             preferred_models=preferred_models,
             allowlist=kc.model_allowlist,
             quality_scores=quality_scores,
+            tps_scores=tps_scores,
+            ttft_scores=ttft_scores,
         )
         if not candidates:
             # Empty result has two distinct causes — distinguish them so the
@@ -328,7 +335,7 @@ async def chat_completions(
             # applies. Cheap (in-memory list comprehension, no DB / network).
             # Use `is not None` to honor explicit empty allowlist (deny-all).
             if kc.model_allowlist is not None:
-                any_capable = choose_auto_model(
+                any_capable, _ = choose_auto_model(
                     needs=needs,
                     deployable=deployable,
                     candidates=CATALOG,
@@ -336,6 +343,8 @@ async def chat_completions(
                     preferred_models=preferred_models,
                     allowlist=None,
                     quality_scores=quality_scores,
+                    tps_scores=tps_scores,
+                    ttft_scores=ttft_scores,
                     top_n=1,
                 )
                 if any_capable:

--- a/app/routes/quality.py
+++ b/app/routes/quality.py
@@ -33,8 +33,9 @@ from app.auto_routing import (
 from app.deps import get_db, get_key_context
 from app.quality_scores import (
     fetch_aa_index,
+    invalidate_metrics_cache,
     load_overrides,
-    resolve_quality_scores,
+    resolve_model_metrics,
 )
 from packages.auth.types import KeyContext
 from packages.db.models.quality_score_override import QualityScoreOverride
@@ -58,11 +59,22 @@ def _serialize_aa_index(idx) -> dict[str, Any]:
     clients. The dashboard uses `raw_count` / `matched_count` for
     freshness signal; the `source` flag distinguishes live vs stale
     (in-process) vs stale (DB).
+
+    `matched_count` is the union (catalog IDs covered by ANY axis), so
+    the dashboard's "X of Y AA models indexed" string still reads as a
+    single useful number. `matched_count_breakdown` exposes the per-axis
+    counts for callers that want to distinguish quality vs latency
+    coverage.
     """
     return {
         "source": idx.source,
         "raw_count": idx.raw_count,
         "matched_count": idx.matched_count,
+        "matched_count_breakdown": {
+            "quality": idx.matched_count_quality,
+            "tps": idx.matched_count_tps,
+            "ttft": idx.matched_count_ttft,
+        },
         "configured": idx.source != "missing-key",
     }
 
@@ -108,6 +120,10 @@ async def quality_status(
                 "aa_score": aa_score,
                 "manual_score": manual_score,
                 "effective_score": effective,
+                # Latency metrics from AA — None when AA didn't cover this
+                # model on that axis. Dashboard renders "—" for None.
+                "tps": aa.tps_scores.get(m.id),
+                "ttft": aa.ttft_scores.get(m.id),
                 "supports_tools": m.supports_tools,
                 "supports_vision": m.supports_vision,
                 "supports_json_mode": m.supports_json_mode,
@@ -150,11 +166,46 @@ async def quality_refresh(
     this to get back online without waiting for natural expiry.
     On AA success, the new snapshot is also persisted to the DB so the
     next process restart inherits it.
+
+    Also drops the resolver-layer metrics cache so balanced/fastest
+    routing sees the fresh values on the very next request, not after
+    the 60s TTL.
     """
     aa = await fetch_aa_index(
         db=db, workspace_id=str(kc.workspace_id), force_refresh=True,
     )
+    invalidate_metrics_cache()  # global — AA fetch refreshes for all workspaces
     return {"aa_index": _serialize_aa_index(aa)}
+
+
+_VALID_STRATEGIES = {"cheapest", "balanced", "fastest", "quality"}
+
+# Human-readable scoring source per strategy + data-availability state.
+# Surfaced verbatim in the dashboard preview ("scoring: ...").
+#
+# The two fallback labels per strategy distinguish:
+#   - "*-cheapest-fallback":         AA data is configured but doesn't cover ANY
+#                                     model in this request's eligible set
+#                                     (deployable + capability + allowlist).
+#                                     Operator likely needs to widen the
+#                                     allowlist or add a manual quality override.
+#   - "*-no-data-fallback":          AA data is globally unavailable (no key
+#                                     configured, AA outage, no overrides).
+#                                     Operator should configure AA or accept
+#                                     cost-only routing.
+# Both fall back to cheapest of the eligible set; differentiating in the UI
+# tells the operator which knob to turn.
+_SCORING_SOURCE_LABELS = {
+    "balanced": "AA quality + catalog cost (50/50 normalized)",
+    "balanced-cheapest-fallback": "AA covers no eligible models — fell back to cheapest",
+    "balanced-no-data-fallback": "no AA quality data configured — fell back to cheapest",
+    "fastest": "AA TPS + AA TTFT (50/50 normalized)",
+    "fastest-cheapest-fallback": "AA covers no eligible models on TPS+TTFT — fell back to cheapest",
+    "fastest-no-data-fallback": "no AA latency data configured — fell back to cheapest",
+    "quality": "AA Intelligence Index + manual overrides",
+    "quality-cost-fallback": "no AA quality data — using cost-as-quality proxy (legacy)",
+    "cheapest": "blended cost (0.3 input + 0.7 output)",
+}
 
 
 @router.get("/auto-preview")
@@ -166,15 +217,25 @@ async def quality_auto_preview(
             "'json_mode'. Empty for plain chat."
         ),
     ),
+    strategy: str | None = Query(
+        None,
+        description=(
+            "Override the workspace's active strategy for this preview only. "
+            "Lets verification curl/tests compare all four strategies "
+            "without flipping the persisted routing config. Dashboard does "
+            "NOT pass this — it relies on the workspace strategy as the "
+            "authoritative source to avoid race conditions during initial load."
+        ),
+    ),
     kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Show what model `model='auto'` would resolve to right now under the
-    workspace's active strategy.
+    workspace's active strategy (or the `?strategy=` override, if given).
 
-    The dashboard re-fetches this on strategy change so the operator sees
-    the routing decision change live, instead of having to fire a real
-    chat completion to find out.
+    Returns the same scoring breakdown the ranker computed, so the
+    dashboard renders exactly the numbers that drove the decision (no
+    DRY drift from re-implementing normalize / weight in the route).
     """
     needs_set: set[str] = (
         {n.strip() for n in needs.split(",") if n.strip()} if needs else set()
@@ -182,9 +243,14 @@ async def quality_auto_preview(
 
     client = await router_cache.get_router(db)
     raw_strategy = getattr(client, "strategy", None)
-    strategy = (
+    workspace_strategy = (
         raw_strategy if isinstance(raw_strategy, str) and raw_strategy else "balanced"
     )
+    if strategy and strategy in _VALID_STRATEGIES:
+        effective_strategy = strategy
+    else:
+        effective_strategy = workspace_strategy
+
     raw_preferred = getattr(client, "preferred_models", None)
     preferred_models = raw_preferred if isinstance(raw_preferred, list) else []
 
@@ -193,48 +259,84 @@ async def quality_auto_preview(
     }
 
     quality_scores: dict[str, float] | None = None
-    if strategy == "quality":
-        quality_scores = await resolve_quality_scores(
+    tps_scores: dict[str, float] | None = None
+    ttft_scores: dict[str, float] | None = None
+    if effective_strategy in ("quality", "balanced", "fastest"):
+        metrics = await resolve_model_metrics(
             db=db, workspace_id=str(kc.workspace_id)
         )
+        quality_scores = metrics.quality_scores
+        tps_scores = metrics.tps_scores
+        ttft_scores = metrics.ttft_scores
 
-    candidates = choose_auto_model(
+    candidates, scoring = choose_auto_model(
         needs=needs_set,
         deployable=deployable,
         candidates=CATALOG,
-        strategy=strategy,
+        strategy=effective_strategy,
         preferred_models=preferred_models,
         allowlist=kc.model_allowlist,
         quality_scores=quality_scores,
+        tps_scores=tps_scores,
+        ttft_scores=ttft_scores,
     )
 
     primary = candidates[0] if candidates else None
     primary_model = CATALOG_BY_ID.get(primary) if primary else None
+    primary_detail = scoring.get(primary) if primary else None
+
+    # scoring_source: distinguish "ran the strategy as designed" vs
+    # "fell back to cheapest because the data wasn't there". Helps the
+    # operator interpret a primary that doesn't match their strategy
+    # selection (and could indicate a missing AA key vs a too-narrow
+    # allowlist that excludes everything AA covers).
+    if effective_strategy == "balanced":
+        if (primary_detail and primary_detail.breakdown
+                and "quality" in primary_detail.breakdown):
+            source_key = "balanced"
+        elif quality_scores:
+            # AA data is configured (and possibly covers OTHER models)
+            # but no eligible model in this request has it. Operator
+            # likely has an allowlist that excludes covered models.
+            source_key = "balanced-cheapest-fallback"
+        else:
+            source_key = "balanced-no-data-fallback"
+    elif effective_strategy == "fastest":
+        if (primary_detail and primary_detail.breakdown
+                and "tps" in primary_detail.breakdown):
+            source_key = "fastest"
+        elif tps_scores and ttft_scores:
+            source_key = "fastest-cheapest-fallback"
+        else:
+            source_key = "fastest-no-data-fallback"
+    elif effective_strategy == "quality":
+        source_key = "quality" if quality_scores else "quality-cost-fallback"
+    else:
+        source_key = "cheapest"
+
+    # Serialize ScoringDetail for JSON. dataclass with frozen=True doesn't
+    # JSON-encode automatically; pull fields explicitly to keep the wire
+    # format under our control (no leaky internal types).
+    primary_score = primary_detail.primary_score if primary_detail else None
+    primary_breakdown = primary_detail.breakdown if primary_detail else None
 
     return {
-        "strategy": strategy,
-        "litellm_routing_strategy": litellm_routing_strategy(strategy),
+        "strategy": effective_strategy,
+        "workspace_strategy": workspace_strategy,
+        "strategy_overridden": effective_strategy != workspace_strategy,
+        "litellm_routing_strategy": litellm_routing_strategy(effective_strategy),
         "needs": sorted(needs_set),
         "preferred_models": preferred_models,
         "deployable_count": len(deployable),
         "primary": primary,
-        "primary_score": (
-            quality_scores.get(primary) if (quality_scores and primary) else None
-        ),
+        "primary_score": primary_score,
+        "primary_score_breakdown": primary_breakdown,
         "primary_blended_cost": (
             _blended_cost(primary_model) if primary_model else None
         ),
         "fallbacks": candidates[1:] if len(candidates) > 1 else [],
         "fallbacks_count": max(0, len(candidates) - 1),
-        "scoring_source": (
-            "quality_scores"
-            if (strategy == "quality" and quality_scores)
-            else (
-                "cost-based-fallback"
-                if strategy == "quality"
-                else f"strategy:{strategy}"
-            )
-        ),
+        "scoring_source": _SCORING_SOURCE_LABELS.get(source_key, source_key),
     }
 
 
@@ -348,6 +450,9 @@ async def upsert_override(
                 )
             )
         ).scalar_one()
+    # Drop the resolver cache so balanced + quality routing see the new
+    # override on the very next request (otherwise stale up to 60s TTL).
+    invalidate_metrics_cache(workspace_id)
     return _serialize_override(row)
 
 
@@ -368,3 +473,4 @@ async def delete_override(
         )
     )
     await db.commit()
+    invalidate_metrics_cache(workspace_id)

--- a/design/app.js
+++ b/design/app.js
@@ -432,6 +432,15 @@ function bindRouting() {
       try {
         await api("/v1/routing", { method: "PUT", body: JSON.stringify({ strategy: val }) });
         toast(`Routing strategy: ${val}`, "ok");
+        // Refresh the Quality preview so the operator sees the new
+        // strategy's primary pick immediately. The preview reads workspace
+        // strategy server-side (NOT a query param — avoids a race where the
+        // dashboard's local default `balanced` overrides the just-saved
+        // value before loadRouting() finishes on initial load).
+        try {
+          await loadQualityPreview();
+          renderQualityPreview();
+        } catch (_) { /* preview is non-critical, never block strategy change */ }
         syncOnboarding();
       } catch (err) {
         state.routing.strategy = prev;
@@ -844,7 +853,7 @@ function renderQualityTable() {
   tbody.innerHTML = "";
   const rows = state.quality?.models || [];
   if (!rows.length) {
-    tbody.innerHTML = `<tr><td colspan="8" class="muted" style="text-align:center;padding:24px">
+    tbody.innerHTML = `<tr><td colspan="10" class="muted" style="text-align:center;padding:24px">
       No models in catalog.
     </td></tr>`;
     return;
@@ -864,6 +873,14 @@ function renderQualityTable() {
     const effectiveCell = m.effective_score == null
       ? '<span class="muted">unscored</span>'
       : `<strong>${m.effective_score.toFixed(0)}</strong>`;
+    // TPS / TTFT come from AA latency benchmarks — null when AA hasn't
+    // indexed this model on that axis. Used by the `fastest` strategy.
+    const tpsCell = m.tps == null
+      ? '<span class="muted">—</span>'
+      : `<span title="Output tokens per second (AA median, max across reasoning variants)">${m.tps.toFixed(0)}</span>`;
+    const ttftCell = m.ttft == null
+      ? '<span class="muted">—</span>'
+      : `<span title="Time to first token in seconds (AA median, min across variants — non-reasoning fast mode)">${m.ttft.toFixed(2)}s</span>`;
     const blendedPerM = (m.blended_cost * 1_000_000).toFixed(2);
     const statusCell = m.deployable
       ? '<span class="pill ok">deployable</span>'
@@ -878,6 +895,8 @@ function renderQualityTable() {
       <td class="num">${aaCell}</td>
       <td class="num">${manualCell}</td>
       <td class="num">${effectiveCell}</td>
+      <td class="num">${tpsCell}</td>
+      <td class="num">${ttftCell}</td>
       <td class="num">$${blendedPerM}</td>
       <td>${statusCell}</td>
       <td class="th-actions">${actions}</td>
@@ -906,15 +925,37 @@ function renderQualityPreview() {
     body.innerHTML = `<p class="muted">No deployable model satisfies the current capability requirements. Configure a provider key on the Providers page.</p>`;
     return;
   }
+  // primary_score is already an int 0-100 from the server (cheapest = null
+  // because raw token cost has no meaningful 0-100 mapping).
   const scoreText = p.primary_score != null
-    ? `<span class="pill ok">score ${p.primary_score.toFixed(0)}</span>`
+    ? `<span class="pill ok">score ${p.primary_score}</span>`
     : `<span class="pill muted">unscored</span>`;
   const fbList = p.fallbacks && p.fallbacks.length
     ? `<div class="small muted">→ falls back to: ${p.fallbacks.map((f) => `<code>${escapeHtml(f)}</code>`).join(", ")}</div>`
     : "";
+
+  // Per-axis breakdown — surfaces the same numbers the ranker used to
+  // decide. Without this, `fastest` looks opaque ("primary X, score 73"
+  // tells you nothing about WHY it won). Renders as
+  // "tps: raw=145.0 (78/100), ttft: raw=0.41s (88/100)" etc.
+  const breakdown = p.primary_score_breakdown || {};
+  const breakdownEntries = Object.entries(breakdown);
+  const breakdownLine = breakdownEntries.length
+    ? `<div class="small muted">${breakdownEntries.map(([axis, vals]) => {
+        const raw = vals && vals.raw != null
+          ? `${typeof vals.raw === "number" ? vals.raw.toLocaleString(undefined, {maximumFractionDigits: 2}) : escapeHtml(String(vals.raw))}`
+          : "—";
+        const norm = vals && vals.normalized != null
+          ? ` (${(vals.normalized * 100).toFixed(0)}/100)`
+          : "";
+        return `<code>${escapeHtml(axis)}</code>: ${raw}${norm}`;
+      }).join(" · ")}</div>`
+    : "";
+
   body.innerHTML = `
     <div><code>${escapeHtml(p.primary)}</code> ${scoreText}</div>
-    <div class="small muted">strategy: <code>${escapeHtml(p.strategy)}</code> · scoring: <code>${escapeHtml(p.scoring_source)}</code></div>
+    <div class="small muted">strategy: <code>${escapeHtml(p.strategy)}</code> · scoring: ${escapeHtml(p.scoring_source)}</div>
+    ${breakdownLine}
     ${fbList}
   `;
 }

--- a/design/index.html
+++ b/design/index.html
@@ -377,7 +377,7 @@
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 2v20M2 12h20"/></svg>
                 </div>
                 <div class="strategy-title">Balanced</div>
-                <p class="strategy-desc">Mix cost, latency &amp; quality. The sane default for most teams.</p>
+                <p class="strategy-desc">50/50 weighted blend of AA quality &amp; cost. The sane default for most teams.</p>
                 <span class="strategy-badge">Recommended</span>
               </label>
               <label class="strategy-card" data-value="cheapest">
@@ -394,7 +394,7 @@
                   <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
                 </div>
                 <div class="strategy-title">Fastest</div>
-                <p class="strategy-desc">Lowest p50 latency from recent traffic. Great for chat UIs.</p>
+                <p class="strategy-desc">Highest throughput + lowest first-token latency, from Artificial Analysis benchmarks. Great for chat UIs.</p>
               </label>
               <label class="strategy-card" data-value="quality">
                 <input type="radio" name="strategy" value="quality">
@@ -447,10 +447,10 @@
                     <th><code>model="auto"</code> picks</th>
                   </tr></thead>
                   <tbody>
-                    <tr><td><strong>balanced</strong></td><td><code>simple-shuffle</code> (RPM/TPM weighted)</td><td>cheapest capable</td></tr>
-                    <tr><td><strong>cheapest</strong></td><td><code>cost-based-routing</code></td><td>cheapest capable</td></tr>
-                    <tr><td><strong>fastest</strong></td><td><code>latency-based-routing</code></td><td>cheapest capable</td></tr>
-                    <tr><td><strong>quality</strong></td><td><code>simple-shuffle</code></td><td>most expensive capable (biggest)</td></tr>
+                    <tr><td><strong>balanced</strong></td><td><code>None</code> (we rank ourselves)</td><td>50/50 normalized AA quality &amp; inverted cost; strict two-axis coverage</td></tr>
+                    <tr><td><strong>cheapest</strong></td><td><code>cost-based-routing</code></td><td>cheapest capable (blended 0.3 input + 0.7 output cost)</td></tr>
+                    <tr><td><strong>fastest</strong></td><td><code>None</code> (we rank ourselves)</td><td>50/50 normalized AA TPS &amp; inverted TTFT; strict two-axis coverage</td></tr>
+                    <tr><td><strong>quality</strong></td><td><code>None</code> (we rank ourselves)</td><td>highest AA Intelligence Index (or manual override); unscored models rank below scored</td></tr>
                   </tbody>
                 </table>
               </div>
@@ -640,6 +640,8 @@
                   <th class="num">AA</th>
                   <th class="num">Manual</th>
                   <th class="num">Effective</th>
+                  <th class="num" title="Output tokens per second (Artificial Analysis median, max across reasoning variants). — when AA hasn't indexed this model.">TPS</th>
+                  <th class="num" title="Time to first token in seconds (Artificial Analysis median, min across reasoning variants — the model's non-reasoning fast mode). — when AA hasn't indexed this model.">TTFT</th>
                   <th class="num">$/M blended</th>
                   <th>Status</th>
                   <th class="th-actions"></th>

--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -1,5 +1,5 @@
-"""Artificial Analysis quality scores — used to rank models in the
-`quality` routing strategy.
+"""Artificial Analysis quality + latency metrics — used to rank models in
+the `quality`, `balanced`, and `fastest` routing strategies.
 
 The strategy was historically implemented as "pick the most expensive
 deployable model" — a fine proxy when newer flagships cost more than
@@ -8,6 +8,17 @@ older ones. Anthropic and OpenAI broke that assumption (Opus 4.7 is
 no longer tracks capability. AA's Intelligence Index is a real
 benchmark-aggregator score (MMLU-Pro, GPQA, MATH, HumanEval, etc.),
 updated as new models ship and stable across providers.
+
+PR 4 extends this from quality-only to three independent metrics:
+  - quality (intelligence_index, max across reasoning variants)
+  - TPS (median_output_tokens_per_second, max across variants)
+  - TTFT (median_time_to_first_token_seconds, min across variants)
+
+Why per-axis aggregation rules: TPS is stable across reasoning effort
+(same token-emission speed) so max picks the best representative.
+TTFT explodes with reasoning effort (1.77s → 32s for GPT-5.5 across
+variants), so min picks the model's "fast mode" — what an operator
+choosing `fastest` actually wants.
 
 Three-layer cache:
   1. In-process dict (1h TTL) — fast, dies with the process
@@ -21,6 +32,11 @@ back to cost-based, which is known wrong). Rotating the AA key
 invalidates DB rows via the `api_key_hash` column so a snapshot taken
 under one account doesn't get served under another.
 
+Per-axis snapshot preservation: if a fresh AA fetch returns one axis
+empty (eg AA renamed `median_output_tokens_per_second`), the saver
+keeps the old axis's data instead of overwriting with `{}`. Prevents
+upstream regressions from disabling a routing strategy.
+
 Attribution: when scores are surfaced (dashboard, header, debug log),
 display "Powered by Artificial Analysis" linking to artificialanalysis.ai
 per their free-tier terms.
@@ -28,11 +44,13 @@ per their free-tier terms.
 
 from __future__ import annotations
 
+import dataclasses
 import hashlib
 import json
+import math
 import re
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -50,13 +68,47 @@ _STALE_GRACE_SECONDS = 24 * 60 * 60   # 24h: keep serving last good value
 
 @dataclass(frozen=True)
 class QualityIndex:
-    """One AA fetch result. `scores` is keyed by our canonical model IDs."""
+    """One AA fetch result. Maps are keyed by our canonical model IDs.
+
+    Field naming: `scores` is the legacy alias for `quality_scores`,
+    preserved so existing callers (`idx.scores`) keep working. Internal
+    code prefers `quality_scores` for symmetry with `tps_scores` /
+    `ttft_scores`.
+
+    `matched_count` is the union (size of distinct catalog IDs covered
+    by ANY axis). Per-axis counts are exposed separately for callers
+    that need to distinguish "AA gave us quality but no TPS" from
+    "AA gave us neither".
+    """
 
     scores: dict[str, float]
     fetched_at: float                 # monotonic seconds
     source: str                       # "live" | "stale-cache" | "missing-key" | "error"
     raw_count: int                    # how many AA entries were considered
-    matched_count: int                # how many mapped to a known catalog ID
+    matched_count: int                # union(三轴): distinct catalog IDs in any axis
+    tps_scores: dict[str, float] = field(default_factory=dict)
+    ttft_scores: dict[str, float] = field(default_factory=dict)
+    matched_count_quality: int = 0
+    matched_count_tps: int = 0
+    matched_count_ttft: int = 0
+
+
+@dataclass(frozen=True)
+class _AARawMetrics:
+    """Raw AA payload after parse + per-axis variant aggregation.
+
+    Internal to this module — exposed via QualityIndex for downstream
+    consumers. Doesn't contain manual-override merging; that's the
+    caller's job (see `app/quality_scores.py:resolve_model_metrics`).
+    """
+
+    quality_scores: dict[str, float]
+    tps_scores: dict[str, float]
+    ttft_scores: dict[str, float]
+    raw_count: int
+    matched_count_quality: int
+    matched_count_tps: int
+    matched_count_ttft: int
 
 
 # Process-wide cache, keyed by API key (so swapping the key in tests
@@ -66,7 +118,7 @@ _cache: dict[str, QualityIndex] = {}
 
 # Strip parenthetical qualifiers like "(max)", "(xhigh)", "(high)",
 # "(low)", "(Non-reasoning, high)" — these mark reasoning-effort variants
-# of the same underlying model. We aggregate by taking MAX score.
+# of the same underlying model. We aggregate per axis (max/max/min).
 _QUALIFIER_RE = re.compile(r"\s*\([^)]*\)\s*$")
 
 
@@ -117,30 +169,53 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
     return None
 
 
-def _build_score_map(aa_payload: list[dict[str, Any]], catalog_ids: set[str]) -> tuple[dict[str, float], int, int]:
-    """Project AA's response into {our_catalog_id: max_score}.
+def _num(v: Any) -> float | None:
+    """Coerce AA's numeric fields. Rejects bool, non-numeric, NaN, inf,
+    and negatives. Even one bad value (NaN) would poison min/max
+    aggregation and the downstream min-max normalization."""
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return None
+    if not math.isfinite(v) or v < 0:
+        return None
+    return float(v)
 
-    AA may include the same base model multiple times under different
-    reasoning-effort qualifiers — we keep the highest score per
-    canonical catalog id. Returns (scores, raw_count, matched_count).
+
+def _build_metrics_map(
+    aa_payload: list[dict[str, Any]], catalog_ids: set[str]
+) -> _AARawMetrics:
+    """Project AA's response into three per-axis maps.
+
+    Aggregation rules per axis:
+      - quality: max across variants (highest intelligence_index)
+      - tps: max across variants (output token rate is stable; max picks the best)
+      - ttft: min across variants (TTFT explodes with reasoning effort;
+        min picks the model's non-reasoning "fast mode")
+
+    Each axis is aggregated independently — we do NOT lock to same-row
+    pairing. If we did, GPT-5.5 picked for `fastest` would carry its
+    max-quality variant's TTFT (32s) instead of its true fast-mode TTFT
+    (1.77s).
+
+    AA fields:
+      - intelligence_index: under entry["evaluations"] (nested)
+      - median_output_tokens_per_second: at entry top-level
+      - median_time_to_first_token_seconds: at entry top-level
+
+    Live-verified against the real AA API on 2026-05-05; field paths
+    and variant aggregate behavior confirmed before this code was written.
     """
-    accum: dict[str, float] = {}
+    quality_scores: dict[str, float] = {}
+    tps_scores: dict[str, float] = {}
+    ttft_scores: dict[str, float] = {}
     raw_count = 0
-    matched_count = 0
 
     for entry in aa_payload:
         if not isinstance(entry, dict):
             continue
         raw_count += 1
-        # AA exposes display names in the `name` field. Some entries may
-        # also have a `slug` or `id`; prefer `name` since it matches the
-        # leaderboard the operator sees.
+
         name = entry.get("name") or entry.get("slug") or entry.get("id")
         if not isinstance(name, str) or not name:
-            continue
-        evals = entry.get("evaluations") or {}
-        score = evals.get("artificial_analysis_intelligence_index")
-        if score is None or not isinstance(score, (int, float)):
             continue
 
         normalized = _normalize_aa_id(name)
@@ -148,20 +223,49 @@ def _build_score_map(aa_payload: list[dict[str, Any]], catalog_ids: set[str]) ->
         if catalog_id is None:
             continue
 
-        prior = accum.get(catalog_id)
-        if prior is None or score > prior:
-            accum[catalog_id] = float(score)
-            if prior is None:
-                matched_count += 1
+        # AA's `evaluations` is normally a dict but we've seen
+        # malformed responses pass a list or null; verify before .get().
+        evals = entry.get("evaluations")
+        if not isinstance(evals, dict):
+            evals = {}
 
-    return accum, raw_count, matched_count
+        quality = _num(evals.get("artificial_analysis_intelligence_index"))
+        tps = _num(entry.get("median_output_tokens_per_second"))
+        ttft = _num(entry.get("median_time_to_first_token_seconds"))
+
+        # Per-axis aggregate. Each axis keeps the most-useful variant
+        # value: max for quality+throughput (higher = better), min for
+        # TTFT (lower = faster, picks the non-reasoning variant).
+        if quality is not None:
+            prior = quality_scores.get(catalog_id)
+            if prior is None or quality > prior:
+                quality_scores[catalog_id] = quality
+        if tps is not None:
+            prior = tps_scores.get(catalog_id)
+            if prior is None or tps > prior:
+                tps_scores[catalog_id] = tps
+        if ttft is not None:
+            prior = ttft_scores.get(catalog_id)
+            if prior is None or ttft < prior:
+                ttft_scores[catalog_id] = ttft
+
+    return _AARawMetrics(
+        quality_scores=quality_scores,
+        tps_scores=tps_scores,
+        ttft_scores=ttft_scores,
+        raw_count=raw_count,
+        matched_count_quality=len(quality_scores),
+        matched_count_tps=len(tps_scores),
+        matched_count_ttft=len(ttft_scores),
+    )
 
 
 class _AAFetchUnusable(Exception):
     """Raised when an AA fetch returns nothing usable — schema mismatch,
-    empty data array, or all entries unmatched. Distinct from a transport
-    error so the caller can route it through the same stale-fallback path
-    instead of persisting an empty score map over a known-good snapshot.
+    empty data array, or all entries unmatched on every axis. Distinct
+    from a transport error so the caller can route it through the
+    stale-fallback path instead of persisting an empty score map over
+    a known-good snapshot.
     """
 
 
@@ -202,12 +306,52 @@ def _api_key_hash(api_key: str) -> str:
 @dataclass(frozen=True)
 class _LoadedSnapshot:
     """A DB-loaded snapshot. Carries wall-clock age so the freshness
-    check at the call site doesn't mix monotonic and wall-clock times."""
-    scores: dict[str, float]
+    check at the call site doesn't mix monotonic and wall-clock times.
+
+    Per-axis fields populated from the new scores_json shape; legacy
+    flat snapshots (quality-only, pre-PR4) hydrate quality_scores from
+    the flat dict and leave tps/ttft empty + their counts at 0.
+    """
+    quality_scores: dict[str, float]
+    tps_scores: dict[str, float]
+    ttft_scores: dict[str, float]
     source: str
     raw_count: int
-    matched_count: int
+    matched_count_quality: int
+    matched_count_tps: int
+    matched_count_ttft: int
     wall_age_seconds: float   # how long ago the row was written, per the DB clock
+
+
+def _parse_snapshot_blob(parsed: Any) -> tuple[
+    dict[str, float], dict[str, float], dict[str, float], int, int, int, int
+]:
+    """Detect new vs legacy scores_json shape and extract per-axis maps.
+
+    New shape: {"quality": {...}, "tps": {...}, "ttft": {...}, "meta": {...}}
+    Legacy shape: {"model_id": float, ...} (quality-only, pre-PR4)
+
+    Returns (quality, tps, ttft, raw_count, mc_quality, mc_tps, mc_ttft).
+    """
+    if not isinstance(parsed, dict):
+        return ({}, {}, {}, 0, 0, 0, 0)
+
+    if "quality" in parsed and isinstance(parsed.get("quality"), dict) and "meta" in parsed:
+        meta = parsed.get("meta") or {}
+        quality = {k: float(v) for k, v in (parsed.get("quality") or {}).items()}
+        tps = {k: float(v) for k, v in (parsed.get("tps") or {}).items()}
+        ttft = {k: float(v) for k, v in (parsed.get("ttft") or {}).items()}
+        return (
+            quality, tps, ttft,
+            int(meta.get("raw_count", 0) or 0),
+            int(meta.get("matched_count_quality", 0) or 0),
+            int(meta.get("matched_count_tps", 0) or 0),
+            int(meta.get("matched_count_ttft", 0) or 0),
+        )
+
+    # Legacy flat: {"model_id": float, ...} = quality only.
+    quality = {k: float(v) for k, v in parsed.items() if isinstance(v, (int, float))}
+    return (quality, {}, {}, len(quality), len(quality), 0, 0)
 
 
 async def _load_db_snapshot(
@@ -237,9 +381,11 @@ async def _load_db_snapshot(
         ).scalar_one_or_none()
         if row is None:
             return None
-        scores = json.loads(row.scores_json)
-        if not isinstance(scores, dict):
-            return None
+        parsed = json.loads(row.scores_json)
+        (
+            quality, tps, ttft,
+            raw_count_meta, mc_q, mc_t, mc_f,
+        ) = _parse_snapshot_blob(parsed)
         # Compute wall-clock age. `updated_at` is server-default `func.now()`
         # so it's UTC on both SQLite and Postgres; coerce naive (SQLite) to
         # UTC for consistent arithmetic.
@@ -248,11 +394,18 @@ async def _load_db_snapshot(
         if row_ts.tzinfo is None:
             row_ts = row_ts.replace(tzinfo=timezone.utc)
         age = max(0.0, (wall_now - row_ts).total_seconds())
+        # Prefer the DB column for raw_count (authoritative for legacy rows
+        # written before meta carried it); fall back to meta if column 0.
+        raw_count = int(row.raw_count) or raw_count_meta
         return _LoadedSnapshot(
-            scores={k: float(v) for k, v in scores.items()},
+            quality_scores=quality,
+            tps_scores=tps,
+            ttft_scores=ttft,
             source=row.source,
-            raw_count=int(row.raw_count),
-            matched_count=int(row.matched_count),
+            raw_count=raw_count,
+            matched_count_quality=mc_q,
+            matched_count_tps=mc_t,
+            matched_count_ttft=mc_f,
             wall_age_seconds=age,
         )
     except Exception:
@@ -260,11 +413,24 @@ async def _load_db_snapshot(
 
 
 async def _save_db_snapshot(
-    db: "AsyncSession", workspace_id: str, api_key_hash: str, idx: QualityIndex
+    db: "AsyncSession",
+    workspace_id: str,
+    api_key_hash: str,
+    source: str,
+    metrics: _AARawMetrics,
 ) -> None:
     """Upsert the snapshot for this workspace + key. Never raises —
     persisting is best-effort; the in-process cache is still the
     authoritative source for the current request.
+
+    Writes new scores_json shape:
+      {"quality": {...}, "tps": {...}, "ttft": {...},
+       "meta": {raw_count, matched_count_quality, _tps, _ttft}}
+
+    Updates the legacy `matched_count` column to union(三轴 keys) so the
+    "X of Y AA models indexed" UI string still reads as the count of
+    catalog IDs with at least one indexed axis (NOT max — max would
+    misleadingly under-report when axes cover different model sets).
 
     Uses `session.merge()` for the upsert: portable across SQLite /
     Postgres / MySQL, race-safe under multi-worker fan-out (vs the
@@ -272,7 +438,23 @@ async def _save_db_snapshot(
     workers fetch AA simultaneously and both try to insert).
     """
     try:
-        scores_json = json.dumps(idx.scores, separators=(",", ":"))
+        blob = {
+            "quality": metrics.quality_scores,
+            "tps": metrics.tps_scores,
+            "ttft": metrics.ttft_scores,
+            "meta": {
+                "raw_count": metrics.raw_count,
+                "matched_count_quality": metrics.matched_count_quality,
+                "matched_count_tps": metrics.matched_count_tps,
+                "matched_count_ttft": metrics.matched_count_ttft,
+            },
+        }
+        scores_json = json.dumps(blob, separators=(",", ":"))
+        union_count = len(
+            set(metrics.quality_scores)
+            | set(metrics.tps_scores)
+            | set(metrics.ttft_scores)
+        )
         # `merge` syncs a detached/new instance with whatever is in the DB,
         # keyed by primary key. Inserts when missing, updates when present.
         # Works identically across all SQLAlchemy-supported dialects.
@@ -282,9 +464,9 @@ async def _save_db_snapshot(
         await db.merge(QualityScoreSnapshot(
             workspace_id=workspace_id,
             api_key_hash=api_key_hash,
-            source=idx.source,
-            raw_count=idx.raw_count,
-            matched_count=idx.matched_count,
+            source=source,
+            raw_count=metrics.raw_count,
+            matched_count=union_count,
             scores_json=scores_json,
         ))
         await db.commit()
@@ -298,6 +480,56 @@ async def _save_db_snapshot(
             pass
 
 
+async def _persist_with_axis_preservation(
+    db: "AsyncSession",
+    workspace_id: str,
+    api_key_hash: str,
+    source: str,
+    new: _AARawMetrics,
+) -> _AARawMetrics:
+    """Save a fresh fetch, preserving any axis that came back empty
+    by reusing the previous snapshot's data for that axis.
+
+    Why: AA upstream regressions (renamed field, partial outage) can
+    return e.g. quality intact but TPS empty. Without this, the saver
+    overwrites the good TPS map with `{}` and disables `fastest`
+    routing on the next request.
+
+    Snapshot PK is composite `(workspace_id, api_key_hash)`. Both
+    must filter the load — preserving an axis from a different AA
+    account's snapshot would silently mix benchmark data across keys.
+
+    Returns the merged metrics that were persisted (so callers can
+    promote the merged version into the in-process cache).
+    """
+    old = await _load_db_snapshot(db, workspace_id, api_key_hash)
+    merged = new
+    if old is not None:
+        # Per-axis: if NEW lost coverage but OLD had it, keep OLD's
+        # values for that axis. Only the axis that regressed is held;
+        # axes with fresh data are taken from NEW.
+        if new.matched_count_quality == 0 and old.matched_count_quality > 0:
+            merged = dataclasses.replace(
+                merged,
+                quality_scores=dict(old.quality_scores),
+                matched_count_quality=old.matched_count_quality,
+            )
+        if new.matched_count_tps == 0 and old.matched_count_tps > 0:
+            merged = dataclasses.replace(
+                merged,
+                tps_scores=dict(old.tps_scores),
+                matched_count_tps=old.matched_count_tps,
+            )
+        if new.matched_count_ttft == 0 and old.matched_count_ttft > 0:
+            merged = dataclasses.replace(
+                merged,
+                ttft_scores=dict(old.ttft_scores),
+                matched_count_ttft=old.matched_count_ttft,
+            )
+    await _save_db_snapshot(db, workspace_id, api_key_hash, source, merged)
+    return merged
+
+
 async def get_quality_index(
     *,
     catalog_ids: set[str],
@@ -305,7 +537,7 @@ async def get_quality_index(
     workspace_id: str = "default",
     force_refresh: bool = False,
 ) -> QualityIndex:
-    """Return the current AA score map for our catalog.
+    """Return the current AA metrics map for our catalog.
 
     Read order:
       1. In-process cache (1h TTL) — fastest, single-process scope.
@@ -314,7 +546,8 @@ async def get_quality_index(
          pass `db=None` and skip this layer.
       3. AA `/api/v2/data/llms/models` — fresh truth, 1000 req/day quota.
 
-    Write order on AA success: in-process cache + DB snapshot (best-effort).
+    Write order on AA success: in-process cache + DB snapshot
+    (best-effort, with per-axis preservation).
 
     On AA failure: serve stale from in-process (within 24h grace), then
     from DB (no upper bound — old data is better than no data here).
@@ -329,8 +562,10 @@ async def get_quality_index(
     s = get_settings()
     api_key = s.artificial_analysis_api_key
     if not api_key:
-        return QualityIndex(scores={}, fetched_at=0.0, source="missing-key",
-                             raw_count=0, matched_count=0)
+        return QualityIndex(
+            scores={}, fetched_at=0.0, source="missing-key",
+            raw_count=0, matched_count=0,
+        )
 
     url = s.artificial_analysis_models_url
     key_hash = _api_key_hash(api_key)
@@ -355,16 +590,22 @@ async def get_quality_index(
         ):
             # Promote DB row into in-process cache. The in-process layer
             # uses monotonic time, so set `fetched_at = now` (treats this
-            # request as the start of a fresh in-process TTL window). Net
-            # effect: cross-restart freshness can extend by up to 1h
-            # beyond the original wall-clock TTL — acceptable in exchange
-            # for a cold-start AA quota saved.
+            # request as the start of a fresh in-process TTL window).
             promoted = QualityIndex(
-                scores=db_snapshot.scores,
+                scores=db_snapshot.quality_scores,
                 fetched_at=now,
                 source=db_snapshot.source,
                 raw_count=db_snapshot.raw_count,
-                matched_count=db_snapshot.matched_count,
+                matched_count=len(
+                    set(db_snapshot.quality_scores)
+                    | set(db_snapshot.tps_scores)
+                    | set(db_snapshot.ttft_scores)
+                ),
+                tps_scores=db_snapshot.tps_scores,
+                ttft_scores=db_snapshot.ttft_scores,
+                matched_count_quality=db_snapshot.matched_count_quality,
+                matched_count_tps=db_snapshot.matched_count_tps,
+                matched_count_ttft=db_snapshot.matched_count_ttft,
             )
             _cache[key_hash] = promoted
             return promoted
@@ -378,33 +619,48 @@ async def get_quality_index(
             # let it overwrite a good DB snapshot with `{}`; route through
             # the stale-fallback path instead.
             raise _AAFetchUnusable("AA returned empty data array")
-        scores, raw_count, matched_count = _build_score_map(raw, catalog_ids)
-        if matched_count == 0:
-            # AA gave us data but none of it mapped to our catalog. This
-            # signals a normalization regression (AA renamed everything)
-            # rather than a healthy fetch — persisting `{}` would silently
-            # disable quality routing on the next restart. Fall back to
-            # stale instead.
+        metrics = _build_metrics_map(raw, catalog_ids)
+        # Treat as unusable only if ALL THREE axes are empty AND we have
+        # no preservable old snapshot. Per-axis preservation in the
+        # saver covers the case where one axis regressed.
+        any_axis = (
+            metrics.matched_count_quality
+            or metrics.matched_count_tps
+            or metrics.matched_count_ttft
+        )
+        if not any_axis:
             raise _AAFetchUnusable(
-                f"AA returned {raw_count} entries but 0 mapped to catalog"
+                f"AA returned {metrics.raw_count} entries but 0 mapped "
+                f"to catalog on any axis"
             )
+        if db is not None:
+            metrics = await _persist_with_axis_preservation(
+                db, workspace_id, key_hash, "live", metrics,
+            )
+        union = len(
+            set(metrics.quality_scores)
+            | set(metrics.tps_scores)
+            | set(metrics.ttft_scores)
+        )
         idx = QualityIndex(
-            scores=scores, fetched_at=now, source="live",
-            raw_count=raw_count, matched_count=matched_count,
+            scores=metrics.quality_scores,
+            fetched_at=now,
+            source="live",
+            raw_count=metrics.raw_count,
+            matched_count=union,
+            tps_scores=metrics.tps_scores,
+            ttft_scores=metrics.ttft_scores,
+            matched_count_quality=metrics.matched_count_quality,
+            matched_count_tps=metrics.matched_count_tps,
+            matched_count_ttft=metrics.matched_count_ttft,
         )
         _cache[key_hash] = idx
-        if db is not None:
-            await _save_db_snapshot(db, workspace_id, key_hash, idx)
         return idx
     except Exception:
         # Stale fallbacks, in order of freshness.
         cached = _cache.get(key_hash)
         if cached is not None and (now - cached.fetched_at) < _STALE_GRACE_SECONDS:
-            return QualityIndex(
-                scores=cached.scores, fetched_at=cached.fetched_at,
-                source="stale-cache",
-                raw_count=cached.raw_count, matched_count=cached.matched_count,
-            )
+            return dataclasses.replace(cached, source="stale-cache")
         if db_snapshot is not None:
             # DB row is older than the in-process TTL but we serve it
             # anyway — better than disabling quality routing entirely.
@@ -412,14 +668,25 @@ async def get_quality_index(
             # they're on stale data; no upper bound on age here because
             # the alternative (cost-based) is known wrong, not just stale.
             return QualityIndex(
-                scores=db_snapshot.scores,
+                scores=db_snapshot.quality_scores,
                 fetched_at=now,  # we just learned this from DB; re-anchor in-process
                 source="stale-db",
                 raw_count=db_snapshot.raw_count,
-                matched_count=db_snapshot.matched_count,
+                matched_count=len(
+                    set(db_snapshot.quality_scores)
+                    | set(db_snapshot.tps_scores)
+                    | set(db_snapshot.ttft_scores)
+                ),
+                tps_scores=db_snapshot.tps_scores,
+                ttft_scores=db_snapshot.ttft_scores,
+                matched_count_quality=db_snapshot.matched_count_quality,
+                matched_count_tps=db_snapshot.matched_count_tps,
+                matched_count_ttft=db_snapshot.matched_count_ttft,
             )
-        return QualityIndex(scores={}, fetched_at=now, source="error",
-                             raw_count=0, matched_count=0)
+        return QualityIndex(
+            scores={}, fetched_at=now, source="error",
+            raw_count=0, matched_count=0,
+        )
 
 
 def reset_cache() -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,11 @@ def _reset_module_state() -> Generator[None, None, None]:
         quality_index.reset_cache()
     except Exception:
         pass
+    try:
+        from app import quality_scores
+        quality_scores.reset_metrics_cache()
+    except Exception:
+        pass
 
 
 @pytest.fixture(autouse=True)

--- a/tests/integration/test_quality_routes.py
+++ b/tests/integration/test_quality_routes.py
@@ -54,14 +54,26 @@ async def quality_client(tmp_sqlite_url, monkeypatch):
     quality_index.reset_cache()
 
     aa_payload = [
+        # Per-axis aggregation: quality MAX, TPS MAX, TTFT MIN. The two
+        # Claude Opus 4.7 variants here exercise that — the Non-reasoning
+        # row has lower quality (52 vs 57) but lower TTFT (the model's
+        # "fast mode"), so the merged metrics carry quality=57 + ttft=0.8.
         {"name": "Claude Opus 4.7 (max)",
-         "evaluations": {"artificial_analysis_intelligence_index": 57}},
+         "evaluations": {"artificial_analysis_intelligence_index": 57},
+         "median_output_tokens_per_second": 60,
+         "median_time_to_first_token_seconds": 12.0},
         {"name": "Claude Opus 4.7 (Non-reasoning, high)",
-         "evaluations": {"artificial_analysis_intelligence_index": 52}},
+         "evaluations": {"artificial_analysis_intelligence_index": 52},
+         "median_output_tokens_per_second": 65,
+         "median_time_to_first_token_seconds": 0.8},
         {"name": "GPT-4o",
-         "evaluations": {"artificial_analysis_intelligence_index": 41}},
+         "evaluations": {"artificial_analysis_intelligence_index": 41},
+         "median_output_tokens_per_second": 80,
+         "median_time_to_first_token_seconds": 0.4},
         {"name": "Claude 3.5 Haiku",
-         "evaluations": {"artificial_analysis_intelligence_index": 28}},
+         "evaluations": {"artificial_analysis_intelligence_index": 28},
+         "median_output_tokens_per_second": 120,
+         "median_time_to_first_token_seconds": 0.3},
     ]
 
     fetch_calls = {"n": 0}
@@ -197,7 +209,11 @@ async def test_auto_preview_uses_aa_scores_under_quality_strategy(quality_client
     assert r.status_code == 200, r.text
     body = r.json()
     assert body["strategy"] == "quality"
-    assert body["scoring_source"] == "quality_scores"
+    # `scoring_source` is now a human-readable label keyed off a
+    # strategy + data-availability state. The label tells the operator
+    # WHY the strategy picked what it picked (and surfaces fallback
+    # cases like "no AA → cost proxy").
+    assert "AA Intelligence Index" in body["scoring_source"], body["scoring_source"]
     # The primary should be a model that AA scored. Concrete name depends
     # on what's in the live catalog vs what our mock AA payload covers,
     # but we can at least assert the score is non-null.
@@ -327,4 +343,212 @@ async def test_override_actually_changes_auto_preview(quality_client):
     assert r2.json()["primary"] == other_choice, (
         f"override should have flipped primary from {primary_before} to {other_choice}, "
         f"got {r2.json()['primary']}"
+    )
+
+
+# ── PR 4: per-axis fields, ?strategy= override, breakdown, cache ───────
+
+
+async def test_v1_quality_rows_carry_tps_and_ttft_fields(quality_client):
+    """Per-model rows expose AA latency metrics so the dashboard table
+    can render TPS / TTFT columns. None when AA hasn't covered a model
+    on that axis (the catalog is much larger than the AA index)."""
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality")
+    body = r.json()
+
+    # Every row carries the new fields (None when not indexed).
+    sample = body["models"][0]
+    assert "tps" in sample
+    assert "ttft" in sample
+
+    # At least one row should have both fields populated (came from AA).
+    indexed = [m for m in body["models"] if m["tps"] is not None]
+    assert indexed, "fixture provides AA metrics for some catalog models"
+    assert all(m["ttft"] is not None for m in indexed), (
+        "fixture pairs TPS + TTFT for all indexed models"
+    )
+
+
+async def test_aa_index_status_carries_per_axis_breakdown(quality_client):
+    """The status block exposes per-axis matched_count so the dashboard
+    can distinguish 'AA gave us quality but no latency' from 'AA covers
+    nothing'. matched_count itself stays a single int (union — count of
+    models with at least one indexed axis) for backward compat with the
+    existing 'X of Y indexed' UI string."""
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality")
+    aa = r.json()["aa_index"]
+
+    assert isinstance(aa["matched_count"], int)
+    assert "matched_count_breakdown" in aa
+    bd = aa["matched_count_breakdown"]
+    assert set(bd.keys()) == {"quality", "tps", "ttft"}
+    # Fixture has all four entries scored on all three axes.
+    assert bd["quality"] >= 1
+    assert bd["tps"] >= 1
+    assert bd["ttft"] >= 1
+
+
+async def test_auto_preview_strategy_query_overrides_workspace(quality_client):
+    """`?strategy=` lets verification scripts compare all four strategies
+    without flipping the persisted workspace config. The dashboard does
+    NOT pass this (race condition with hardcoded `state.routing.strategy`
+    default during initial load) — server reads workspace strategy as
+    the authoritative source."""
+    client, _, _ = quality_client
+
+    # Workspace default is "balanced" (seed). Override to "cheapest"
+    # via query and verify the response reflects the override.
+    r_balanced = await client.get("/v1/quality/auto-preview")
+    r_cheapest = await client.get("/v1/quality/auto-preview?strategy=cheapest")
+    assert r_balanced.status_code == 200
+    assert r_cheapest.status_code == 200
+
+    body_b = r_balanced.json()
+    body_c = r_cheapest.json()
+
+    assert body_b["strategy"] == "balanced"
+    assert body_c["strategy"] == "cheapest"
+    assert body_c["strategy_overridden"] is True
+    assert body_c["workspace_strategy"] == "balanced"
+    # cheapest's primary_score is None (no normalized 0-100 mapping for
+    # raw token cost), unlike balanced which gives an int.
+    assert body_c["primary_score"] is None
+
+
+async def test_auto_preview_fastest_includes_breakdown_with_tps_and_ttft(quality_client):
+    """fastest preview must surface the per-axis raw + normalized values
+    so the operator can see WHY a model won (otherwise the score is opaque
+    and the strategy choice loses its explanatory power)."""
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality/auto-preview?strategy=fastest")
+    body = r.json()
+    assert body["strategy"] == "fastest"
+    breakdown = body["primary_score_breakdown"]
+    assert breakdown is not None, (
+        "fastest must always emit a breakdown when it ranks (or fall back "
+        "to cheapest with cost-only breakdown — either way breakdown is set)"
+    )
+    # When fastest succeeds, breakdown carries tps + ttft. When it falls
+    # back to cheapest (no AA latency), breakdown has cost only.
+    assert ("tps" in breakdown and "ttft" in breakdown) or "cost" in breakdown
+
+
+async def test_auto_preview_balanced_excludes_unscored_strict_coverage(quality_client):
+    """A model in the catalog that AA hasn't scored (no quality data)
+    must NOT appear in the balanced primary or fallbacks — strict
+    coverage drops it from candidates entirely. Operators wanting
+    coverage of unscored models must use cheapest or set a manual
+    override."""
+    client, _, _ = quality_client
+    r = await client.get("/v1/quality?")
+    quality_table = r.json()
+    # Find a deployable catalog model that's NOT in our mocked AA payload.
+    unscored_deployable = next(
+        (m for m in quality_table["models"]
+         if m["deployable"] and m["aa_score"] is None),
+        None,
+    )
+    if unscored_deployable is None:
+        pytest.skip("fixture's mocked AA covers all deployable models")
+
+    r2 = await client.get("/v1/quality/auto-preview?strategy=balanced")
+    body = r2.json()
+    candidates = [body["primary"]] + (body["fallbacks"] or [])
+    assert unscored_deployable["id"] not in candidates, (
+        f"strict coverage: balanced must drop unscored model "
+        f"{unscored_deployable['id']!r}, got candidates={candidates}"
+    )
+
+
+async def test_metrics_cache_invalidates_on_override_put(quality_client):
+    """After PUT /v1/quality/overrides/{model}, the next request that
+    triggers metrics resolution must see the override — not 60s of
+    cached pre-override data. Without cache invalidation, an operator
+    setting an override would see no effect until TTL expires."""
+    client, _, _ = quality_client
+
+    # Prime the cache: fire a balanced auto-preview (uses metrics).
+    r1 = await client.get("/v1/quality/auto-preview?strategy=balanced")
+    primary_before = r1.json()["primary"]
+
+    # Force a different model to win by giving it a manual quality
+    # override. quality.py PUT route invalidates the metrics cache.
+    table = (await client.get("/v1/quality")).json()["models"]
+    deployable_others = [m for m in table
+                         if m["deployable"] and m["id"] != primary_before
+                         and m["aa_score"] is not None]
+    if not deployable_others:
+        pytest.skip("only one deployable AA-scored model in fixture")
+    target = deployable_others[0]["id"]
+
+    await client.put(
+        f"/v1/quality/overrides/{target}",
+        json={"score": 100.0, "note": "test override"},
+    )
+
+    # Without cache invalidation, this would return the OLD primary
+    # (cached for 60s). With invalidation, the override is visible
+    # immediately.
+    r2 = await client.get("/v1/quality/auto-preview?strategy=balanced")
+    primary_after = r2.json()["primary"]
+    # The override may or may not flip the actual winner (depends on
+    # cost weighting), but the score in the response MUST reflect the
+    # override path. Check via /v1/quality table — the row's effective_score
+    # for `target` should be 100.0 (manual override wins over AA).
+    table_after = (await client.get("/v1/quality")).json()["models"]
+    target_row = next(m for m in table_after if m["id"] == target)
+    assert target_row["effective_score"] == 100.0, (
+        f"override visible immediately after PUT (no 60s TTL wait); "
+        f"primary went {primary_before} → {primary_after}"
+    )
+
+
+async def test_metrics_cache_invalidates_on_quality_refresh(quality_client):
+    """POST /v1/quality/refresh re-fetches AA AND drops the resolver
+    cache so subsequent routing reflects the freshly-pulled scores."""
+    client, _, fetch_calls = quality_client
+
+    # Prime resolver cache.
+    await client.get("/v1/quality/auto-preview?strategy=balanced")
+    fetch_count_before = fetch_calls["n"]
+
+    # Refresh — bypasses AA cache + invalidates resolver cache.
+    r = await client.post("/v1/quality/refresh")
+    assert r.status_code == 200
+    assert fetch_calls["n"] > fetch_count_before, "refresh must hit AA"
+
+    # Next preview must walk through resolver again (cache-cold), proving
+    # invalidate fired. We can't directly observe cache miss, but we can
+    # verify the response is internally consistent with the latest AA data.
+    r2 = await client.get("/v1/quality/auto-preview?strategy=balanced")
+    assert r2.status_code == 200
+
+
+def test_scoring_source_label_dict_distinguishes_uncovered_from_no_data():
+    """Codex follow-up: the SCORING_SOURCE label dictionary itself must
+    carry distinct entries for 'AA configured but doesn't cover any
+    eligible model' vs 'AA not configured'. End-to-end env mutation is
+    fragile (pydantic-settings reads .env outside test control), so we
+    pin the contract at the label-dict layer where it lives."""
+    from app.routes.quality import _SCORING_SOURCE_LABELS
+
+    # Both balanced and fastest must have BOTH fallback variants so the
+    # operator can tell whether to configure AA or widen their allowlist.
+    assert "balanced-cheapest-fallback" in _SCORING_SOURCE_LABELS
+    assert "balanced-no-data-fallback" in _SCORING_SOURCE_LABELS
+    assert "fastest-cheapest-fallback" in _SCORING_SOURCE_LABELS
+    assert "fastest-no-data-fallback" in _SCORING_SOURCE_LABELS
+
+    # Labels must be visibly different so the dashboard renders distinct
+    # text for the two failure modes (otherwise the operator can't tell
+    # what to fix).
+    assert (
+        _SCORING_SOURCE_LABELS["balanced-cheapest-fallback"]
+        != _SCORING_SOURCE_LABELS["balanced-no-data-fallback"]
+    )
+    assert (
+        _SCORING_SOURCE_LABELS["fastest-cheapest-fallback"]
+        != _SCORING_SOURCE_LABELS["fastest-no-data-fallback"]
     )

--- a/tests/unit/test_auto_routing.py
+++ b/tests/unit/test_auto_routing.py
@@ -88,7 +88,7 @@ def test_choose_model_picks_cheapest_meeting_no_requirements():
         CatalogModel("medium", "openai", "openai/", True, True, True, 1e-6, 3e-6),
     ]
     deployable = {"cheap", "medium", "expensive"}
-    chosen = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
+    chosen, _scoring = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
     # Cheapest first, then the rest in cost order — the full ordered list
     # becomes the primary + fallback chain.
     assert chosen == ["cheap", "medium", "expensive"]
@@ -104,7 +104,7 @@ def test_choose_model_excludes_non_deployable():
         CatalogModel("cheap-and-keyed", "anthropic", "anthropic/", True, False, False, 1e-7, 4e-7),
     ]
     deployable = {"cheap-and-keyed"}  # only this provider has a key
-    chosen = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
+    chosen, _scoring = choose_auto_model(needs=set(), deployable=deployable, candidates=candidates)
     assert chosen == ["cheap-and-keyed"]
 
 
@@ -119,7 +119,7 @@ def test_choose_model_filters_by_capability():
         CatalogModel("vision-capable", "openai", "openai/", True, True, True, 1e-6, 3e-6),
     ]
     deployable = {"cheap-no-vision", "vision-capable"}
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs={"vision"}, deployable=deployable, candidates=candidates
     )
     # Only one capable model survives the capability filter.
@@ -135,7 +135,7 @@ def test_choose_model_returns_empty_when_no_candidate_satisfies():
     candidates = [
         CatalogModel("text-only", "groq", "groq/", True, False, False, 1e-8, 1e-8),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs={"vision"}, deployable={"text-only"}, candidates=candidates
     )
     assert chosen == []
@@ -152,7 +152,7 @@ def test_choose_model_uses_blended_input_plus_output_cost():
         # Low input, high output → high blended cost
         CatalogModel("b", "openai", "openai/", True, False, False, 1e-7, 1e-5),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(), deployable={"a", "b"}, candidates=candidates
     )
     # `a` wins the blended-cost comparison (output dominates).
@@ -171,7 +171,7 @@ def test_choose_model_quality_strategy_picks_most_expensive():
         CatalogModel("medium", "openai", "openai/", True, False, False, 1e-6, 3e-6),
         CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap", "medium", "expensive"},
         candidates=candidates,
@@ -189,7 +189,7 @@ def test_choose_model_cheapest_strategy_matches_default():
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
         CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap", "expensive"},
         candidates=candidates,
@@ -208,7 +208,7 @@ def test_choose_model_preferred_models_narrows_eligible_set():
         CatalogModel("preferred-mid", "openai", "openai/", True, False, False, 1e-6, 3e-6),
         CatalogModel("preferred-big", "openai", "openai/", True, False, False, 1e-5, 3e-5),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap-not-preferred", "preferred-mid", "preferred-big"},
         candidates=candidates,
@@ -227,7 +227,7 @@ def test_choose_model_preferred_models_falls_back_when_none_eligible():
     candidates = [
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap"},
         candidates=candidates,
@@ -242,9 +242,12 @@ def test_litellm_routing_strategy_maps_known_values():
     from app.auto_routing import litellm_routing_strategy
 
     assert litellm_routing_strategy("cheapest") == "cost-based-routing"
-    assert litellm_routing_strategy("fastest") == "latency-based-routing"
-    # `balanced` and `quality` use litellm's default (no override)
+    # `balanced`, `fastest`, `quality` are all None as of PR 4 — strategy
+    # intent is realized in `choose_auto_model`'s ranking logic, not via
+    # litellm's routing_strategy. `latency-based-routing` is a no-op for
+    # 1-deployment-per-model anyway, so we don't pass it.
     assert litellm_routing_strategy("balanced") is None
+    assert litellm_routing_strategy("fastest") is None
     assert litellm_routing_strategy("quality") is None
 
 
@@ -269,7 +272,7 @@ def test_choose_model_caps_results_at_top_n():
         for i in range(10)
     ]
     deployable = {f"m{i}" for i in range(10)}
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(), deployable=deployable, candidates=candidates, top_n=3
     )
     # Cheapest 3 in cost order; the rest are dropped.
@@ -294,7 +297,7 @@ def test_quality_strategy_uses_quality_scores_when_provided():
     deployable = {"claude-opus-4-old", "claude-opus-4-7"}
     quality_scores = {"claude-opus-4-7": 57.0, "claude-opus-4-old": 47.0}
 
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(), deployable=deployable, candidates=candidates,
         strategy="quality", quality_scores=quality_scores,
     )
@@ -314,11 +317,11 @@ def test_quality_strategy_falls_back_to_cost_when_scores_empty():
         CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen_none = choose_auto_model(
+    chosen_none, _ = choose_auto_model(
         needs=set(), deployable={"cheap", "expensive"}, candidates=candidates,
         strategy="quality", quality_scores=None,
     )
-    chosen_empty = choose_auto_model(
+    chosen_empty, _ = choose_auto_model(
         needs=set(), deployable={"cheap", "expensive"}, candidates=candidates,
         strategy="quality", quality_scores={},
     )
@@ -338,7 +341,7 @@ def test_quality_unscored_models_drop_below_scored():
         CatalogModel("unscored-expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
         CatalogModel("scored-high", "openai", "openai/", True, False, False, 1e-6, 3e-6),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"scored-low", "unscored-expensive", "scored-high"},
         candidates=candidates,
@@ -360,7 +363,7 @@ def test_quality_cost_breaks_score_ties():
         CatalogModel("flagship", "openai", "openai/", True, False, False, 1e-5, 3e-5),
         CatalogModel("distill", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(), deployable={"flagship", "distill"}, candidates=candidates,
         strategy="quality",
         quality_scores={"flagship": 57.0, "distill": 57.0},
@@ -378,7 +381,7 @@ def test_choose_model_default_top_n_is_5():
                      1e-7 * (i + 1), 4e-7 * (i + 1))
         for i in range(10)
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(), deployable={f"m{i}" for i in range(10)}, candidates=candidates
     )
     assert len(chosen) == 5
@@ -401,7 +404,7 @@ def test_allowlist_filters_before_top_n_truncation():
         for i in range(10)
     ]
     deployable = {f"m{i}" for i in range(10)}
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable=deployable,
         candidates=candidates,
@@ -423,7 +426,7 @@ def test_allowlist_with_intersection_returns_only_allowed():
         CatalogModel("medium", "openai", "openai/", True, False, False, 1e-7, 4e-7),
         CatalogModel("expensive", "openai", "openai/", True, False, False, 1e-5, 3e-5),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap", "medium", "expensive"},
         candidates=candidates,
@@ -441,7 +444,7 @@ def test_allowlist_with_no_intersection_returns_empty():
     candidates = [
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap"},
         candidates=candidates,
@@ -460,7 +463,7 @@ def test_explicit_empty_allowlist_denies_all():
     candidates = [
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap"},
         candidates=candidates,
@@ -479,7 +482,7 @@ def test_none_allowlist_means_no_restriction():
     candidates = [
         CatalogModel("cheap", "openai", "openai/", True, False, False, 1e-7, 4e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"cheap"},
         candidates=candidates,
@@ -541,7 +544,7 @@ def test_choose_model_dedupes_sibling_versions():
         CatalogModel("gpt-5-nano", "openai", "openai/", True, False, False, 2e-7, 5e-7),
         CatalogModel("gpt-5-nano-2025-08-07", "openai", "openai/", True, False, False, 2.1e-7, 5.1e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={c.id for c in candidates},
         candidates=candidates,
@@ -569,7 +572,7 @@ def test_dedupe_preserves_strategy_ranking():
         CatalogModel("foo-001", "x", "x/", True, False, False, 1e-7, 4e-7),
     ]
     # Give the suffix-variant the higher score.
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"foo", "foo-001"},
         candidates=candidates,
@@ -591,7 +594,7 @@ def test_dedupe_does_not_collapse_unrelated_models():
         CatalogModel("gpt-4o", "openai", "openai/", True, False, False, 5e-6, 15e-6),
         CatalogModel("gpt-4o-mini", "openai", "openai/", True, False, False, 1.5e-7, 6e-7),
     ]
-    chosen = choose_auto_model(
+    chosen, _scoring = choose_auto_model(
         needs=set(),
         deployable={"gpt-4o", "gpt-4o-mini"},
         candidates=candidates,
@@ -600,3 +603,277 @@ def test_dedupe_does_not_collapse_unrelated_models():
     assert "gpt-4o" in chosen and "gpt-4o-mini" in chosen, (
         "branding suffix is not a version — both must remain"
     )
+
+
+# ── balanced + fastest: PR 4 strict-coverage strategies ────────────────
+
+
+def _mk(id_, cost, *, vision=False, json_mode=True):
+    """Test-only constructor — keeps fixtures readable."""
+    from packages.litellm_adapter.catalog import CatalogModel
+    return CatalogModel(id_, "test", None, True, vision, json_mode, cost, cost)
+
+
+def test_balanced_normalized_50_50_avoids_cheap_bias():
+    """Critical bias regression: under naive skip-on-missing weighting,
+    a cheap-but-no-quality model normalized to 1.0 on cost would beat
+    a fully-scored mid-quality model. Strict coverage drops the cheap
+    unscored model from the candidate set so the 50/50 normalize gives
+    a real middle-ground winner."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)   # cheap, low quality
+    B = _mk("B", 5e-6)   # expensive, high quality
+    C = _mk("C", 1e-6)   # middle on both
+    candidates = [A, B, C]
+    quality = {"A": 20.0, "B": 80.0, "C": 50.0}
+
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="balanced",
+        quality_scores=quality,
+    )
+    # C wins (best balance), A and B tie at 0.5 → cost tiebreak puts A
+    # second, B last.
+    assert chosen == ["C", "A", "B"]
+    assert scoring["C"].primary_score == 66
+    assert scoring["A"].primary_score == 50
+    assert scoring["B"].primary_score == 50
+
+
+def test_balanced_strict_coverage_drops_unscored_from_candidates():
+    """Strict-coverage means: a model with no quality data is not
+    appended at the end — it's removed from the candidate set entirely.
+    Otherwise LiteLLM's fallback chain could still serve traffic from
+    a model the operator's strategy says shouldn't be eligible."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)
+    B = _mk("B", 5e-6)
+    D = _mk("D", 2e-6)   # NO quality data
+    candidates = [A, B, D]
+    quality = {"A": 20.0, "B": 80.0}   # D missing
+
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="balanced",
+        quality_scores=quality,
+    )
+    assert "D" not in chosen, "unscored model must be dropped, not re-appended"
+    assert "D" not in scoring
+
+
+def test_balanced_falls_back_to_cheapest_within_eligible_only():
+    """Strict-coverage drop with an empty result must NOT re-expand the
+    candidate pool to the full catalog — that would route to models
+    outside the deployable set (no provider key configured)."""
+    from app.auto_routing import choose_auto_model
+
+    deployed = _mk("deployed", 1e-6)
+    not_deployed = _mk("not-deployed", 1e-9)
+    candidates = [deployed, not_deployed]
+
+    chosen, _ = choose_auto_model(
+        needs=set(),
+        deployable={"deployed"},   # not_deployed excluded upfront
+        candidates=candidates,
+        strategy="balanced",
+        quality_scores={},   # no scored models → fallback path
+    )
+    assert chosen == ["deployed"]
+    assert "not-deployed" not in chosen
+
+
+def test_fastest_combines_tps_and_ttft_50_50():
+    """fastest = 0.5 × tps_norm + 0.5 × ttft_inverted_norm. Verified
+    against the plan fixture (computed by hand): A dominates both
+    axes, B is worst on both, C is middle and gets ~53/100."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)
+    B = _mk("B", 5e-6)
+    C = _mk("C", 1e-6)
+    candidates = [A, B, C]
+    tps =  {"A": 200.0, "B": 50.0,  "C": 120.0}
+    ttft = {"A": 0.3,   "B": 2.0,   "C": 1.0}
+
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="fastest",
+        tps_scores=tps,
+        ttft_scores=ttft,
+    )
+    assert chosen == ["A", "C", "B"]
+    assert scoring["A"].primary_score == 100
+    assert scoring["C"].primary_score == 53   # round(0.527 * 100)
+    assert scoring["B"].primary_score == 0
+
+
+def test_fastest_strict_two_axis_drops_single_axis_models():
+    """A model with only TPS (no TTFT) would normalize to 1.0 on its
+    only axis under skip-on-missing — the same reverse bias balanced
+    fixed. fastest requires BOTH axes to participate."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)
+    B = _mk("B", 5e-6)
+    SINGLE = _mk("only-tps", 1e-6)   # has TPS but no TTFT
+    candidates = [A, B, SINGLE]
+    tps =  {"A": 200.0, "B": 50.0, "only-tps": 999.0}
+    ttft = {"A": 0.3,   "B": 2.0}   # SINGLE missing
+
+    chosen, _ = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="fastest",
+        tps_scores=tps,
+        ttft_scores=ttft,
+    )
+    assert "only-tps" not in chosen, (
+        "single-axis model must not participate (would get inflated score)"
+    )
+
+
+def test_fastest_falls_back_to_cheapest_without_any_metrics():
+    """No TPS, no TTFT → fall back to cheapest within eligible. Without
+    this the fastest strategy would silently return zero candidates
+    when AA isn't configured."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)
+    B = _mk("B", 5e-6)
+    candidates = [A, B]
+
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="fastest",
+        tps_scores=None,
+        ttft_scores=None,
+    )
+    assert chosen == ["A", "B"], "fall back to cheapest order"
+    # cheapest scoring → primary_score is None
+    assert scoring["A"].primary_score is None
+
+
+def test_normalize_helper_handles_collapsed_range():
+    """All-equal values would divide by zero in min-max. Guard returns
+    1.0 for everyone so tiebreakers decide."""
+    from app.auto_routing import _normalize
+
+    # All same value
+    out = _normalize({"a": 5.0, "b": 5.0, "c": 5.0}, ["a", "b", "c"])
+    assert out == {"a": 1.0, "b": 1.0, "c": 1.0}
+
+
+def test_normalize_helper_returns_empty_on_no_input():
+    """Empty input → empty output. Caller must handle (we don't return
+    {a: 0, b: 0} which would silently let the caller invent rankings)."""
+    from app.auto_routing import _normalize
+
+    assert _normalize({}, []) == {}
+    assert _normalize({}, ["a", "b"]) == {}
+
+
+def test_choose_auto_model_returns_scoring_dict_keyed_on_winner_after_dedupe():
+    """Sibling-version dedupe runs after sort. The returned scoring dict
+    must be keyed only by the deduped survivors (the IDs in the result
+    list), not include the dropped sibling."""
+    from app.auto_routing import choose_auto_model
+
+    base = _mk("gemini-2.0-flash", 1e-7)
+    dated = _mk("gemini-2.0-flash-001", 1e-7)   # version sibling
+    other = _mk("other", 5e-6)
+    candidates = [base, dated, other]
+
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="cheapest",
+    )
+    # One of the gemini siblings drops out; whichever survives is in scoring.
+    assert set(scoring.keys()) == set(chosen)
+    assert "other" in scoring
+
+
+def test_primary_score_is_int_0_to_100():
+    """Score scale contract: balanced/fastest emit int 0-100. UI
+    `toFixed(0)` callsites would silently break if the type drifted
+    back to float (or worse, NaN)."""
+    from app.auto_routing import choose_auto_model
+
+    A = _mk("A", 1e-7)
+    B = _mk("B", 5e-6)
+    C = _mk("C", 1e-6)
+    candidates = [A, B, C]
+
+    _, scoring = choose_auto_model(
+        needs=set(),
+        deployable={m.id for m in candidates},
+        candidates=candidates,
+        strategy="balanced",
+        quality_scores={"A": 20.0, "B": 80.0, "C": 50.0},
+    )
+    for sd in scoring.values():
+        assert isinstance(sd.primary_score, int)
+        assert 0 <= sd.primary_score <= 100
+
+
+def test_balanced_falls_back_when_aa_covers_no_eligible_model():
+    """Edge case codex caught: AA quality data is configured GLOBALLY
+    (`quality_scores` is non-empty) but no model in this request's
+    eligible set is in it (allowlist or capability filter excluded all
+    covered models). Plan-intentional behavior: fall back to cheapest
+    of the eligible set so traffic still flows. The dashboard's
+    `scoring_source` distinguishes this from the no-AA-configured case."""
+    from app.auto_routing import choose_auto_model
+
+    covered = _mk("covered", 1e-6)
+    uncovered_only = _mk("uncovered", 5e-6)
+    candidates = [covered, uncovered_only]
+    # AA has quality for `covered` — but `covered` is NOT in deployable
+    # (eg the operator's only configured provider key serves `uncovered`).
+    quality = {"covered": 90.0}
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={"uncovered"},
+        candidates=candidates,
+        strategy="balanced",
+        quality_scores=quality,
+    )
+    assert chosen == ["uncovered"]
+    assert scoring["uncovered"].primary_score is None, (
+        "fall-back path emits cheapest scoring (no primary_score), so the "
+        "dashboard can show the operator they're not getting balanced ranking"
+    )
+
+
+def test_fastest_falls_back_when_aa_covers_no_eligible_model():
+    """Same as above for fastest. AA TPS+TTFT exist, but no eligible model
+    is covered on both axes. Fall back to cheapest, surface via scoring."""
+    from app.auto_routing import choose_auto_model
+
+    covered = _mk("covered", 1e-6)
+    uncovered = _mk("uncovered", 5e-6)
+    candidates = [covered, uncovered]
+    tps =  {"covered": 200.0}   # eligible (uncovered) not in maps
+    ttft = {"covered": 0.3}
+    chosen, scoring = choose_auto_model(
+        needs=set(),
+        deployable={"uncovered"},
+        candidates=candidates,
+        strategy="fastest",
+        tps_scores=tps,
+        ttft_scores=ttft,
+    )
+    assert chosen == ["uncovered"]
+    assert scoring["uncovered"].primary_score is None

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -93,15 +93,15 @@ def test_match_catalog_id_no_match():
     assert _match_catalog_id("totally-fake", {"gpt-4o"}) is None
 
 
-# ── score aggregation: max across reasoning-effort variants ───────────
+# ── three-axis aggregation: max quality, max TPS, min TTFT ─────────────
 
 
-def test_build_score_map_takes_max_across_variants():
+def test_build_metrics_takes_max_quality_across_variants():
     """AA splits the same model into separate rows by reasoning effort
     (e.g. 'GPT-5.5 (xhigh)' = 60 vs 'GPT-5.5 (low)' = 51). Our routing
     picks a model_name not an effort, so we keep the highest score per
     base model — the operator can always set effort separately."""
-    from packages.litellm_adapter.quality_index import _build_score_map
+    from packages.litellm_adapter.quality_index import _build_metrics_map
 
     aa = [
         {"name": "GPT-5.5 (xhigh)",
@@ -112,16 +112,16 @@ def test_build_score_map_takes_max_across_variants():
          "evaluations": {"artificial_analysis_intelligence_index": 51}},
     ]
     catalog = {"gpt-5-5"}
-    scores, raw, matched = _build_score_map(aa, catalog)
-    assert scores == {"gpt-5-5": 60.0}, "must keep the max across variants"
-    assert raw == 3
-    assert matched == 1
+    m = _build_metrics_map(aa, catalog)
+    assert m.quality_scores == {"gpt-5-5": 60.0}, "must keep the max across variants"
+    assert m.raw_count == 3
+    assert m.matched_count_quality == 1
 
 
-def test_build_score_map_skips_unmatched():
+def test_build_metrics_skips_unmatched():
     """Models that don't map to any catalog id are dropped — no point
     surfacing scores we can't act on."""
-    from packages.litellm_adapter.quality_index import _build_score_map
+    from packages.litellm_adapter.quality_index import _build_metrics_map
 
     aa = [
         {"name": "Some Future Model X",
@@ -130,26 +130,112 @@ def test_build_score_map_skips_unmatched():
          "evaluations": {"artificial_analysis_intelligence_index": 57}},
     ]
     catalog = {"claude-opus-4-7"}
-    scores, raw, matched = _build_score_map(aa, catalog)
-    assert scores == {"claude-opus-4-7": 57.0}
-    assert raw == 2
-    assert matched == 1
+    m = _build_metrics_map(aa, catalog)
+    assert m.quality_scores == {"claude-opus-4-7": 57.0}
+    assert m.raw_count == 2
+    assert m.matched_count_quality == 1
 
 
-def test_build_score_map_skips_missing_score():
+def test_build_metrics_skips_missing_score():
     """AA entries without an intelligence_index field (e.g. brand-new
-    additions, deprecated rows) are skipped — better to omit than to
-    invent a fake score."""
-    from packages.litellm_adapter.quality_index import _build_score_map
+    additions, deprecated rows) are skipped on the quality axis — better
+    to omit than to invent a fake score. Other axes still apply."""
+    from packages.litellm_adapter.quality_index import _build_metrics_map
 
     aa = [
         {"name": "Claude Opus 4.7 (max)", "evaluations": {}},
         {"name": "GPT-5"},  # no evaluations at all
     ]
     catalog = {"claude-opus-4-7", "gpt-5"}
-    scores, _raw, matched = _build_score_map(aa, catalog)
-    assert scores == {}
-    assert matched == 0
+    m = _build_metrics_map(aa, catalog)
+    assert m.quality_scores == {}
+    assert m.matched_count_quality == 0
+
+
+def test_build_metrics_extracts_quality_tps_ttft_from_top_level():
+    """AA's payload puts intelligence_index nested under `evaluations`
+    but TPS / TTFT are at the entry top level. Verified against live
+    AA payload on 2026-05-05; getting this wrong silently drops the
+    latency data."""
+    from packages.litellm_adapter.quality_index import _build_metrics_map
+
+    aa = [{
+        "name": "Claude Sonnet 4.6",
+        "evaluations": {"artificial_analysis_intelligence_index": 65},
+        "median_output_tokens_per_second": 56,
+        "median_time_to_first_token_seconds": 1.0,
+    }]
+    m = _build_metrics_map(aa, {"claude-sonnet-4-6"})
+    assert m.quality_scores == {"claude-sonnet-4-6": 65.0}
+    assert m.tps_scores == {"claude-sonnet-4-6": 56.0}
+    assert m.ttft_scores == {"claude-sonnet-4-6": 1.0}
+
+
+def test_build_metrics_aggregates_variants_max_max_min():
+    """Per-axis aggregation: TPS=max (throughput stable across variants),
+    TTFT=min (model's non-reasoning fast mode = the latency operator
+    actually wants when picking `fastest`). Each axis is independent —
+    NOT same-row pairing — so the TTFT for `fastest` isn't bound to the
+    quality-max variant's slow-thinking value (32s for GPT-5.5 vs 1.77s
+    in fast mode)."""
+    from packages.litellm_adapter.quality_index import _build_metrics_map
+
+    aa = [
+        {"name": "GPT-5.5 (xhigh)",
+         "evaluations": {"artificial_analysis_intelligence_index": 60},
+         "median_output_tokens_per_second": 72,
+         "median_time_to_first_token_seconds": 32.17},
+        {"name": "GPT-5.5 (low)",
+         "evaluations": {"artificial_analysis_intelligence_index": 51},
+         "median_output_tokens_per_second": 77,
+         "median_time_to_first_token_seconds": 1.77},
+    ]
+    m = _build_metrics_map(aa, {"gpt-5-5"})
+    assert m.quality_scores == {"gpt-5-5": 60.0}, "max quality across variants"
+    assert m.tps_scores == {"gpt-5-5": 77.0}, "max TPS across variants"
+    assert m.ttft_scores == {"gpt-5-5": 1.77}, "MIN TTFT — fast-mode latency"
+
+
+def test_build_metrics_handles_nan_inf_negative_in_aa_values():
+    """AA occasionally returns NaN, inf, or negative numbers (broken
+    instrumentation, division by zero in their backend). Even one NaN
+    poisons the downstream min-max normalization, so the parser rejects
+    them at the boundary."""
+    from packages.litellm_adapter.quality_index import _build_metrics_map
+
+    aa = [{
+        "name": "GPT-4o",
+        "evaluations": {"artificial_analysis_intelligence_index": float("nan")},
+        "median_output_tokens_per_second": -5,
+        "median_time_to_first_token_seconds": float("inf"),
+    }]
+    m = _build_metrics_map(aa, {"gpt-4o"})
+    assert m.quality_scores == {}
+    assert m.tps_scores == {}
+    assert m.ttft_scores == {}
+
+
+def test_build_metrics_validates_evaluations_isinstance_dict():
+    """AA's `evaluations` is normally a dict but malformed responses can
+    pass a list / string / null. The parser must isinstance-check before
+    calling .get(), or one bad entry crashes the whole fetch."""
+    from packages.litellm_adapter.quality_index import _build_metrics_map
+
+    aa = [
+        # evaluations is a string — would AttributeError on .get()
+        {"name": "GPT-4o", "evaluations": "not a dict",
+         "median_output_tokens_per_second": 100,
+         "median_time_to_first_token_seconds": 0.5},
+        # evaluations is a list — would TypeError on .get()
+        {"name": "Claude Opus 4.7", "evaluations": ["weird"],
+         "median_output_tokens_per_second": 60,
+         "median_time_to_first_token_seconds": 1.0},
+    ]
+    m = _build_metrics_map(aa, {"gpt-4o", "claude-opus-4-7"})
+    # Quality dropped (no valid evaluations dict), latency still extracted.
+    assert m.quality_scores == {}
+    assert m.tps_scores == {"gpt-4o": 100.0, "claude-opus-4-7": 60.0}
+    assert m.ttft_scores == {"gpt-4o": 0.5, "claude-opus-4-7": 1.0}
 
 
 # ── end-to-end fetch with httpx mocked at the boundary ────────────────
@@ -533,11 +619,14 @@ async def test_empty_aa_response_does_not_poison_db_snapshot(monkeypatch, db_ses
         "empty AA fetch must not overwrite existing DB snapshot"
     )
 
-    # And the DB row must still hold the good data, not `{}`.
+    # And the DB row must still hold the good data, not `{}`. New
+    # snapshot shape nests per-axis maps under a typed envelope; the
+    # quality axis is what must be preserved across the empty fetch.
     row = (await db_session.execute(select(QualityScoreSnapshot))).scalar_one()
     import json as _json
-    assert _json.loads(row.scores_json) == {"claude-opus-4-7": 57.0}, (
-        "DB snapshot must not have been overwritten with empty score map"
+    parsed = _json.loads(row.scores_json)
+    assert parsed.get("quality") == {"claude-opus-4-7": 57.0}, (
+        "DB snapshot quality axis must not have been overwritten with empty score map"
     )
 
 
@@ -625,3 +714,155 @@ async def test_get_quality_index_serves_stale_on_failure(monkeypatch):
     )
     assert idx_stale.source == "stale-cache"
     assert idx_stale.scores == {"claude-opus-4-7": 57.0}, "stale value preserved"
+
+
+# ── DB snapshot: new shape round-trip + legacy backward compat ─────────
+
+
+async def test_db_snapshot_round_trip_preserves_three_maps(monkeypatch, db_session):
+    """A live AA fetch carrying all three axes must round-trip through
+    the DB unchanged (the JSON envelope keeps quality + tps + ttft
+    independent so a partial refresh later can preserve the others)."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return _aa_response([{
+            "name": "Claude Opus 4.7 (max)",
+            "evaluations": {"artificial_analysis_intelligence_index": 57},
+            "median_output_tokens_per_second": 60,
+            "median_time_to_first_token_seconds": 1.2,
+        }])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime DB.
+    idx = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert idx.scores == {"claude-opus-4-7": 57.0}
+    assert idx.tps_scores == {"claude-opus-4-7": 60.0}
+    assert idx.ttft_scores == {"claude-opus-4-7": 1.2}
+    assert idx.matched_count_quality == 1
+    assert idx.matched_count_tps == 1
+    assert idx.matched_count_ttft == 1
+    # union(三轴 keys) — single model in all axes → 1
+    assert idx.matched_count == 1
+
+    # Drop in-memory cache, re-load from DB → same data.
+    quality_index.reset_cache()
+    idx2 = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert idx2.source in ("live", "stale-db"), (
+        "DB hit should promote to in-process, not refetch AA — but live is also OK"
+    )
+    assert idx2.scores == {"claude-opus-4-7": 57.0}
+    assert idx2.tps_scores == {"claude-opus-4-7": 60.0}
+    assert idx2.ttft_scores == {"claude-opus-4-7": 1.2}
+
+
+async def test_db_snapshot_loader_handles_legacy_flat_quality_only_shape(
+    monkeypatch, db_session,
+):
+    """Dev databases written before PR4 have a flat scores_json
+    `{model_id: float}` (quality only). The loader detects shape and
+    hydrates the legacy data into the quality axis with empty TPS/TTFT,
+    so the snapshot still serves rather than crashing on KeyError."""
+    import json
+
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
+
+    # Manually plant a legacy-shape snapshot row, then make AA unreachable
+    # so the loader is forced through the DB path (not the live fetch).
+    legacy_blob = json.dumps({"claude-opus-4-7": 57.0, "gpt-4o": 70.0})
+    db_session.add(QualityScoreSnapshot(
+        workspace_id="default",
+        api_key_hash=quality_index._api_key_hash("sk-aa-test"),
+        source="live",
+        raw_count=2,
+        matched_count=2,
+        scores_json=legacy_blob,
+    ))
+    await db_session.commit()
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503)
+    _patch_aa_transport(monkeypatch, handler)
+
+    idx = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7", "gpt-4o"},
+        db=db_session, workspace_id="default",
+    )
+    # Legacy shape detected → quality hydrated, TPS/TTFT empty (feature
+    # didn't exist when the row was written).
+    assert idx.scores == {"claude-opus-4-7": 57.0, "gpt-4o": 70.0}
+    assert idx.tps_scores == {}
+    assert idx.ttft_scores == {}
+    assert idx.matched_count_quality == 2
+
+
+async def test_persist_with_axis_preservation_keeps_old_quality_when_new_empty(
+    monkeypatch, db_session,
+):
+    """If AA upstream regresses (renamed `intelligence_index`) and a
+    fresh fetch carries TPS / TTFT but empty quality, the saver must
+    keep the old quality map. Otherwise quality routing silently dies
+    on the next request (no scores to rank by)."""
+    from app import config as cfg
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "sk-aa-test")
+    cfg.get_settings.cache_clear()
+
+    state = {"mode": "full"}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if state["mode"] == "quality_lost":
+            # Quality field missing (or AA renamed it); TPS / TTFT still here.
+            return _aa_response([{
+                "name": "Claude Opus 4.7 (max)",
+                "evaluations": {},  # no quality score
+                "median_output_tokens_per_second": 65,
+                "median_time_to_first_token_seconds": 0.9,
+            }])
+        return _aa_response([{
+            "name": "Claude Opus 4.7 (max)",
+            "evaluations": {"artificial_analysis_intelligence_index": 57},
+            "median_output_tokens_per_second": 60,
+            "median_time_to_first_token_seconds": 1.2,
+        }])
+
+    _patch_aa_transport(monkeypatch, handler)
+
+    # Prime with full data.
+    idx_full = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"}, db=db_session, workspace_id="default",
+    )
+    assert idx_full.scores == {"claude-opus-4-7": 57.0}
+
+    # Simulate AA quality regression on next refresh.
+    quality_index.reset_cache()
+    state["mode"] = "quality_lost"
+    idx_after = await quality_index.get_quality_index(
+        catalog_ids={"claude-opus-4-7"},
+        db=db_session, workspace_id="default", force_refresh=True,
+    )
+    # Quality preserved from old snapshot, TPS/TTFT taken from new fetch.
+    assert idx_after.scores == {"claude-opus-4-7": 57.0}, (
+        "quality must be preserved when new fetch has empty quality axis"
+    )
+    assert idx_after.tps_scores == {"claude-opus-4-7": 65.0}, "TPS taken from new"
+    assert idx_after.ttft_scores == {"claude-opus-4-7": 0.9}, "TTFT taken from new"


### PR DESCRIPTION
## Summary

- Before: `balanced` and `fastest` were dead code — both fell into the same `cheapest` else-branch in `choose_auto_model`. Marketing promised four strategies, code shipped two.
- After: real implementations using AA's per-model TPS + TTFT (extracted alongside the existing intelligence_index), with strict two-axis coverage to avoid single-axis "perfect score" reverse bias.
- Added `?strategy=` query param on `/auto-preview` for verification, distinguishable fallback labels in `scoring_source`, per-row TPS/TTFT in `/v1/quality`, dashboard renders breakdowns + new columns.

## What changes for the user

| Strategy | Before | After |
|---|---|---|
| `cheapest` | blended cost ascending | unchanged |
| `quality` | AA Intelligence Index desc | unchanged |
| `balanced` | **same as cheapest** | `0.5 × quality_norm + 0.5 × (1 − cost_norm)` (50/50 weighted) |
| `fastest` | **same as cheapest** | `0.5 × tps_norm + 0.5 × ttft_inverted_norm` (50/50 weighted) |

Real-data E2E (52 quality + 54 TPS + 54 TTFT models from AA):
- `balanced` → `gemini-3-flash-preview` (score 86, quality 76 + cost 97)
- `fastest`  → `gemini-3-flash-preview` (score 98, TPS 100 + TTFT 96)
- `quality`  → `claude-opus-4-7` (score 57)
- `cheapest` → `gemini-2.0-flash-lite`

## Highlights

- **Strict axis coverage** — no skip-on-missing reverse bias. Single-axis or unscored models are excluded from `balanced`/`fastest` candidates entirely (operator can use `cheapest` or set a manual quality override to cover them).
- **Per-axis snapshot preservation** — fresh AA fetch with one axis empty does not overwrite the previous snapshot's good data on that axis. Prevents AA upstream regressions from disabling routing.
- **No alembic infrastructure introduced** — `scores_json` blob shape changed (nested `{quality, tps, ttft, meta}`); `matched_count` column repurposed to union count; loader detects shape and hydrates legacy flat snapshots as quality-only.
- **60s in-memory metrics cache** — keeps default `balanced` strategy off the DB-query hot path. Override PUT/DELETE and quality refresh routes invalidate immediately so operator changes are visible without TTL wait.
- **`ScoringDetail` returned alongside candidates** — `/auto-preview` renders the same numbers the ranker computed, no DRY drift from re-implementing normalize/weight in the route. `primary_score: int | None` (None for cheapest, int 0-100 for the others).
- **5 rounds of plan review + 1 codex implementation review** absorbed before commit (53 plan findings + 3 implementation findings, all addressed).

## Test plan

- [x] `pytest` 278 pass (251 baseline + 27 new). Migrated 22 existing `choose_auto_model(...) == [...]` assertions to tuple destructure.
- [x] `node --check design/app.js` passes.
- [x] Real-data E2E against real AA payload — fetched + parsed + persisted in new shape, all 4 strategies picked distinct sensible winners.
- [x] Backward compat — legacy flat-shape snapshot loaded as quality-only, balanced ranking still works.
- [x] Cache invalidation — override PUT immediately flipped balanced primary (gpt-4o with manual=99).
- [x] Dashboard HTML serves updated strategy mapping table + new TPS/TTFT columns + revised card copy.
- [ ] First successful AA fetch persists; subsequent restarts serve from DB cache (verifies once daily AA quota is no longer rate-limited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)