### PR TITLE
Fix ruff I001 in quality_index inline import

### DIFF
--- a/packages/litellm_adapter/quality_index.py
+++ b/packages/litellm_adapter/quality_index.py
@@ -636,7 +636,9 @@ def _apply_static_baseline(qi: QualityIndex, catalog_ids: set[str]) -> QualityIn
     """
     try:
         from packages.litellm_adapter.quality_scores_static import (
-            STATIC_QUALITY, STATIC_TPS, STATIC_TTFT,
+            STATIC_QUALITY,
+            STATIC_TPS,
+            STATIC_TTFT,
         )
     except ImportError:
         return qi


### PR DESCRIPTION
## Summary

Main CI was red on ruff I001 — the inline import `from packages.litellm_adapter.quality_scores_static import (STATIC_QUALITY, STATIC_TTFT, STATIC_TPS,)` inside `_apply_static_baseline` had three names on one wrapped line, ruff wants one per line. Auto-fixed via `ruff check --fix`.

## Test plan

- [x] `ruff check .` clean locally
- [x] All 189 unit tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)