### PR TITLE
test: make cache-group preview test hermetic against litellm catalog drift

### DIFF
--- a/tests/unit/test_cache_group_check.py
+++ b/tests/unit/test_cache_group_check.py
@@ -151,14 +151,25 @@ def test_version_suffix_does_not_confuse_distinct_models():
     ) is False
 
 
-def test_preview_suffix_is_not_a_version_variant():
+def test_preview_suffix_is_not_a_version_variant(monkeypatch):
     """`gpt-4-turbo-preview` is a DISTINCT catalog model from `gpt-4-turbo`,
     not a version of it. The version-suffix pass must NOT match `-preview`
     or the cache will be poisoned across these two models. Catalog lookup
     catches the cascade after the version pass falls through."""
     from app.routes.chat import _served_same_group_as_requested
-    # Both gpt-4-turbo and gpt-4-turbo-preview are in CATALOG_BY_ID as
-    # distinct entries. The catalog lookup should detect this as a cascade.
+    from packages.litellm_adapter import catalog as catalog_mod
+
+    # Pin the catalog entry instead of relying on the live litellm-sourced
+    # CATALOG: gpt-4-turbo-preview is past its deprecation_date, so current
+    # litellm metadata drops it at load and the catalog-lookup pass would
+    # silently fall through to the permissive default.
+    monkeypatch.setitem(
+        catalog_mod.CATALOG_BY_ID,
+        "gpt-4-turbo-preview",
+        catalog_mod.CatalogModel(
+            id="gpt-4-turbo-preview", provider="openai", litellm_prefix="openai/"
+        ),
+    )
     assert _served_same_group_as_requested(
         requested_group="gpt-4-turbo",
         served_model="gpt-4-turbo-preview",


### PR DESCRIPTION
## Description

`tests/unit/test_cache_group_check.py::test_preview_suffix_is_not_a_version_variant` currently fails on every branch, including `main`, blocking CI for open PRs (#50, #52).

### Root cause

The test asserts that the catalog-lookup pass in `_served_same_group_as_requested()` classifies `gpt-4-turbo-preview` as a cascade from `gpt-4-turbo`. That relied on `gpt-4-turbo-preview` being present in `CATALOG_BY_ID`, which is built at import time from `litellm.model_cost` and filtered by `_is_obviously_dead()`. The model is now past its `deprecation_date`, so current litellm metadata drops it at catalog load, the lookup falls through to the permissive default, and the assertion fails. CI was green in May because the deprecation date had not passed yet and an older litellm version was installed.

### Fix

Inject the catalog entry with `monkeypatch.setitem` so the test exercises the catalog-lookup branch deterministically, regardless of litellm version or the current date.

## Type of Change

- [x] Test update (no production code changes)

## How Has This Been Tested?

- `ruff check .` passes.
- The change is test-only; CI on this PR runs the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
