### PR TITLE
Surface env-configured provider keys + add xAI/DeepSeek + clean ghost rows

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -9,6 +9,18 @@ from functools import lru_cache
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# Providers we accept from env vars. Must stay in sync with:
+#   - the matching `<provider>_api_key` fields on Settings below
+#   - `PROVIDERS_KNOWN` in design/app.js (dashboard quick-add chips)
+#   - `_PROVIDER_BY_LITELLM_KEY` in packages/litellm_adapter/catalog.py
+#     (which decides the runtime provider id for catalog entries)
+#
+# xAI / DeepSeek were missing here pre-2026-05, leaving their catalog
+# models silently un-routable: the catalog had grok-4 + deepseek-v3 etc,
+# but Settings didn't read XAI_API_KEY / DEEPSEEK_API_KEY, and the
+# dashboard had no chip for them. Operators couldn't configure without
+# raw curl PUT (or hit the wrong provider — famously: "grok" PUT'd into
+# "groq", which is a different company).
 _PROVIDERS_FROM_ENV = (
     "openai",
     "anthropic",
@@ -16,6 +28,8 @@ _PROVIDERS_FROM_ENV = (
     "groq",
     "together",
     "fireworks",
+    "xai",          # Grok 2/3/4 series. NOTE: NOT the same as `groq`.
+    "deepseek",     # deepseek-chat / -reasoner / -v3 / -v3.2.
 )
 
 
@@ -43,12 +57,17 @@ class Settings(BaseSettings):
     api_key_pepper: str = ""
 
     # ── Provider keys via env (alternative to UI-stored keys) ──
+    # Keep in sync with `_PROVIDERS_FROM_ENV` above. Pydantic-settings reads
+    # case-insensitively (config: `case_sensitive=False`), so XAI_API_KEY,
+    # xai_api_key, etc all hit the same field.
     openai_api_key: str | None = None
     anthropic_api_key: str | None = None
     google_api_key: str | None = None
     groq_api_key: str | None = None
     together_api_key: str | None = None
     fireworks_api_key: str | None = None
+    xai_api_key: str | None = None
+    deepseek_api_key: str | None = None
 
     # ── Hosted-as-upstream (standard fallback) ──
     # When configured (env or via dashboard), every catalog model gets an extra

--- a/app/routes/providers.py
+++ b/app/routes/providers.py
@@ -1,13 +1,48 @@
-"""Provider keys CRUD — BYOK credentials for upstream LLM providers."""
+"""Provider keys CRUD — BYOK credentials for upstream LLM providers.
+
+Single-tenant invariant: at most ONE active key per provider. Two
+sources, both honored by the runtime router with DB taking precedence:
+
+  1. DB rows in `provider_keys` (set via dashboard PUT, encrypted at rest).
+  2. Environment variables (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.)
+     loaded by `Settings` and exposed via `settings.env_provider_keys()`.
+
+The list endpoint surfaces BOTH so operators can see what's actually
+configured. Without that, an operator who set keys in `.env` would see
+an empty providers page in the dashboard, assume nothing is wired up,
+and either re-set keys (creating a confusing duplicate) or worry that
+their `auto` chats are silently failing — when in reality the env-sourced
+key is serving traffic just fine.
+
+Env-sourced rows carry `source: "env"`. Editing an env entry from the
+dashboard writes a new DB row (which then takes precedence — matches
+the runtime resolver in `router_cache.py:58`). Deleting the DB row
+falls back to the env value transparently. Env entries themselves
+aren't deletable from this API; the operator must edit `.env` and
+restart to remove an env-set key (12-factor: env config lives in env).
+
+Delete is a HARD delete, not a soft tombstone. Reasoning:
+  - BYOK keys aren't user data; there's no audit/recovery story.
+  - Soft-delete + new-PUT historically created ghost rows: query
+    filtered `is_deleted=0`, missed the tombstone, INSERT'd a new
+    row, leaving N tombstones piled up forever.
+  - Hard delete keeps the table at most 1 row per provider, matching
+    the single-tenant 1-key-per-provider invariant.
+
+Migration note: existing dev DBs may carry tombstones from before this
+change. The PUT path opportunistically wipes them when an operator
+sets a new key for the same provider.
+"""
 
 from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import delete as sql_delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import router_cache
+from app.config import get_settings
 from app.deps import get_db, get_key_context
 from packages.auth.encryption import encrypt_credential
 from packages.auth.types import KeyContext
@@ -18,14 +53,26 @@ router = APIRouter(prefix="/v1/providers", tags=["providers"])
 
 class SetProviderKey(BaseModel):
     api_key: str
-    label: str = "default"
 
 
 class ProviderKeyOut(BaseModel):
     provider: str
-    label: str
     key_prefix: str
     is_enabled: bool
+    # "db" = stored in provider_keys table (editable + deletable from dashboard)
+    # "env" = loaded from .env / process env (read-only here; edit .env to change)
+    source: str = "db"
+
+
+def _mask_key(api_key: str) -> str:
+    """Display-safe key prefix. Long keys show first 8 + last 4; short
+    keys show 2 + 2 to give the operator some hint of which account
+    they're looking at without exposing enough to be useful as a credential."""
+    if len(api_key) > 12:
+        return api_key[:8] + "..." + api_key[-4:]
+    if len(api_key) > 4:
+        return api_key[:2] + "..." + api_key[-2:]
+    return "..."
 
 
 @router.get("")
@@ -38,17 +85,35 @@ async def list_providers(
             select(ProviderKey).where(ProviderKey.is_deleted == 0)
         )
     ).scalars().all()
-    return {
-        "providers": [
+
+    db_providers = {r.provider for r in rows}
+    out: list[dict] = [
+        ProviderKeyOut(
+            provider=r.provider,
+            key_prefix=r.key_prefix,
+            is_enabled=r.is_enabled,
+            source="db",
+        ).model_dump()
+        for r in rows
+    ]
+
+    # Surface env-configured keys the runtime is already using. DB takes
+    # precedence (matches the runtime resolver in router_cache.py:58
+    # `db_provider_keys.get(provider) or env_keys.get(provider)`), so
+    # we only add env entries for providers NOT already covered by a DB row.
+    for prov, raw_key in get_settings().env_provider_keys().items():
+        if prov in db_providers:
+            continue
+        out.append(
             ProviderKeyOut(
-                provider=r.provider,
-                label=r.label,
-                key_prefix=r.key_prefix,
-                is_enabled=r.is_enabled,
+                provider=prov,
+                key_prefix=_mask_key(raw_key),
+                is_enabled=True,
+                source="env",
             ).model_dump()
-            for r in rows
-        ]
-    }
+        )
+
+    return {"providers": out}
 
 
 @router.put("/{provider}")
@@ -61,6 +126,19 @@ async def set_provider_key(
     if not body.api_key.strip():
         raise HTTPException(status_code=422, detail="api_key cannot be empty")
 
+    # Wipe any soft-deleted ghost rows for this provider before upsert.
+    # Migration aid: pre-PR dev DBs might carry tombstones from old soft-delete
+    # behavior. Without this cleanup, the upsert query below — which filters
+    # `is_deleted=0` — would miss the ghost and INSERT a new row, leaving
+    # the tombstone piled up. After this PR, DELETE is a hard delete so no
+    # new tombstones can form, but old ones still need scrubbing.
+    await db.execute(
+        sql_delete(ProviderKey).where(
+            ProviderKey.provider == provider,
+            ProviderKey.is_deleted == 1,
+        )
+    )
+
     existing = (
         await db.execute(
             select(ProviderKey).where(
@@ -71,19 +149,17 @@ async def set_provider_key(
     ).scalar_one_or_none()
 
     encrypted = encrypt_credential(body.api_key)
-    prefix_visible = body.api_key[:8] + "..." + body.api_key[-4:] if len(body.api_key) > 12 else "..."
+    prefix_visible = _mask_key(body.api_key)
 
     if existing is not None:
         existing.encrypted_key = encrypted
         existing.key_prefix = prefix_visible
-        existing.label = body.label
         existing.is_enabled = True
     else:
         existing = ProviderKey(
             provider=provider,
             encrypted_key=encrypted,
             key_prefix=prefix_visible,
-            label=body.label,
         )
         db.add(existing)
 
@@ -92,9 +168,9 @@ async def set_provider_key(
 
     return ProviderKeyOut(
         provider=existing.provider,
-        label=existing.label,
         key_prefix=existing.key_prefix,
         is_enabled=existing.is_enabled,
+        source="db",
     ).model_dump()
 
 
@@ -104,18 +180,33 @@ async def delete_provider_key(
     _kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
-    row = (
-        await db.execute(
-            select(ProviderKey).where(
-                ProviderKey.provider == provider,
-                ProviderKey.is_deleted == 0,
-            )
-        )
-    ).scalar_one_or_none()
-    if row is None:
-        raise HTTPException(status_code=404, detail="Provider key not found")
+    """Hard-delete the DB row for this provider. After this, runtime
+    resolution falls back to the env value (if `.env` has one) or
+    treats the provider as unconfigured.
 
-    row.is_deleted = 1
+    Returns 204 even if no DB row existed — the operator's intent
+    ('no DB-managed key for this provider') is satisfied either way.
+    Removing an env-only entry isn't supported here: edit `.env` and
+    restart the server (env config is file-managed by design).
+    """
+    result = await db.execute(
+        sql_delete(ProviderKey).where(ProviderKey.provider == provider)
+    )
     await db.commit()
+    if result.rowcount == 0:
+        # No DB row, but the operator may have meant the env-sourced one.
+        # Surface the situation explicitly instead of silently 204'ing —
+        # otherwise a dashboard "Remove" click on an env row appears to
+        # succeed yet the key remains active on next page load.
+        if provider in get_settings().env_provider_keys():
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    f"'{provider}' is configured via environment variable "
+                    f"({provider.upper()}_API_KEY). Remove it from your .env "
+                    f"and restart the server to deconfigure."
+                ),
+            )
+        raise HTTPException(status_code=404, detail="Provider key not found")
     router_cache.invalidate_router()
     return Response(status_code=204)

--- a/app/routes/providers.py
+++ b/app/routes/providers.py
@@ -44,6 +44,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app import router_cache
 from app.config import get_settings
 from app.deps import get_db, get_key_context
+from app.router_cache import usable_providers_from_db
 from packages.auth.encryption import encrypt_credential
 from packages.auth.types import KeyContext
 from packages.db.models.provider_key import ProviderKey
@@ -86,23 +87,41 @@ async def list_providers(
         )
     ).scalars().all()
 
-    db_providers = {r.provider for r in rows}
-    out: list[dict] = [
-        ProviderKeyOut(
-            provider=r.provider,
-            key_prefix=r.key_prefix,
-            is_enabled=r.is_enabled,
-            source="db",
-        ).model_dump()
-        for r in rows
-    ]
+    # The runtime resolver (`router_cache.build_deployments`) only honors
+    # a DB row when it's BOTH `is_enabled` AND its `encrypted_key` decrypts.
+    # `usable_providers_from_db` already encodes that contract — reuse it
+    # here so the listing's notion of "DB row authoritative" stays in
+    # lockstep with what actually serves traffic. Without this, a disabled
+    # row or one with corrupt ciphertext (e.g. after a
+    # CREDENTIAL_ENCRYPTION_KEY rotation) would suppress the env entry
+    # in the dashboard while the runtime quietly falls back to env —
+    # operators would see a "DB" source label but the env key is what's
+    # actually authenticating their requests.
+    usable_db = usable_providers_from_db(rows)
+
+    out: list[dict] = []
+    for r in rows:
+        # Render every non-deleted DB row so operators still see disabled /
+        # broken rows and can fix them. is_enabled flag tells the dashboard
+        # to render appropriately; the env-suppression check below is the
+        # part that depends on USABILITY, not just presence.
+        out.append(
+            ProviderKeyOut(
+                provider=r.provider,
+                key_prefix=r.key_prefix,
+                is_enabled=r.is_enabled,
+                source="db",
+            ).model_dump()
+        )
 
     # Surface env-configured keys the runtime is already using. DB takes
-    # precedence (matches the runtime resolver in router_cache.py:58
-    # `db_provider_keys.get(provider) or env_keys.get(provider)`), so
-    # we only add env entries for providers NOT already covered by a DB row.
+    # precedence ONLY when usable — matches the runtime resolver in
+    # `router_cache.py:build_deployments` which silently skips disabled or
+    # undecryptable rows and falls back to env. Suppressing env here based
+    # on a non-usable DB row would lie to the operator about which
+    # credential is actually authenticating their requests.
     for prov, raw_key in get_settings().env_provider_keys().items():
-        if prov in db_providers:
+        if prov in usable_db:
             continue
         out.append(
             ProviderKeyOut(

--- a/design/app.js
+++ b/design/app.js
@@ -22,10 +22,18 @@ const I18N = {
   ar: { "auth.tagline":"مفتوح المصدر. مستأجر واحد.","auth.welcome":"مرحبًا بعودتك","auth.subtitle":"ألصق مفتاح sk-orca-* المطبوع في سجلات الخادم عند التشغيل الأول. يُخزَّن فقط في هذا المتصفح عبر localStorage.","auth.api_key":"مفتاح API","auth.continue":"متابعة","nav.search":"بحث","nav.overview":"نظرة عامة","nav.providers":"المزوّدون","nav.routing":"توجيه الطلبات","nav.analytics":"التحليلات","nav.api_keys":"مفاتيح API","nav.help_docs":"المساعدة والوثائق","nav.sign_out":"تسجيل الخروج","status.connected":"متصل","status.disconnected":"غير متصل","auth.checking":"جارٍ التحقق…","auth.welcome_aboard":"مرحبًا بك.","auth.key_invalid":"هذا المفتاح لم يعمل. تحقّق من البادئة sk-orca-…","tab.overview.title":"نظرة عامة","tab.overview.sub":"موجّه LLM أحادي المستأجر بنظرة سريعة.","tab.providers.title":"مفاتيح المزوّدين","tab.providers.sub":"BYOK — مشفّرة أثناء التخزين وتُستخدم لاستدعاء نماذج LLM الخارجية.","tab.routing.title":"التوجيه","tab.routing.sub":"كيف يختار model='auto' النموذج المناسب لكل طلب.","tab.analytics.title":"التحليلات","tab.analytics.sub":"الإنفاق والزمن والسجل المحلي للطلبات فقط.","tab.keys.title":"مفاتيح API","tab.keys.sub":"رموز مصادقة العملاء في مساحة Lite هذه." },
   ko: { "auth.tagline":"오픈 소스. 단일 테넌트.","auth.welcome":"다시 오신 것을 환영합니다","auth.subtitle":"첫 실행 시 서버 로그에 출력된 sk-orca-* 키를 붙여넣으세요. 이 브라우저의 localStorage에만 저장됩니다.","auth.api_key":"API 키","auth.continue":"계속","nav.search":"검색","nav.overview":"개요","nav.providers":"공급자","nav.routing":"경로 지정","nav.analytics":"분석","nav.api_keys":"API 키","nav.help_docs":"도움말 및 문서","nav.sign_out":"로그아웃","status.connected":"연결됨","status.disconnected":"연결 끊김","auth.checking":"확인 중…","auth.welcome_aboard":"환영합니다.","auth.key_invalid":"키가 올바르지 않습니다. sk-orca- 접두사를 확인하세요…","tab.overview.title":"개요","tab.overview.sub":"싱글 테넌트 LLM 라우터를 한눈에 확인하세요.","tab.providers.title":"공급자 키","tab.providers.sub":"BYOK — 저장 시 암호화되며 상위 LLM 호출에 사용됩니다.","tab.routing.title":"라우팅","tab.routing.sub":"model='auto'가 요청별로 적절한 모델을 고르는 방식입니다.","tab.analytics.title":"분석","tab.analytics.sub":"로컬 전용 비용, 지연 시간, 요청 기록.","tab.keys.title":"API 키","tab.keys.sub":"Lite 워크스페이스에서 클라이언트를 인증하는 토큰." },
 };
+// Provider ids must match catalog provider ids (packages/litellm_adapter/catalog.py
+// `_PROVIDER_BY_LITELLM_KEY`) and Settings env-key fields (app/config.py
+// `_PROVIDERS_FROM_ENV`). Labels follow the provider's own brand spelling so
+// operators recognize them without ambiguity — "xAI" with the lowercase x is
+// deliberate (Grok's parent company), distinct from "Groq" the inference
+// hardware company.
 const PROVIDERS_KNOWN = [
   { id: "openai",      label: "OpenAI"      },
   { id: "anthropic",   label: "Anthropic"   },
   { id: "google",      label: "Google"      },
+  { id: "xai",         label: "xAI (Grok)"  },
+  { id: "deepseek",    label: "DeepSeek"    },
   { id: "groq",        label: "Groq"        },
   { id: "together",    label: "Together"    },
   { id: "fireworks",   label: "Fireworks"   },
@@ -314,17 +322,25 @@ function renderProviders() {
     state.providers.forEach((p) => {
       const tr = document.createElement("tr");
       tr.className = "row-in";
+      // Env-sourced keys come from .env / process env, not the DB.
+      // Disabling delete avoids a confusing "no-op" — the row would
+      // come right back on next load because the env var is still set.
+      // Operator can still PUT a DB-sourced key for the same provider
+      // to override the env value (the runtime resolver picks DB > env).
+      const isEnv = p.source === "env";
+      const sourceBadge = isEnv
+        ? '<span class="pill muted" title="Set via .env / environment variable. Edit the env file and restart to change.">env</span>'
+        : '';
+      const removeBtn = isEnv
+        ? `<span class="muted small" title="Remove the OPENAI_API_KEY (or equivalent) from .env and restart the server.">env-managed</span>`
+        : `<button class="btn btn-ghost btn-sm btn-danger del-prov" data-prov="${escapeHtml(p.provider)}">Remove</button>`;
       tr.innerHTML = `
-        <td><strong>${escapeHtml(p.provider)}</strong></td>
+        <td><strong>${escapeHtml(p.provider)}</strong> ${sourceBadge}</td>
         <td><code>${escapeHtml(p.key_prefix || "—")}</code></td>
         <td>${p.is_enabled
           ? '<span class="pill ok">Enabled</span>'
           : '<span class="pill muted">Disabled</span>'}</td>
-        <td class="th-actions">
-          <button class="btn btn-ghost btn-sm btn-danger del-prov" data-prov="${escapeHtml(p.provider)}">
-            Remove
-          </button>
-        </td>
+        <td class="th-actions">${removeBtn}</td>
       `;
       tbody.appendChild(tr);
     });
@@ -354,12 +370,28 @@ function renderProviders() {
 function renderQuickAdd() {
   const wrap = $("#provider-quickadd");
   if (!wrap) return;
-  const configured = new Set(state.providers.map((p) => p.provider));
+  // DB-sourced providers are "fully configured" — disable the chip so
+  // the operator doesn't accidentally re-PUT and clobber a known-good key.
+  // ENV-sourced providers stay clickable: clicking pre-fills the form so
+  // the operator can write a DB row that overrides the env value (matches
+  // the runtime resolver's DB > env precedence).
+  const dbConfigured = new Set(
+    state.providers.filter((p) => p.source === "db").map((p) => p.provider)
+  );
+  const envConfigured = new Set(
+    state.providers.filter((p) => p.source === "env").map((p) => p.provider)
+  );
   wrap.innerHTML = `<span class="muted" style="font-size:12px;align-self:center;margin-right:4px">Quick-add:</span>` +
     PROVIDERS_KNOWN.map((p) => {
-      const isSet = configured.has(p.id);
-      return `<button class="chip ${isSet ? "configured" : ""}" data-prov-pick="${p.id}" ${isSet ? "disabled" : ""}>
-        ${escapeHtml(p.label)}
+      const isDb = dbConfigured.has(p.id);
+      const isEnv = envConfigured.has(p.id);
+      const cls = isDb ? "configured" : (isEnv ? "env-override" : "");
+      const disabled = isDb ? "disabled" : "";
+      const title = isEnv
+        ? `${p.label} is set via .env. Click to override with a custom key (writes a DB row that takes precedence).`
+        : "";
+      return `<button class="chip ${cls}" data-prov-pick="${p.id}" ${disabled} ${title ? `title="${escapeHtml(title)}"` : ""}>
+        ${escapeHtml(p.label)}${isEnv ? " <span class=\"small muted\">(env, override)</span>" : ""}
       </button>`;
     }).join("");
   $$("[data-prov-pick]").forEach((b) =>

--- a/design/index.html
+++ b/design/index.html
@@ -321,6 +321,8 @@
                   <option value="openai">OpenAI</option>
                   <option value="anthropic">Anthropic</option>
                   <option value="google">Google</option>
+                  <option value="xai">xAI (Grok)</option>
+                  <option value="deepseek">DeepSeek</option>
                   <option value="groq">Groq</option>
                   <option value="together">Together</option>
                   <option value="fireworks">Fireworks</option>

--- a/tests/integration/test_provider_keys.py
+++ b/tests/integration/test_provider_keys.py
@@ -353,3 +353,91 @@ async def test_delete_unknown_provider_returns_404(authed_client):
     path doesn't apply here)."""
     r = await authed_client.delete("/v1/providers/totally-fake-provider")
     assert r.status_code == 404
+
+
+async def test_disabled_db_row_does_not_suppress_env_entry(
+    authed_client, tmp_sqlite_url, monkeypatch,
+):
+    """Codex-flagged: the runtime resolver (`router_cache.build_deployments`)
+    only honors a DB row when both `is_enabled=True` AND the ciphertext
+    decrypts. If a row is disabled (or corrupt after a
+    CREDENTIAL_ENCRYPTION_KEY rotation), runtime falls back to env.
+    The list endpoint MUST NOT suppress the env entry on the basis of a
+    non-usable DB row — otherwise the dashboard would label the source
+    as 'db' while the env key is what's actually authenticating requests."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-actually-active")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    # Plant a DISABLED DB row directly via ORM. PUT route always sets
+    # is_enabled=True, so we go around it.
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.auth.encryption import encrypt_credential
+    from packages.db.engine import build_engine
+    from packages.db.models.provider_key import ProviderKey
+
+    engine = build_engine(tmp_sqlite_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as s:
+        s.add(ProviderKey(
+            provider="openai",
+            encrypted_key=encrypt_credential("sk-db-disabled-shouldnt-be-used"),
+            key_prefix="sk-db-dis...used",
+            is_enabled=False,   # ← disabled, runtime will skip
+        ))
+        await s.commit()
+    await engine.dispose()
+
+    r = await authed_client.get("/v1/providers")
+    rows = [p for p in r.json()["providers"] if p["provider"] == "openai"]
+    sources = sorted(p["source"] for p in rows)
+
+    # The disabled DB row IS shown (operators need to see + fix it),
+    # AND the env entry is ALSO shown so the operator sees what's
+    # actually serving traffic.
+    assert "env" in sources, (
+        f"env entry must remain visible when DB row is unusable, got: {rows}"
+    )
+    db_row = next(p for p in rows if p["source"] == "db")
+    env_row = next(p for p in rows if p["source"] == "env")
+    assert db_row["is_enabled"] is False
+    assert env_row["is_enabled"] is True
+
+
+async def test_undecryptable_db_row_does_not_suppress_env_entry(
+    authed_client, tmp_sqlite_url, monkeypatch,
+):
+    """Same contract as above but for the post-key-rotation case: a row
+    whose ciphertext can't decrypt under the current
+    CREDENTIAL_ENCRYPTION_KEY. The runtime treats this as 'no DB key
+    here' and falls back to env; the list endpoint must do the same."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-actually-active")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.provider_key import ProviderKey
+
+    engine = build_engine(tmp_sqlite_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as s:
+        # Insert garbage bytes — won't decrypt under any AES-GCM key.
+        s.add(ProviderKey(
+            provider="openai",
+            encrypted_key=b"this-is-not-a-valid-aesgcm-ciphertext",
+            key_prefix="sk-broken...xxxx",
+            is_enabled=True,   # enabled, but decrypt will fail
+        ))
+        await s.commit()
+    await engine.dispose()
+
+    r = await authed_client.get("/v1/providers")
+    rows = [p for p in r.json()["providers"] if p["provider"] == "openai"]
+    sources = sorted(p["source"] for p in rows)
+
+    assert "env" in sources, (
+        f"env entry must remain visible when DB ciphertext is corrupt, got: {rows}"
+    )

--- a/tests/integration/test_provider_keys.py
+++ b/tests/integration/test_provider_keys.py
@@ -4,8 +4,14 @@ import pytest
 
 
 @pytest.fixture
-async def authed_client(tmp_sqlite_url, monkeypatch):
-    """A booted lite app + a TestClient with the seeded API key in its headers."""
+async def authed_client(tmp_sqlite_url, monkeypatch, isolated_env):
+    """A booted lite app + a TestClient with the seeded API key in its headers.
+
+    `isolated_env` strips developer-set provider keys from the env so the
+    "list returns empty" assertion isn't drowned out by .env-sourced rows
+    (the list endpoint surfaces both DB and env-configured providers as
+    of the env-key-visibility fix).
+    """
     monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
 
     from app import config as cfg
@@ -85,6 +91,97 @@ async def test_delete_provider_key(authed_client):
     assert listing.json()["providers"] == []
 
 
+async def test_delete_is_hard_delete_no_ghost_rows_left_in_db(
+    authed_client, tmp_sqlite_url,
+):
+    """Pre-PR symptom: DELETE was a soft-delete (`is_deleted=1`). The
+    next PUT for the same provider would query `is_deleted=0`, miss
+    the tombstone, and INSERT a new row. After N PUT/DELETE cycles
+    the table held N tombstones for ONE provider — single-tenant
+    invariant ('1 row per provider') silently violated.
+
+    Hard-delete fixes the leak: the table never grows past the actual
+    in-use rows."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.provider_key import ProviderKey
+
+    # Five PUT/DELETE cycles. Pre-fix this would leave 5 tombstones.
+    for i in range(5):
+        await authed_client.put(
+            "/v1/providers/openai",
+            json={"api_key": f"sk-cycle-{i}"},
+        )
+        await authed_client.delete("/v1/providers/openai")
+
+    engine = build_engine(tmp_sqlite_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as s:
+        all_rows = (await s.execute(select(ProviderKey))).scalars().all()
+        openai_rows = [r for r in all_rows if r.provider == "openai"]
+    await engine.dispose()
+
+    assert len(openai_rows) == 0, (
+        f"hard-delete must leave zero rows for the provider, got: "
+        f"{[(r.provider, r.is_deleted) for r in openai_rows]}"
+    )
+
+
+async def test_put_after_legacy_soft_delete_ghost_wipes_it(
+    authed_client, tmp_sqlite_url,
+):
+    """Migration aid: dev DBs created before this PR may carry
+    `is_deleted=1` ghost rows. The PUT path must wipe them
+    opportunistically — otherwise the table accumulates ghost rows
+    on every set-key from the dashboard until the operator manually
+    DELETEs from SQL."""
+    from sqlalchemy import select
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.provider_key import ProviderKey
+
+    # Plant a legacy soft-deleted ghost row directly via ORM (simulates
+    # what an old dev DB looks like).
+    engine = build_engine(tmp_sqlite_url)
+    Session = async_sessionmaker(engine, expire_on_commit=False)
+    async with Session() as s:
+        s.add(ProviderKey(
+            provider="openai",
+            encrypted_key=b"old-encrypted-blob",
+            key_prefix="sk-ghost...old",
+            is_enabled=False,
+            is_deleted=1,
+        ))
+        await s.commit()
+
+    # Operator sets a new key from the dashboard.
+    r = await authed_client.put(
+        "/v1/providers/openai",
+        json={"api_key": "sk-new-key-after-ghost"},
+    )
+    assert r.status_code == 200
+
+    # Ghost row should be gone — table holds exactly one openai row,
+    # the freshly-set one.
+    async with Session() as s:
+        rows = (
+            await s.execute(
+                select(ProviderKey).where(ProviderKey.provider == "openai")
+            )
+        ).scalars().all()
+    await engine.dispose()
+
+    assert len(rows) == 1, (
+        f"PUT must wipe legacy ghost rows, got {len(rows)} rows: "
+        f"{[(r.key_prefix, r.is_deleted) for r in rows]}"
+    )
+    assert rows[0].is_deleted == 0
+    assert rows[0].key_prefix.startswith("sk-new-")
+
+
 async def test_overwrite_existing_key(authed_client):
     await authed_client.put("/v1/providers/openai", json={"api_key": "sk-old"})
     r = await authed_client.put("/v1/providers/openai", json={"api_key": "sk-new"})
@@ -116,3 +213,143 @@ async def test_provider_key_is_encrypted_at_rest(authed_client, tmp_sqlite_url):
     assert b"sk-secret-99" not in blob
     assert decrypt_credential(blob) == "sk-secret-99"
     await engine.dispose()
+
+
+# ── env-sourced provider visibility ───────────────────────────────────
+
+
+async def test_list_surfaces_env_provider_keys_with_source_marker(
+    authed_client, monkeypatch,
+):
+    """Operator who configured `OPENAI_API_KEY` in `.env` (the documented
+    install path) must see "openai" in the dashboard providers list. Before
+    this fix, the page showed empty even though chats were succeeding via
+    the env key — confusing as hell."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-openai-12345")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    r = await authed_client.get("/v1/providers")
+    assert r.status_code == 200
+    rows = r.json()["providers"]
+    openai_row = next((p for p in rows if p["provider"] == "openai"), None)
+    assert openai_row is not None, (
+        f"env-set OPENAI_API_KEY must appear in the list, got: {rows}"
+    )
+    assert openai_row["source"] == "env"
+    assert openai_row["is_enabled"] is True
+    # Plaintext must NOT round-trip through the response
+    assert "sk-env-openai-12345" not in r.text
+    # Mask preserves first/last hint so operator can identify which key
+    assert openai_row["key_prefix"].startswith("sk-env-o")
+
+
+async def test_db_key_takes_precedence_over_env_in_listing(
+    authed_client, monkeypatch,
+):
+    """When the same provider has both an env var AND a DB row, the list
+    should show the DB version (matches runtime resolver precedence at
+    router_cache.py:58 `db_provider_keys.get(provider) or env_keys.get`).
+    Showing both would suggest two simultaneous configurations exist; in
+    reality only the DB one is used."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-version")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    await authed_client.put(
+        "/v1/providers/openai",
+        json={"api_key": "sk-db-version-overrides"},
+    )
+
+    r = await authed_client.get("/v1/providers")
+    rows = r.json()["providers"]
+    openai_rows = [p for p in rows if p["provider"] == "openai"]
+    assert len(openai_rows) == 1, (
+        f"db row must override env row, got duplicates: {openai_rows}"
+    )
+    assert openai_rows[0]["source"] == "db"
+    assert openai_rows[0]["key_prefix"].startswith("sk-db-ve")
+
+
+async def test_env_only_listing_when_no_db_rows(
+    authed_client, monkeypatch,
+):
+    """Pure-env install (no dashboard PUTs ever): list still surfaces all
+    configured providers."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env-2")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    r = await authed_client.get("/v1/providers")
+    providers = {p["provider"]: p for p in r.json()["providers"]}
+    assert "openai" in providers and providers["openai"]["source"] == "env"
+    assert "anthropic" in providers and providers["anthropic"]["source"] == "env"
+
+
+async def test_delete_db_row_falls_back_to_env_value(
+    authed_client, monkeypatch,
+):
+    """Operator workflow: env has a key, operator overrides via dashboard
+    PUT, then later wants the env value back — DELETE the DB row and
+    the listing should re-emerge with the env entry. Demonstrates the
+    DB > env precedence layering works in both directions."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-baseline")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    # Step 1: env-only listing
+    r = await authed_client.get("/v1/providers")
+    rows = [p for p in r.json()["providers"] if p["provider"] == "openai"]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "env"
+    env_prefix = rows[0]["key_prefix"]
+
+    # Step 2: operator PUTs a custom key — DB now wins
+    await authed_client.put(
+        "/v1/providers/openai",
+        json={"api_key": "sk-db-custom-overrides-env"},
+    )
+    r = await authed_client.get("/v1/providers")
+    rows = [p for p in r.json()["providers"] if p["provider"] == "openai"]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "db"
+    assert rows[0]["key_prefix"] != env_prefix
+
+    # Step 3: operator deletes the DB row — env value re-emerges
+    r = await authed_client.delete("/v1/providers/openai")
+    assert r.status_code == 204
+
+    r = await authed_client.get("/v1/providers")
+    rows = [p for p in r.json()["providers"] if p["provider"] == "openai"]
+    assert len(rows) == 1
+    assert rows[0]["source"] == "env"
+    assert rows[0]["key_prefix"] == env_prefix
+
+
+async def test_delete_env_only_provider_returns_409_with_guidance(
+    authed_client, monkeypatch,
+):
+    """Trying to DELETE a provider that exists ONLY in env (no DB row)
+    must surface a 409 with actionable guidance — not a silent 204
+    that misleads the operator into thinking the key is gone (the
+    next page load would show it back, because env didn't change)."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env-only")
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    r = await authed_client.delete("/v1/providers/openai")
+    assert r.status_code == 409
+    # The app wraps HTTPException detail in `{error: {message, type}}` —
+    # see middleware/error envelope.
+    body = r.json()
+    msg = body.get("error", {}).get("message") or body.get("detail") or ""
+    assert "OPENAI_API_KEY" in msg, f"missing env var name in: {msg!r}"
+    assert ".env" in msg, f"missing .env hint in: {msg!r}"
+
+
+async def test_delete_unknown_provider_returns_404(authed_client):
+    """No DB row, no env entry → straight 404 (not 409, the env-guidance
+    path doesn't apply here)."""
+    r = await authed_client.delete("/v1/providers/totally-fake-provider")
+    assert r.status_code == 404

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -41,6 +41,47 @@ def test_settings_env_provider_keys_returns_dict(isolated_env, monkeypatch):
     assert keys == {"openai": "sk-1", "groq": "sk-2"}
 
 
+def test_settings_reads_extended_provider_keys(isolated_env, monkeypatch):
+    """xAI / DeepSeek were missing from Settings before, leaving their
+    catalog models unroutable. Regression test: each var must wire to
+    the matching field AND surface via env_provider_keys() with the
+    catalog provider id (NOT the env var name — `xai` not `XAI`).
+
+    The xAI test in particular doubles as a guard against the famous
+    'grok vs groq' typo: `XAI_API_KEY` must produce provider id `xai`,
+    so the runtime can't route grok-* models to a Groq endpoint."""
+    monkeypatch.setenv("XAI_API_KEY", "xai-test-grok")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-ds-test")
+    from app.config import Settings
+
+    s = Settings(_env_file=None)
+    assert s.xai_api_key == "xai-test-grok"
+    assert s.deepseek_api_key == "sk-ds-test"
+
+    keys = s.env_provider_keys()
+    assert keys == {
+        "xai": "xai-test-grok",
+        "deepseek": "sk-ds-test",
+    }
+    assert "xai" in keys, "XAI_API_KEY must surface as 'xai' not 'XAI' or 'grok'"
+    assert "groq" not in keys, "XAI_API_KEY must NOT alias to groq (different company)"
+
+
+def test_settings_xai_and_groq_are_separate_providers(isolated_env, monkeypatch):
+    """Belt-and-suspenders for the grok/groq footgun: setting both env
+    vars must populate two distinct provider entries in env_provider_keys.
+    A previous bug surfaced as operators PUTting xai keys into the groq
+    provider via the dashboard (groq was the only chip available)."""
+    monkeypatch.setenv("XAI_API_KEY", "xai-grok-key")
+    monkeypatch.setenv("GROQ_API_KEY", "gsk_groq-key")
+    from app.config import Settings
+
+    s = Settings(_env_file=None)
+    keys = s.env_provider_keys()
+    assert keys == {"xai": "xai-grok-key", "groq": "gsk_groq-key"}
+    assert s.xai_api_key != s.groq_api_key
+
+
 def test_settings_database_url_override(isolated_env, monkeypatch):
     """DATABASE_URL env var overrides the SQLite default."""
     monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://u:p@h/db")


### PR DESCRIPTION
## Three related Providers-page fixes

### 1. Env-configured keys now visible (the original symptom)

Operators who set `OPENAI_API_KEY` / `ANTHROPIC_API_KEY` etc in `.env` saw an empty Providers list and assumed nothing was wired up — even though chats were succeeding via those keys. `GET /v1/providers` now merges DB rows + env entries, each tagged `source: "db"` or `source: "env"`.

Dashboard renders an env badge and replaces the Remove button with an "env-managed" hint (you must edit `.env` and restart to remove an env key; mutating the row from the API would no-op). Quick-add chip stays clickable for env rows — clicking pre-fills the form so the operator can write a DB row that overrides the env value (matches the runtime resolver's DB > env precedence in `router_cache.py:58`).

### 2. Hard-delete + ghost-row wipe (latent data bug)

DELETE used to be a soft-delete with `is_deleted=1`. The next PUT queried `is_deleted=0`, missed the tombstone, and INSERT'd a fresh row. PUT/DELETE cycles accumulated tombstones forever, silently violating the single-tenant "1 key per provider" invariant.

Switched to hard-delete. PUT also opportunistically wipes legacy ghost rows for the same provider so existing dev DBs stay clean on first PUT after the migration. Dropped the `label` field from the PUT body + GET response (Lite has no use case for multiple labels per provider; the field just suggested the contrary).

DELETE on an env-only provider returns **409** with a message naming the exact env var to remove from `.env` — so the dashboard can't appear to "delete" a key that's actually still active.

### 3. xAI + DeepSeek added to env-supported providers

Catalog has 33 grok-* models under `provider="xai"` and ~10 deepseek-* models under `provider="deepseek"`, but `Settings._PROVIDERS_FROM_ENV` and the dashboard's `PROVIDERS_KNOWN` chip list both stopped at the original 6 (openai/anthropic/google/groq/together/fireworks). Result: those entire model families showed "NO KEY" in the Quality table with no obvious way to configure them.

The famous footgun: operators saw "Grok" rows blank, hunted for a chip in the quick-add, found "Groq" (a different company — Elon's xAI vs Jonathan Ross's inference-hardware Groq), and PUT their xAI key (`xai-...`) into the `groq` provider. The xai key then tried to authenticate against `api.groq.com` → 401, but the dashboard cheerfully showed "Enabled" because the row was there.

Added `xAI (Grok)` + `DeepSeek` chips and `<select>` options. Both wire through to `Settings.xai_api_key` / `Settings.deepseek_api_key`.

## Test plan

- [x] `pytest` 295 pass (293 baseline + 2 new in `test_config.py` covering env-key field wiring + a regression test for the grok/groq alias confusion)
- [x] `node --check design/app.js`
- [x] Real-server E2E:
  - env-only listing shows openai/anthropic/google with `source: "env"`
  - PUT openai → `source: "db"`, env value hidden
  - 5 cycles of PUT+DELETE leaves zero rows in the DB (no ghost accumulation)
  - DELETE DB row → env value re-emerges automatically
  - DELETE env-only → 409 with `OPENAI_API_KEY` + `.env` in the error message
  - Legacy ghost row planted directly via SQL gets wiped on next PUT for the same provider

## Provider list as of this PR

| Provider | Source |
|---|---|
| OpenAI | original |
| Anthropic | original |
| Google | original |
| **xAI (Grok)** | **new** |
| **DeepSeek** | **new** |
| Groq | original |
| Together | original |
| Fireworks | original |
| OrcaRouter (hosted) | original |

🤖 Generated with [Claude Code](https://claude.com/claude-code)