### PR TITLE
fix(chat): prevent PEP 525 RuntimeError on stream disconnect and fix streaming log persistence

### DIFF
--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -639,6 +639,10 @@ async def chat_completions(
                     }
                 }
                 yield f"data: {json.dumps(err_body)}\n\n"
+                # Not handling GeneratorExit here, so yielding the sentinel
+                # is legal; clients reading until [DONE] still get it after
+                # an upstream error.
+                yield "data: [DONE]\n\n"
             finally:
                 # Same shielding reason as the cancel branch: ensure the
                 # log write actually completes before we unwind, even if

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -531,11 +531,21 @@ async def chat_completions(
                     requested_model=requested_model,
                     actual_resolved=agg_model,
                 )
-                db.add(log)
-                try:
-                    await db.commit()
-                except Exception as commit_err:
-                    logger.warning("request_log_commit_failed", error=str(commit_err))
+                from packages.db import session as session_mod
+
+                if session_mod._session_factory is not None:
+                    try:
+                        async with session_mod._session_factory() as s:
+                            s.add(log)
+                            await s.commit()
+                    except Exception as commit_err:
+                        logger.warning("request_log_commit_failed", error=str(commit_err))
+                else:
+                    db.add(log)
+                    try:
+                        await db.commit()
+                    except Exception as commit_err:
+                        logger.warning("request_log_commit_failed", error=str(commit_err))
 
             try:
                 async for chunk in _aiter(stream_obj):
@@ -551,6 +561,7 @@ async def chat_completions(
                     if d.get("model"):
                         agg_model = d["model"]
                     yield f"data: {json.dumps(d, separators=(',', ':'))}\n\n"
+                yield "data: [DONE]\n\n"
             except (asyncio.CancelledError, GeneratorExit):
                 # Client closed the connection (Ctrl+C, tab closed, browser
                 # navigated away, proxy timeout, ...). Two distinct signals
@@ -629,14 +640,6 @@ async def chat_completions(
                 }
                 yield f"data: {json.dumps(err_body)}\n\n"
             finally:
-                # Try to send the [DONE] sentinel. If the client is still
-                # listening they need it to stop reading. If they're gone
-                # (cancel path already ran), the yield will raise — swallow
-                # silently because there's no consumer to deliver to.
-                try:
-                    yield "data: [DONE]\n\n"
-                except (asyncio.CancelledError, GeneratorExit):
-                    pass
                 # Same shielding reason as the cancel branch: ensure the
                 # log write actually completes before we unwind, even if
                 # we're inside a cancelled scope. The cancel branch may

--- a/tests/integration/test_stream_disconnect.py
+++ b/tests/integration/test_stream_disconnect.py
@@ -1,8 +1,9 @@
 """Test to verify clean teardown of sse() generator without RuntimeError on client disconnect."""
 
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from app import router_cache
 from app.routes.chat import chat_completions

--- a/tests/integration/test_stream_disconnect.py
+++ b/tests/integration/test_stream_disconnect.py
@@ -2,7 +2,7 @@
 
 import asyncio
 import pytest
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from app import router_cache
 from app.routes.chat import chat_completions
@@ -42,6 +42,7 @@ async def test_sse_generator_clean_teardown(monkeypatch):
     )
 
     db_mock = AsyncMock()
+    db_mock.add = MagicMock()  # Synchronous method on AsyncSession
 
     # Call the chat_completions endpoint handler
     response = await chat_completions(

--- a/tests/integration/test_stream_disconnect.py
+++ b/tests/integration/test_stream_disconnect.py
@@ -1,0 +1,63 @@
+"""Test to verify clean teardown of sse() generator without RuntimeError on client disconnect."""
+
+import asyncio
+import pytest
+from unittest.mock import AsyncMock
+
+from app import router_cache
+from app.routes.chat import chat_completions
+from app.schemas import ChatCompletionRequest
+from packages.auth.types import KeyContext
+
+
+@pytest.mark.asyncio
+async def test_sse_generator_clean_teardown(monkeypatch):
+    """Verify that calling aclose() on the sse generator closes cleanly without RuntimeError."""
+
+    # Mock stream object that mimics a provider stream
+    async def mock_stream():
+        yield {"choices": [{"delta": {"content": "hello"}}]}
+        await asyncio.sleep(10)  # simulate long stream
+        yield {"choices": [{"delta": {"content": "world"}}]}
+
+    stream_obj = mock_stream()
+    fake_client = AsyncMock()
+    fake_client.acompletion = AsyncMock(return_value=stream_obj)
+
+    async def _fake_get_router(_session):
+        return fake_client
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        stream=True,
+    )
+    kc = KeyContext(
+        key_id="test_key",
+        workspace_id="default",
+        name="test",
+        key_type="standard",
+    )
+
+    db_mock = AsyncMock()
+
+    # Call the chat_completions endpoint handler
+    response = await chat_completions(
+        body=body,
+        request=AsyncMock(),
+        kc=kc,
+        db=db_mock,
+    )
+
+    # Get the underlying async generator from StreamingResponse
+    gen = response.body_iterator
+
+    # Read the first chunk
+    first_chunk = await gen.__anext__()
+    assert "hello" in first_chunk
+
+    # Simulate client disconnect / generator closing mid-stream
+    # Must close cleanly without throwing RuntimeError or unhandled exceptions
+    await gen.aclose()


### PR DESCRIPTION
Fixes #49 

## Description

This PR fixes two critical issues in the SSE streaming completions endpoint (`POST /v1/chat/completions`):

1. **PEP 525 Violation (`RuntimeError: async generator ignored GeneratorExit`)**:
   - **Problem**: `yield "data: [DONE]\n\n"` was executed inside the `finally:` block of the `sse()` generator. When a client disconnects mid-stream (or when task cancellation occurs), Starlette/AnyIO closes the generator by throwing `GeneratorExit`. Per Python PEP 525, yielding a value while handling `GeneratorExit` raises `RuntimeError: async generator ignored GeneratorExit`.
   - **Fix**: Moved `yield "data: [DONE]\n\n"` out of `finally:` to the normal end of the `try:` block execution. The `finally:` block now contains strictly non-yielding cleanup logic inside a shielded cancellation scope.

2. **Streaming Request Log Persistence Teardown Race**:
   - **Problem**: FastAPI closes the request-scoped `db` dependency context as soon as `chat_completions()` returns `StreamingResponse`. When `sse()` completes or disconnects later, `_finalize()` attempted `db.add(log)` and `await db.commit()` on a closed/detached session, causing 100% of streaming request logs to fail with `request_log_commit_failed`.
   - **Fix**: Updated `_finalize()` to acquire a fresh, isolated session from `session_mod._session_factory()` so log persistence succeeds reliably regardless of request context state.

---

## Type of Change

- [x] 🐛 **Bug fix** (non-breaking change fixing an issue)
- [x] 🧪 **Test update** (added test cases for stream cancellation/teardown)

---

## How Has This Been Tested?

### Automated Tests
1. **Targeted Disconnect Integration Test**:
   ```bash
   pytest tests/integration/test_stream_disconnect.py -s
   ```
   *Result*: `1 passed in 1.93s` — verifies `aclose()` closes cleanly without `RuntimeError`.

2. **Full Integration & Unit Test Suite**:
   ```bash
   pytest
   ```
   *Result*: `303 passed in 6.97s`

### Test Environment
- **OS**: Linux (Fedora / Ubuntu)
- **Python**: 3.14.6
- **Frameworks**: FastAPI / Starlette / AnyIO / SQLAlchemy Async Engine

---

## Checklist

- [x] My code follows the code style guidelines of this project.
- [x] I have performed a self-review of my code.
- [x] I have added a new unit/integration test (`tests/integration/test_stream_disconnect.py`).
- [x] New and existing tests pass locally with my changes.
- [x] No breaking API contract changes introduced.
