### PR TITLE
Fix pre-existing ruff I001 in app/routes/providers.py

### DIFF
--- a/app/routes/providers.py
+++ b/app/routes/providers.py
@@ -38,7 +38,8 @@ from __future__ import annotations
 
 from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
-from sqlalchemy import delete as sql_delete, select
+from sqlalchemy import delete as sql_delete
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import router_cache


### PR DESCRIPTION
## Summary

CI is red on main with ruff I001 (introduced by #29 — `from sqlalchemy import delete as sql_delete, select` mixes aliased and non-aliased on one line). Auto-fixed via `ruff check --fix`.

## Test plan

- [x] `ruff check` clean locally
- [x] All 189 unit tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)