### PR TITLE
Match AA scores to namespaced catalog ids (Llama 4, Qwen3, Yi, Phi)

### DIFF
--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -180,6 +180,12 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
       4. Family match: any catalog id that starts with `normalized + "-"`
          (covers the case where AA gives a base name and the catalog
          has dated/versioned variants like "claude-opus-4-7-20260416")
+      5. Last-segment match: half the catalog stores models under
+         provider namespaces (`accounts/fireworks/models/qwen3-235b-a22b`,
+         `Qwen/Qwen3-235B-A22B-Instruct-2507-tput`). Without unwrapping
+         the namespace AND case-folding for compare, the entire Llama 4
+         / Qwen3 / Yi / Phi / Mistral-via-Together family silently drops
+         from AA matching.
 
     Returns the first matching catalog id, or None.
     """
@@ -208,6 +214,39 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
         candidates = [c for c in catalog_ids if c.startswith(family_prefix)]
         if candidates:
             return sorted(candidates)[0]
+    # Last-segment match (case-insensitive) for namespaced catalog ids.
+    # Catalog stores half its entries under provider namespaces — match
+    # against the post-slash trailing segment so AA's "Qwen3 235B" finds
+    # `accounts/fireworks/models/qwen3-235b-a22b`. We try exact-segment
+    # first, then segment-family, both in case-insensitive form.
+    bare_lower = bare.lower()
+    bare_family_lower = bare_lower + "-"
+    exact_segment_hits: list[str] = []
+    family_segment_hits: list[str] = []
+    for cid in catalog_ids:
+        if "/" not in cid:
+            continue   # already covered by exact / family above
+        last = cid.split("/")[-1].lower()
+        if last == bare_lower:
+            exact_segment_hits.append(cid)
+        elif last.startswith(bare_family_lower):
+            family_segment_hits.append(cid)
+    if exact_segment_hits:
+        return sorted(exact_segment_hits)[0]
+    if family_segment_hits:
+        return sorted(family_segment_hits)[0]
+    # Same last-segment scan with dotted alternates — covers namespaced
+    # catalog ids that also use dotted versions (eg unlikely but possible
+    # `Qwen/Qwen3.5-...`).
+    for alt in _dotted_version_variants(bare):
+        alt_lower = alt.lower()
+        alt_family_lower = alt_lower + "-"
+        for cid in catalog_ids:
+            if "/" not in cid:
+                continue
+            last = cid.split("/")[-1].lower()
+            if last == alt_lower or last.startswith(alt_family_lower):
+                return cid
     return None
 
 

--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -238,6 +238,15 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
     # Same last-segment scan with dotted alternates — covers namespaced
     # catalog ids that also use dotted versions (eg unlikely but possible
     # `Qwen/Qwen3.5-...`).
+    #
+    # Collect ALL hits and pick `sorted(...)[0]` rather than `return cid`
+    # mid-iteration. `catalog_ids` is a `set`; Python set iteration order
+    # is hash-seeded and non-deterministic across processes (PYTHONHASHSEED
+    # randomizes by default). Without sorting, two providers exposing
+    # `.../qwen3.5-*` could route AA metrics to a different catalog id
+    # on every restart, making routing decisions and tests flaky.
+    dotted_exact: list[str] = []
+    dotted_family: list[str] = []
     for alt in _dotted_version_variants(bare):
         alt_lower = alt.lower()
         alt_family_lower = alt_lower + "-"
@@ -245,8 +254,14 @@ def _match_catalog_id(normalized: str, catalog_ids: set[str]) -> str | None:
             if "/" not in cid:
                 continue
             last = cid.split("/")[-1].lower()
-            if last == alt_lower or last.startswith(alt_family_lower):
-                return cid
+            if last == alt_lower:
+                dotted_exact.append(cid)
+            elif last.startswith(alt_family_lower):
+                dotted_family.append(cid)
+    if dotted_exact:
+        return sorted(dotted_exact)[0]
+    if dotted_family:
+        return sorted(dotted_family)[0]
     return None
 
 

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -186,6 +186,53 @@ def test_match_catalog_id_last_segment_does_not_override_exact_match():
     assert _match_catalog_id("mistral-large", catalog) == "mistral-large"
 
 
+def test_match_catalog_id_dotted_last_segment_picks_deterministically():
+    """Codex review of PR #28 caught a non-determinism bug: when multiple
+    namespaced models share a dotted last-segment family (eg two providers
+    both exposing `.../qwen3.5-...` variants), the matcher picked one via
+    raw `set` iteration → process-hash-order dependent → different runs
+    routed AA metrics to different catalog ids → flaky tests + unstable
+    routing across restarts. Fix collects all hits and uses sorted()[0]
+    same as the earlier match passes.
+
+    This test plants four equally-valid namespaced family hits in a set
+    and asserts the matcher picks the lexicographic-first across runs.
+    Without the sort, set-iteration order would surface here."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {
+        "providerB/qwen3.5-235b-instruct",
+        "providerA/qwen3.5-32b-instruct",
+        "providerC/qwen3.5-72b-instruct",
+        "accounts/fireworks/models/qwen3.5-distill",
+    }
+    # Run several times; the result must be stable within a process AND
+    # match the explicit sort order. (Cross-process determinism is what
+    # the underlying fix is about — sorted() guarantees both.)
+    expected = sorted(catalog)[0]
+    for _ in range(5):
+        assert _match_catalog_id("qwen3-5", catalog) == expected, (
+            "dotted last-segment fallback must pick sorted-first hit, "
+            "not whatever set iteration yields this run"
+        )
+
+
+def test_match_catalog_id_dotted_last_segment_exact_beats_family():
+    """Within the dotted-last-segment fallback, an exact-segment match
+    must take precedence over a family-segment match (mirrors the
+    bare-side ordering — exact_segment_hits checked before
+    family_segment_hits)."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {
+        # Family-segment-only (would match if we didn't prefer exact)
+        "ns/qwen3.5-instruct-72b",
+        # Exact dotted last-segment match
+        "other-ns/qwen3.5",
+    }
+    assert _match_catalog_id("qwen3-5", catalog) == "other-ns/qwen3.5"
+
+
 # ── three-axis aggregation: max quality, max TPS, min TTFT ─────────────
 
 

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -134,6 +134,58 @@ def test_match_catalog_id_dotted_fallback_does_not_break_dashed_models():
     assert _match_catalog_id("claude-opus-4-7", catalog) == "claude-opus-4-7"
 
 
+def test_match_catalog_id_namespaced_last_segment_match():
+    """Half the catalog stores models under provider namespaces
+    (`accounts/fireworks/models/qwen3-235b-a22b`,
+    `meta-llama/Llama-4-Scout-17B-16E-Instruct`,
+    `Qwen/Qwen3-235B-A22B-Instruct-2507-tput`). Without unwrapping the
+    namespace AND case-folding, AA's "Qwen3 235B" → `qwen3-235b` and
+    "Llama 4 Scout" → `llama-4-scout` silently miss every Fireworks /
+    HuggingFace-style entry — entire Llama 4, Qwen3, Yi, Phi families
+    drop out of AA scoring."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {
+        "accounts/fireworks/models/qwen3-235b-a22b",
+        "Qwen/Qwen3-235B-A22B-Instruct-2507-tput",
+        "meta-llama/Llama-4-Scout-17B-16E-Instruct",
+        "accounts/fireworks/models/llama4-maverick-instruct-basic",
+        # A non-namespaced model that should still take exact-match
+        # priority over any namespaced family-segment cousin.
+        "qwen3-235b",
+    }
+    # Plain bare match still wins (exact > namespaced)
+    assert _match_catalog_id("qwen3-235b", catalog) == "qwen3-235b"
+
+    # Namespaced family match — last segment starts with `qwen3-32b-`?
+    # No exact match here; family-segment hits the namespaced row.
+    assert _match_catalog_id(
+        "qwen3-235b-a22b",
+        {"accounts/fireworks/models/qwen3-235b-a22b"},
+    ) == "accounts/fireworks/models/qwen3-235b-a22b"
+
+    # Llama 4 Scout: catalog stores it under meta-llama/ namespace with
+    # mixed case — the lowercase last-segment family scan must catch it.
+    assert _match_catalog_id(
+        "llama-4-scout",
+        {"meta-llama/Llama-4-Scout-17B-16E-Instruct"},
+    ) == "meta-llama/Llama-4-Scout-17B-16E-Instruct"
+
+
+def test_match_catalog_id_last_segment_does_not_override_exact_match():
+    """An exact match in the bare-id namespace must always win over a
+    namespaced family-segment hit. Otherwise `Mistral Large` could be
+    routed to a random `accounts/...` namespaced variant when the
+    canonical bare entry is also in the catalog."""
+    from packages.litellm_adapter.quality_index import _match_catalog_id
+
+    catalog = {
+        "mistral-large",                                # canonical bare
+        "accounts/fireworks/models/mistral-large-2407", # namespaced family
+    }
+    assert _match_catalog_id("mistral-large", catalog) == "mistral-large"
+
+
 # ── three-axis aggregation: max quality, max TPS, min TTFT ─────────────
 
 


### PR DESCRIPTION
## Symptom

After PR #27 (GPT-5.x dotted-version fix), AA matched count was still ~52 out of 513 raw entries. Investigation: half the catalog (280 of 556) lives under provider namespaces, and the matcher never unwraps them on the catalog side.

## Root cause

| AA name | Normalized | Catalog stores | Membership check |
|---|---|---|---|
| "Qwen3 235B" | `qwen3-235b` | `Qwen/Qwen3-235B-A22B-Instruct-2507-tput` | ❌ no `/` strip on catalog side |
| "Llama 4 Scout" | `llama-4-scout` | `meta-llama/Llama-4-Scout-17B-16E-Instruct` | ❌ case-sensitive against `Llama-4-Scout` |
| "Yi 34B" | `yi-34b` | `accounts/fireworks/models/yi-34b` | ❌ namespace not stripped |

Two issues compound: namespace prefix never stripped on the catalog side; case-sensitive compare while catalog mixes case freely.

## Fix

After the existing exact + dotted + family passes fail, scan catalog for entries with `/` and compare the **lowercased last segment** against our normalized name. Both exact-segment and family-segment passes, with dotted alternates folded in.

Last-segment scan runs AFTER bare-id and family checks, so an exact canonical hit (`mistral-large`) still wins over a namespaced family cousin (`accounts/fireworks/models/mistral-large-2407`).

## Coverage gain

Audit on 41 popular AA-tracked models: **76% → 85% match rate**.

Models that now match (sample):
- `Qwen3 235B` → `Qwen/Qwen3-235B-A22B-Instruct-2507-tput`
- `Qwen3 32B` → `accounts/fireworks/models/qwen3-32b`
- `Llama 4 Scout` → `meta-llama/Llama-4-Scout-17B-16E-Instruct`
- `Llama 4 Maverick` → `meta-llama/Llama-4-Maverick-17B-128E-Instruct-FP8`

Remaining 6 misses are real catalog gaps (DeepSeek V4 / Yi 1.5 / Phi-4 / Claude 3 Opus / Gemini 1.5 Pro+Flash). Fixable only by adding upstream provider model lists — PR 6 territory.

## Test plan

- [x] `pytest` 287 pass (285 baseline + 2 new for namespaced + exact-priority paths).
- [ ] After merge + AA quota recovery + refresh: dashboard's `matched_count_breakdown.quality` should jump from 52 to ~62-65 (52 + Llama 4 + Qwen3 + Yi + Phi families).

🤖 Generated with [Claude Code](https://claude.com/claude-code)