### PR TITLE
Fix dashboard "X ago" off by user's timezone offset

### DIFF
--- a/app/_time_util.py
+++ b/app/_time_util.py
@@ -1,0 +1,32 @@
+"""Tiny helpers for serializing datetimes to ISO 8601 with explicit UTC.
+
+Why this exists: the DB columns use `server_default=func.now()` which
+yields naive UTC datetimes on SQLite (no tzinfo) and timezone-aware
+UTC on Postgres. Calling `.isoformat()` directly emits a naive string
+on SQLite (`2026-05-05T13:24:59`), and JavaScript's `new Date()`
+parses that as **local time**, not UTC. Result: dashboards in any
+non-UTC timezone show timestamps shifted by the TZ offset (e.g. CST
+users saw "8h ago" on requests they made seconds earlier).
+
+Always go through `iso_utc()` when serializing a datetime to JSON
+that the frontend will render — it forces a `+00:00` suffix so JS
+`new Date()` gets a timezone-anchored string.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+
+def iso_utc(dt: datetime | None) -> str | None:
+    """Serialize a UTC datetime as ISO 8601 with explicit `+00:00` suffix.
+
+    Naive datetimes are assumed to be UTC (matches the DB convention
+    from `server_default=func.now()`). Already-aware datetimes pass
+    through unchanged. None → None.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.isoformat()

--- a/app/routes/analytics.py
+++ b/app/routes/analytics.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import desc, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app._time_util import iso_utc
 from app.config import get_settings
 from app.deps import get_db, get_key_context
 from app.router_cache import HOSTED_PROVIDER_NAME, hosted_key_source, usable_providers_from_db
@@ -53,7 +54,7 @@ async def recent_requests(
             "latency_ms": r.latency_ms,
             "status_code": r.status_code,
             "error_type": r.error_type,
-            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "created_at": iso_utc(r.created_at),
         }
         for r in rows
     ]

--- a/app/routes/keys.py
+++ b/app/routes/keys.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app._time_util import iso_utc
 from app.deps import get_db, get_key_context
 from packages.auth.hashing import generate_api_key
 from packages.auth.types import KeyContext
@@ -38,9 +39,9 @@ async def list_keys(
                 "name": r.name,
                 "key_prefix": r.key_prefix,
                 "is_active": r.is_active,
-                "last_used_at": r.last_used_at.isoformat() if r.last_used_at else None,
-                "revoked_at": r.revoked_at.isoformat() if r.revoked_at else None,
-                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "last_used_at": iso_utc(r.last_used_at),
+                "revoked_at": iso_utc(r.revoked_at),
+                "created_at": iso_utc(r.created_at),
             }
             for r in rows
         ]

--- a/app/routes/quality.py
+++ b/app/routes/quality.py
@@ -26,6 +26,7 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import router_cache
+from app._time_util import iso_utc
 from app.auto_routing import (
     choose_auto_model,
     litellm_routing_strategy,
@@ -363,8 +364,8 @@ def _serialize_override(row: QualityScoreOverride) -> dict:
         "model_id": row.model_id,
         "score": row.score,
         "note": row.note,
-        "created_at": row.created_at.isoformat() if row.created_at else None,
-        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+        "created_at": iso_utc(row.created_at),
+        "updated_at": iso_utc(row.updated_at),
     }
 
 

--- a/tests/unit/test_time_util.py
+++ b/tests/unit/test_time_util.py
@@ -1,0 +1,45 @@
+"""Tests for iso_utc — the helper that fixes naive-ISO timezone bugs."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from app._time_util import iso_utc
+
+
+def test_iso_utc_none_returns_none():
+    assert iso_utc(None) is None
+
+
+def test_iso_utc_naive_datetime_treated_as_utc():
+    """SQLite's `server_default=func.now()` yields naive datetimes —
+    we assume UTC (matches DB convention) and add the offset suffix.
+    Without this, JS `new Date()` on the dashboard would interpret
+    the string as local time and shift by the user's TZ offset."""
+    dt = datetime(2026, 5, 5, 13, 24, 59)  # naive
+    out = iso_utc(dt)
+    assert out is not None
+    assert out.endswith("+00:00"), f"missing UTC suffix: {out!r}"
+    assert "2026-05-05T13:24:59" in out
+
+
+def test_iso_utc_aware_datetime_passthrough():
+    """Postgres timestamptz columns return aware datetimes — leave
+    them alone, just emit canonical ISO with the existing offset."""
+    dt = datetime(2026, 5, 5, 13, 24, 59, tzinfo=timezone.utc)
+    out = iso_utc(dt)
+    assert out is not None
+    assert out.endswith("+00:00")
+    assert "2026-05-05T13:24:59" in out
+
+
+def test_iso_utc_round_trip_parses_as_utc_in_python():
+    """The output must round-trip back to the same UTC instant. JS
+    `new Date(s).getTime()` should produce the same epoch ms as
+    Python's `datetime.fromisoformat(s).timestamp() * 1000` — that's
+    only true if the offset is explicit."""
+    original = datetime(2026, 5, 5, 13, 24, 59, tzinfo=timezone.utc)
+    parsed = datetime.fromisoformat(iso_utc(original))
+    assert parsed.tzinfo is not None
+    assert parsed.utcoffset().total_seconds() == 0
+    assert parsed == original


### PR DESCRIPTION
## Symptom

Dashboard's "Recent requests" shows requests just made as "8h ago" for a CST (UTC+8) user. The offset always equals the user's local timezone offset.

## Root cause

Route serializers called `dt.isoformat()` directly on naive (SQLite) datetimes. The output `"2026-05-05T13:24:59"` has no timezone marker, and JS `new Date(s)` parses it as **local time** per the ECMAScript spec. A real-UTC 13:24 timestamp ends up rendered as if it happened at local 13:24, shifting "now" by the TZ offset.

## Fix

Tiny `app/_time_util.py:iso_utc()` helper that:
- Treats naive input as UTC (matches `server_default=func.now()` convention).
- Aware datetimes pass through.
- Always emits the explicit `+00:00` suffix so JS gets a timezone-anchored string.

Applied to all 5 datetime fields the dashboard renders:
| File | Field |
|---|---|
| `app/routes/analytics.py` | request log `created_at` (the smoking gun in the screenshot) |
| `app/routes/keys.py` | api key `last_used_at`, `revoked_at`, `created_at` |
| `app/routes/quality.py` | override `created_at`, `updated_at` |

DB storage convention (UTC across SQLite and Postgres) is unchanged. This is a wire-format-only fix.

## Test plan

- [x] `pytest` 282 pass (278 baseline + 4 new for `iso_utc`).
- [ ] Curl `GET /v1/analytics/recent` after merge — `created_at` must end with `+00:00`.
- [ ] Dashboard reload — "Recent requests" should show correct relative time ("just now" / "5s ago" / "2m ago" instead of "8h ago").

🤖 Generated with [Claude Code](https://claude.com/claude-code)