### PR TITLE
Docker hygiene: add .dockerignore + builder native build deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,55 @@
+# VCS
+.git
+.gitignore
+.gitattributes
+
+# Python build / cache
+__pycache__/
+*.py[cod]
+*$py.class
+*.egg-info/
+*.egg
+build/
+dist/
+.pytest_cache/
+.ruff_cache/
+.coverage
+.coverage.*
+htmlcov/
+
+# Virtual envs
+.venv/
+venv/
+env/
+
+# Editor / OS
+.vscode/
+.idea/
+*.swp
+.DS_Store
+Thumbs.db
+
+# Local dev artifacts
+.env
+.env.local
+.env.*.local
+*.db
+*.db-journal
+*.sqlite
+*.sqlite-journal
+
+# Tests / docs / dev-only
+tests/
+docs/
+*.md
+!README.md
+
+# Claude Code / agent caches
+.claude/
+.context/
+.gstack/
+
+# Docker / compose
+docker-compose*.yml
+Dockerfile*
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,16 @@
 # ── Build stage ────────────────────────────────────────
 FROM python:3.12-slim AS builder
 
+# Build deps for any source-built wheels (cryptography / bcrypt fall back to
+# source on platforms without manylinux wheels). Currently all listed deps
+# ship wheels for linux/amd64 + arm64, but adding these costs ~80MB in the
+# builder layer (discarded in the runtime stage) and prevents silent breaks
+# the next time we add a native dep.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        gcc libffi-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 COPY pyproject.toml .
 RUN mkdir -p app packages \


### PR DESCRIPTION
## Summary

Two small Docker improvements, no behavior change:

**1. New `.dockerignore` (55 lines)**
Without it, every `COPY` was slurping `.git/`, `__pycache__/`, `.pytest_cache/`, agent caches (`.claude/`, `.context/`, `.gstack/`), local SQLite files, and `.env`. The `.env` exclusion is the security-relevant one — `docker-compose.yml` already injects it at runtime via `env_file`, so the file never needs to be inside the image. Excluded categories:

- VCS metadata (`.git/`, `.gitignore`, `.gitattributes`)
- Python build / cache (`__pycache__/`, `*.pyc`, `*.egg-info/`, `.pytest_cache/`, `.ruff_cache/`, `.coverage*`)
- Virtualenvs (`.venv/`, `venv/`, `env/`)
- Editor / OS junk (`.vscode/`, `.idea/`, `.DS_Store`, `*.swp`)
- Local dev artifacts (`.env*`, `*.db`, `*.sqlite`)
- Tests / docs (`tests/`, `docs/`, `*.md` except `README.md`)
- Agent caches (`.claude/`, `.context/`, `.gstack/`)
- Docker meta (`Dockerfile*`, `docker-compose*`, `.dockerignore` itself)

**2. Builder stage native build deps**

Add `gcc libffi-dev libssl-dev` to the builder stage. All current deps (cryptography, bcrypt, orjson, aiosqlite) ship manylinux wheels for amd64 + arm64, so today this is a **no-op for actual builds**. It's defensive: the next time someone adds a native dep that lacks a wheel for the target arch, pip falls back to source build and would otherwise hard-fail at `gcc not found`. The packages live in the discarded builder stage, so the runtime image size is unchanged.

## Out of scope

- The setuptools "empty `app/` + `packages/` mkdir" trick for layer caching still works under setuptools >=69. Defer until CI flags it.
- Compose `platforms` lock — kept flexible per discussion (lock at build command instead, e.g. `docker buildx build --platform linux/amd64`).

## Test plan

- [ ] `docker build .` succeeds locally on Apple Silicon (arm64) and produces a working image
- [ ] `docker compose up` runs as before, `.env` injected at runtime via env_file
- [ ] Image inspect: `.git/`, `tests/`, `__pycache__/`, `.env` not present at any path inside the image

🤖 Generated with [Claude Code](https://claude.com/claude-code)