### PR TITLE
Match GPT-5.x AA scores to dotted catalog ids

### DIFF
--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -142,6 +142,29 @@ def _normalize_aa_id(aa_name: str) -> str:
     return s
 
 
+_DIGIT_DASH_DIGIT_RE = re.compile(r"(\d)-(\d)")
+
+
+def _dotted_version_variants(bare: str) -> list[str]:
+    """Generate alternates that put a dot back at any digit-dash-digit
+    position. Handles litellm's inconsistent OpenAI versioning where
+    some entries are stored with dots (`gpt-5.5`, `gpt-5.1`) but our
+    normalizer's blanket `replace(".", "-")` produces `gpt-5-5`.
+
+    Example: `gpt-5-5-mini` → `["gpt-5.5-mini"]`
+             `gpt-5-1-2025-11-13` → `["gpt-5.1-2025-11-13",
+                                      "gpt-5-1-2025.11-13",  ...]`
+
+    Cheap to compute (typically 0-2 candidates) and only tried after
+    exact + bare lookup fails, so the happy path is unaffected.
+    """
+    out: list[str] = []
+    for m in _DIGIT_DASH_DIGIT_RE.finditer(bare):
+        idx = m.start() + 1  # position of the dash
+        out.append(bare[:idx] + "." + bare[idx + 1:])
+    return out
+
+
 def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
     """Find a LiteLLM catalog id that matches a normalized AA name.
 
@@ -149,7 +172,12 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
       1. Exact match
       2. Match with provider prefix stripped (the catalog already
          strips prefixes at load, but be defensive)
-      3. Family match: any catalog id that starts with `normalized + "-"`
+      3. Dotted-version match: try restoring `.` at any digit-dash-digit
+         position. Litellm catalog stores `gpt-5.5` with the dot intact
+         while our normalizer produces `gpt-5-5` from AA's "GPT-5.5",
+         silently dropping AA scores for the entire OpenAI 5.x family
+         without this fallback.
+      4. Family match: any catalog id that starts with `normalized + "-"`
          (covers the case where AA gives a base name and the catalog
          has dated/versioned variants like "claude-opus-4-7-20260416")
 
@@ -160,12 +188,26 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
     bare = normalized.split("/", 1)[-1] if "/" in normalized else normalized
     if bare in catalog_ids:
         return bare
+    # Try dotted-version alternates BEFORE the family-prefix scan —
+    # a hit here is a more specific match (gpt-5.5 the canonical id
+    # vs gpt-5-mini-XXX as a stray family member of `gpt-5`).
+    for alt in _dotted_version_variants(bare):
+        if alt in catalog_ids:
+            return alt
     # Family match — pick the longest suffix-extended id that starts with
     # our normalized base. Stable order via sort so test runs are reproducible.
     family_prefix = bare + "-"
     candidates = [c for c in catalog_ids if c.startswith(family_prefix)]
     if candidates:
         return sorted(candidates)[0]
+    # Family match for dotted alternates — handles cases where AA gives
+    # a base like "GPT-5.5" → "gpt-5-5" but the catalog only carries
+    # the dated form "gpt-5.5-2026-04-23".
+    for alt in _dotted_version_variants(bare):
+        family_prefix = alt + "-"
+        candidates = [c for c in catalog_ids if c.startswith(family_prefix)]
+        if candidates:
+            return sorted(candidates)[0]
     return None
 
 

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -93,6 +93,47 @@ def test_match_catalog_id_no_match():
     assert _match_catalog_id("totally-fake", {"gpt-4o"}) is None
 
 
+def test_match_catalog_id_dotted_version_fallback():
+    """Litellm catalog stores OpenAI 5.x with dots intact (`gpt-5.5`,
+    `gpt-5.1`, `gpt-5.2`), but our normalizer's blanket `replace('.', '-')`
+    converts AA's "GPT-5.5" → `gpt-5-5`. Without the dotted-fallback
+    pass, every AA score for the OpenAI 5.x family was silently dropped
+    on match. Symptom: dashboard showed "matched 47 of 513" with ALL
+    GPT-5.x rows blank in the Quality table."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {"gpt-5.5", "gpt-5.1", "gpt-5.2", "gpt-5", "gpt-5-mini"}
+    assert _match_catalog_id("gpt-5-5", catalog) == "gpt-5.5"
+    assert _match_catalog_id("gpt-5-1", catalog) == "gpt-5.1"
+    assert _match_catalog_id("gpt-5-2", catalog) == "gpt-5.2"
+    # Non-dotted versions still match exactly.
+    assert _match_catalog_id("gpt-5", catalog) == "gpt-5"
+    assert _match_catalog_id("gpt-5-mini", catalog) == "gpt-5-mini"
+
+
+def test_match_catalog_id_dotted_family_fallback_for_dated_variants():
+    """When AA gives a base ("GPT-5.5") but the catalog only carries
+    the dated variant (`gpt-5.5-2026-04-23`), the dotted family fallback
+    must still find it."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {"gpt-5.5-2026-04-23", "gpt-5.5-mini"}
+    # Plain bare "gpt-5-5" → no exact, no bare → tries dotted "gpt-5.5"
+    # → no exact → tries family `gpt-5.5-` → hit dated variant first.
+    assert _match_catalog_id("gpt-5-5", catalog) == "gpt-5.5-2026-04-23"
+
+
+def test_match_catalog_id_dotted_fallback_does_not_break_dashed_models():
+    """Claude/Anthropic models use dashes consistently
+    (`claude-3-5-sonnet-latest`, `claude-opus-4-7`). The dotted-version
+    fallback must not mis-route them by trying e.g. `claude-3.5-sonnet`."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {"claude-3-5-sonnet-latest", "claude-opus-4-7"}
+    assert _match_catalog_id("claude-3-5-sonnet", catalog) == "claude-3-5-sonnet-latest"
+    assert _match_catalog_id("claude-opus-4-7", catalog) == "claude-opus-4-7"
+
+
 # ── three-axis aggregation: max quality, max TPS, min TTFT ─────────────
 
 


### PR DESCRIPTION
## Symptom

Dashboard Quality table shows AA score blank for every GPT-5.1 / GPT-5.2 / GPT-5.5 row, even when AA has them. The 7 newest OpenAI models silently have no AA data flowing through to routing decisions.

## Root cause

Name normalization vs catalog convention mismatch:

| Source | Form |
|---|---|
| AA exposes | `"GPT-5.5"`, `"GPT-5.5 (xhigh)"` |
| `_normalize_aa_id` produces | `gpt-5-5` (blanket `.` → `-` for "Claude 3.5 Sonnet" handling) |
| Litellm catalog stores | `gpt-5.5`, `gpt-5.1`, `gpt-5.2` (dots intact for OpenAI 5.x) |

`_match_catalog_id("gpt-5-5", catalog)` returned `None` → silently no AA score → dashboard blank → routing strategies couldn't see these models.

## Fix

After exact + bare lookups fail, try restoring `.` at any digit-dash-digit position before falling through to the family-prefix scan. Two-stage:
1. Direct dotted lookup: `gpt-5-5` → try `gpt-5.5` → catalog hit
2. Dotted family fallback: `gpt-5-5` → try `gpt-5.5-` prefix → matches dated variant `gpt-5.5-2026-04-23`

## Why it doesn't regress Claude

Anthropic catalog uses dashes consistently (`claude-3-5-sonnet-latest`, `claude-opus-4-7`). The dotted attempts (`claude-3.5-sonnet`) miss, fall through to the existing family scan, behavior unchanged.

## Test plan

- [x] `pytest` 285 pass (282 baseline + 3 new for dotted-fallback paths)
- [x] Direct probe with real catalog confirms `gpt-5.5`, `gpt-5.1`, `gpt-5.2` now resolve
- [x] `claude-3-5-sonnet` still resolves to `claude-3-5-sonnet-latest` (no regression)
- [ ] After merge + AA quota recovery + refresh: dashboard's `matched_count_breakdown.quality` should jump from ~52 to ~59 (52 + 7 new GPT-5.x matches), and the Quality table's GPT-5.x rows fill in

🤖 Generated with [Claude Code](https://claude.com/claude-code)