### PR TITLE
Simplify Railway deploy: drop the Volume step

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ for chunk in client.chat.completions.create(
 | Platform | Setup |
 |---|---|
 | [Fly.io](#flyio) | `fly launch --no-deploy` → `fly secrets set ...` → `fly deploy` (`fly.toml` in repo) |
-| [Railway](#railway) | Connect repo, add `/data` volume, paste env vars (`railway.json` in repo) |
+| [Railway](#railway) | Connect repo, paste env vars (`railway.json` in repo) |
 | [Render](#render--bare-docker) | Connect repo (auto-detects Dockerfile), add `/data` Disk, paste env vars |
 | [Bare Docker](#render--bare-docker) | `cp .env.example .env`, append two secrets, `docker compose up -d` |
 
@@ -234,19 +234,14 @@ when idle and auto-starts on the next request, controlling cost.
 Repo includes `railway.json` with Dockerfile build + healthcheck pre-configured.
 
 1. **Connect repo**: New Project → Deploy from GitHub repo → pick this repo
-2. **Create a volume**: open the Command Palette (`⌘K`) and select "Create Volume"
-   (or right-click the project canvas → New → Volume). When prompted, attach it
-   to the service and set the **mount path** to `/data`. Default size depends on
-   plan (Hobby: 5 GB) — 1 GB is plenty for SQLite.
-3. **Set env vars** in Service → Variables:
-   - `DATABASE_URL=sqlite+aiosqlite:////data/orca.db` (note the four slashes)
+2. **Set env vars** in Service → Variables:
    - `CREDENTIAL_ENCRYPTION_KEY=` (paste output of `openssl rand -hex 32`)
    - `API_KEY_PEPPER=` (paste another `openssl rand -hex 32`)
-   - Optional: `OPENAI_API_KEY=sk-...` or any other provider key — these can
-     also be added later from the dashboard at `/`
-4. **Generate a public domain**: Service → Settings → Networking →
+   - Optional: `OPENAI_API_KEY=sk-...` or any other provider key — also
+     addable later from the dashboard at `/`
+3. **Generate a public domain**: Service → Settings → Networking →
    Public Networking → Generate Domain.
-5. Railway auto-deploys on every push to `main`.
+4. Railway auto-deploys on every push to `main`.
 
 ### Render / Bare Docker
 


### PR DESCRIPTION
## Summary

Real-world deploy hit a UX dead-end: Railway's Volume creation entry point is hard to find in the current dashboard (not in the project canvas right-click menu, and the Service Settings → Volumes section is buried/conditional). Following PR #35's docs, users ended up creating a Bucket (S3-compatible object storage) by mistake.

Drop the Volume step from the Railway section to remove the friction. Without a volume the container's `/data` is ephemeral, but:

- The Dockerfile already creates `/data` (`RUN mkdir -p /data`), so SQLite writes succeed inside the container
- For "trying it out" / demo, ephemeral is fine — exactly what most one-click PaaS deploys deliver by default
- Operators who actually need persistence can add a Railway Volume or swap to the Postgres add-on; documenting both paths would be longer than the rest of the Railway section, and Railway's own UI is the source of truth for those workflows

Also drops `DATABASE_URL` from the env vars list — without `/data` mount, the in-container default `sqlite+aiosqlite:///./orca.db` (resolves to `/app/orca.db` inside the container) works without any explicit override.

Updated the table row at the top of the section to match.

## Test plan

- [x] `git diff` shows only README changes
- [x] Markdown still renders cleanly (Railway section now has 4 numbered steps instead of 5, no orphan references)
- [ ] One real Railway deploy walking through the simplified steps end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)