### PR TITLE
Keep hyphenated AA static keys for dotted hosted catalog ids

### DIFF
--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -643,8 +643,18 @@ def _apply_static_baseline(qi: QualityIndex, catalog_ids: set[str]) -> QualityIn
     if not STATIC_QUALITY and not STATIC_TPS and not STATIC_TTFT:
         return qi
 
+    # Accept both the literal catalog_id AND its dot↔hyphen variant. AA
+    # publishes hyphenated keys (`claude-opus-4-7`) but our catalog carries
+    # the O2-native dotted form (`claude-opus-4.7`) via HOSTED_CATALOG_SUPPLEMENT
+    # when LiteLLM doesn't ship the model. A naive `if k in catalog_ids` filter
+    # would drop the hyphenated baseline before `_lookup_score`'s dot→hyphen
+    # fallback could rescue it, leaving hosted Claude/Qwen unscored under
+    # quality / balanced / fastest strategies.
+    accept = set(catalog_ids)
+    accept.update(cid.replace(".", "-") for cid in catalog_ids if "." in cid)
+
     def _merge(static: dict[str, float], live: dict[str, float]) -> dict[str, float]:
-        filtered = {k: v for k, v in static.items() if k in catalog_ids}
+        filtered = {k: v for k, v in static.items() if k in accept}
         return {**filtered, **live}  # live (AA) wins on overlap
 
     merged_quality = _merge(STATIC_QUALITY, qi.scores)

--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -643,19 +643,33 @@ def _apply_static_baseline(qi: QualityIndex, catalog_ids: set[str]) -> QualityIn
     if not STATIC_QUALITY and not STATIC_TPS and not STATIC_TTFT:
         return qi
 
-    # Accept both the literal catalog_id AND its dot↔hyphen variant. AA
-    # publishes hyphenated keys (`claude-opus-4-7`) but our catalog carries
+    # AA publishes hyphenated keys (`claude-opus-4-7`) but our catalog carries
     # the O2-native dotted form (`claude-opus-4.7`) via HOSTED_CATALOG_SUPPLEMENT
-    # when LiteLLM doesn't ship the model. A naive `if k in catalog_ids` filter
-    # would drop the hyphenated baseline before `_lookup_score`'s dot→hyphen
-    # fallback could rescue it, leaving hosted Claude/Qwen unscored under
-    # quality / balanced / fastest strategies.
-    accept = set(catalog_ids)
-    accept.update(cid.replace(".", "-") for cid in catalog_ids if "." in cid)
+    # when LiteLLM doesn't ship the model. Build a reverse index so we can
+    # rekey hyphenated static rows to their dotted catalog id — keeping the
+    # QualityIndex contract that scores are keyed by catalog id, not AA's
+    # canonical name. (A pure dot→hyphen fallback at read time only saves
+    # callers that go through `_lookup_score`; direct `scores.get(m.id)`
+    # consumers like /v1/quality would still see the model as unscored.)
+    hyphen_to_dotted = {
+        cid.replace(".", "-"): cid
+        for cid in catalog_ids
+        if "." in cid
+    }
 
     def _merge(static: dict[str, float], live: dict[str, float]) -> dict[str, float]:
-        filtered = {k: v for k, v in static.items() if k in accept}
-        return {**filtered, **live}  # live (AA) wins on overlap
+        out: dict[str, float] = {}
+        for k, v in static.items():
+            if k in catalog_ids:
+                out[k] = v
+            # Also write under the dotted catalog id when the static row is
+            # the hyphenated AA form. Both forms get the score when both are
+            # deployable (LiteLLM ships hyphen + supplement adds dotted).
+            dotted = hyphen_to_dotted.get(k)
+            if dotted is not None:
+                out[dotted] = v
+        out.update(live)  # live (AA) wins on overlap
+        return out
 
     merged_quality = _merge(STATIC_QUALITY, qi.scores)
     merged_tps     = _merge(STATIC_TPS,     qi.tps_scores)

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -464,31 +464,35 @@ async def test_get_quality_index_returns_missing_key_when_unconfigured(monkeypat
     assert idx.scores  # non-empty due to static baseline
 
 
-async def test_static_baseline_keeps_hyphenated_keys_for_dotted_catalog_ids(monkeypatch):
+async def test_static_baseline_rekeys_hyphenated_to_dotted_catalog_id(monkeypatch):
     """When the catalog carries an O2-native dotted ID (claude-opus-4.7) but
     the static table is keyed under AA's hyphenated form (claude-opus-4-7),
-    the catalog_ids filter must accept both — otherwise the hyphenated baseline
-    is stripped and `_lookup_score`'s dot→hyphen fallback finds nothing,
-    leaving hosted Claude/Qwen unscored under quality / balanced / fastest.
+    the merge must rekey the row to the dotted catalog id — not just keep
+    the hyphenated form. QualityIndex callers that read via direct
+    `scores.get(m.id)` (e.g. /v1/quality dashboard route) need to see the
+    baseline under the catalog id, not only via `_lookup_score`'s
+    dot→hyphen fallback.
     """
     from app import config as cfg
-    from app.auto_routing import _lookup_score
     from packages.litellm_adapter import quality_index
 
     quality_index.reset_cache()
     monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "")
     cfg.get_settings.cache_clear()
 
-    # Catalog has the dotted form only (as it would when the model comes
-    # exclusively from HOSTED_CATALOG_SUPPLEMENT, not LiteLLM model_cost).
+    # Catalog has the dotted form only (as when the model comes exclusively
+    # from HOSTED_CATALOG_SUPPLEMENT, not LiteLLM model_cost).
     idx = await quality_index.get_quality_index(catalog_ids={"claude-opus-4.7"})
 
-    # The hyphenated static key survives the filter, and a dot→hyphen lookup
-    # against the deployment id resolves it.
-    assert _lookup_score(idx.scores, "claude-opus-4.7") is not None, (
-        "Hosted Claude must have a baseline score even when only the dotted "
-        "deployment ID is in catalog_ids"
+    # Score keyed under the dotted catalog id directly (per QualityIndex
+    # contract). No fallback helper needed.
+    assert idx.scores.get("claude-opus-4.7") is not None, (
+        "Hosted Claude must be keyed under the dotted catalog id so direct "
+        "`scores.get(m.id)` consumers (dashboard /v1/quality) see it"
     )
+    # The hyphenated AA form is NOT a catalog id when only the dotted form
+    # was passed — it must not leak into the result.
+    assert "claude-opus-4-7" not in idx.scores
 
 
 async def test_get_quality_index_fetches_and_caches(monkeypatch):

--- a/tests/unit/test_quality_index.py
+++ b/tests/unit/test_quality_index.py
@@ -464,6 +464,33 @@ async def test_get_quality_index_returns_missing_key_when_unconfigured(monkeypat
     assert idx.scores  # non-empty due to static baseline
 
 
+async def test_static_baseline_keeps_hyphenated_keys_for_dotted_catalog_ids(monkeypatch):
+    """When the catalog carries an O2-native dotted ID (claude-opus-4.7) but
+    the static table is keyed under AA's hyphenated form (claude-opus-4-7),
+    the catalog_ids filter must accept both — otherwise the hyphenated baseline
+    is stripped and `_lookup_score`'s dot→hyphen fallback finds nothing,
+    leaving hosted Claude/Qwen unscored under quality / balanced / fastest.
+    """
+    from app import config as cfg
+    from app.auto_routing import _lookup_score
+    from packages.litellm_adapter import quality_index
+
+    quality_index.reset_cache()
+    monkeypatch.setenv("ARTIFICIAL_ANALYSIS_API_KEY", "")
+    cfg.get_settings.cache_clear()
+
+    # Catalog has the dotted form only (as it would when the model comes
+    # exclusively from HOSTED_CATALOG_SUPPLEMENT, not LiteLLM model_cost).
+    idx = await quality_index.get_quality_index(catalog_ids={"claude-opus-4.7"})
+
+    # The hyphenated static key survives the filter, and a dot→hyphen lookup
+    # against the deployment id resolves it.
+    assert _lookup_score(idx.scores, "claude-opus-4.7") is not None, (
+        "Hosted Claude must have a baseline score even when only the dotted "
+        "deployment ID is in catalog_ids"
+    )
+
+
 async def test_get_quality_index_fetches_and_caches(monkeypatch):
     """Real fetch + cache flow: first call drives the AA-shaped HTTP mock
     through the real `_fetch_remote` parser; second call within TTL


### PR DESCRIPTION
## Summary

Follow-up to #30. Codex review there caught a real P2 bug in `_apply_static_baseline._merge` that left hosted Claude / Qwen 3.5 / 3.6 unscored under `quality` / `balanced` / `fastest` strategies.

**The bug:**

- `HOSTED_MODELS` has `claude-opus-4.7` (dotted, registered via `HOSTED_CATALOG_SUPPLEMENT` because LiteLLM doesn't ship that ID)
- `STATIC_QUALITY` has `claude-opus-4-7: 57.3` (hyphenated, AA's slug convention)
- `_merge()` filters `static.items()` with `if k in catalog_ids` — hyphenated key fails because catalog_ids only has the dotted form, so the baseline is stripped
- Later `_lookup_score("claude-opus-4.7")` falls back to `claude-opus-4-7` per the dot→hyphen rule, but that key is gone

Net effect: hosted Claude got `quality_score = None`, dropped out of `balanced` strict-coverage, and `quality` strategy treated it as unscored (sorted to bottom). Auto-routing silently underweighted O2-only models.

**The fix:**

Expand the accept set to include both forms when a catalog id is dotted:
```python
accept = set(catalog_ids)
accept.update(cid.replace(".", "-") for cid in catalog_ids if "." in cid)
filtered = {k: v for k, v in static.items() if k in accept}
```

Read-time lookup is unchanged — `_lookup_score`'s existing dot→hyphen fallback handles the merged dict's mixed-form keys.

## Test plan

- [x] New regression test `test_static_baseline_keeps_hyphenated_keys_for_dotted_catalog_ids` covers the exact scenario: `catalog_ids={"claude-opus-4.7"}` + no AA key + assert `_lookup_score` returns non-None
- [x] All 189 unit tests green (`pytest tests/unit/`)
- [ ] Cold-start quality verification: route a `model="auto"` workspace with O2 key only and confirm hosted Claude variants show up at expected quality ranks (not bottom of unscored bucket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)