### PR TITLE
Cross worker cache invalidation using redis pub/sub model.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,10 @@ LOG_LEVEL=info
 # DATABASE_URL=postgresql+asyncpg://user:pass@host:5432/orca
 
 # ── Redis (optional — improves throughput) ────────────
+# Also enables cross-worker cache invalidation: with multiple
+# uvicorn workers / k8s replicas, a config change (provider key,
+# routing, quality override) is broadcast so every worker drops
+# its stale cache. Without it, siblings serve stale until TTL.
 # REDIS_URL=redis://localhost:6379/0
 
 # ── Encryption (auto-generated on first run if empty) ──

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ for chunk in client.chat.completions.create(
 - `GET/POST/DELETE /v1/keys/...` — list / rotate / revoke API keys
 - Single-page dashboard at `/`
 - SQLite by default; Postgres opt-in via `DATABASE_URL`; Redis optional
+- Multi-worker safe: set `REDIS_URL` and config changes (provider keys, routing, quality overrides) are invalidated across all workers/replicas via pub/sub. Single worker (the default) needs no Redis.
 
 ### Cross-provider prompt cache
 

--- a/app/cache_invalidation_bus.py
+++ b/app/cache_invalidation_bus.py
@@ -1,0 +1,172 @@
+"""Cross-worker cache invalidation over Redis pub/sub (issue #53).
+
+The Lite default (1 uvicorn worker) keeps the router client + metrics
+caches process-local, and a mutation route dropping its own cache is
+enough. Under multiple workers / k8s replicas each process has its own
+RAM heap, so a mutation only invalidates the worker that served the
+request — siblings keep serving a stale router client (e.g. an old
+provider key) or stale metrics until their own TTL / a restart.
+
+When ``REDIS_URL`` is set, every mutation route broadcasts a plain-string
+invalidation message on one channel and a per-worker background listener
+applies it locally. No Redis configured → every broadcast is a no-op and
+behavior is exactly the single-worker path. This module is transport
+only: it reuses the existing local ``invalidate_*()`` functions.
+
+# ponytail: one channel + string messages, no generic bus. Add a message
+# schema / more targets only when a third cache needs invalidating.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+
+import structlog
+
+_INVALIDATION_CHANNEL = "orca:invalidate"
+_ROUTER_CACHE_MESSAGE = "router"
+_METRICS_CACHE_MESSAGE = "metrics"
+
+log = structlog.get_logger()
+
+_redis_publisher_client = None  # lazily-created redis client for PUBLISH
+_redis_publisher_initialized = False
+_invalidation_listener_task: asyncio.Task | None = None
+_invalidation_listener_connection = None
+
+
+def _configured_redis_url() -> str | None:
+    from app.config import get_settings
+
+    return get_settings().redis_url
+
+
+# ── Broadcast (mutation side: drop locally + tell sibling workers) ─────────
+
+
+async def broadcast_router_cache_invalidation() -> None:
+    """Drop this worker's router cache and tell sibling workers to do the same."""
+    from app import router_cache
+
+    router_cache.invalidate_router()
+    await _publish_invalidation_message(_ROUTER_CACHE_MESSAGE)
+
+
+async def broadcast_metrics_cache_invalidation(workspace_id: str | None = None) -> None:
+    """Drop this worker's metrics cache and tell sibling workers to do the same.
+
+    ``workspace_id=None`` clears every workspace (mirrors
+    ``invalidate_metrics_cache``).
+    """
+    from app.quality_scores import invalidate_metrics_cache
+
+    invalidate_metrics_cache(workspace_id)
+    await _publish_invalidation_message(
+        _METRICS_CACHE_MESSAGE
+        if workspace_id is None
+        else f"{_METRICS_CACHE_MESSAGE}:{workspace_id}"
+    )
+
+
+# ── Publisher ─────────────────────────────────────────────────────────────
+
+
+async def _get_redis_publisher_client():
+    global _redis_publisher_client, _redis_publisher_initialized
+    if _redis_publisher_initialized:
+        return _redis_publisher_client
+    _redis_publisher_initialized = True
+    redis_url = _configured_redis_url()
+    if not redis_url:
+        return None
+    try:
+        import redis.asyncio as aioredis
+
+        _redis_publisher_client = aioredis.from_url(redis_url, decode_responses=True)
+    except Exception as exc:  # redis extra not installed / bad url
+        log.warning("invalidation_publisher_unavailable", error=str(exc))
+        _redis_publisher_client = None
+    return _redis_publisher_client
+
+
+async def _publish_invalidation_message(message: str) -> None:
+    client = await _get_redis_publisher_client()
+    if client is None:
+        return
+    try:
+        await client.publish(_INVALIDATION_CHANNEL, message)
+    except Exception as exc:  # never fail a mutation on a bus hiccup
+        log.warning("invalidation_publish_failed", error=str(exc), message=message)
+
+
+# ── Listener (subscriber side: local invalidation only, never re-publish) ──
+
+
+def _apply_invalidation_message_locally(message: str) -> None:
+    """Apply a received invalidation message to this worker's local caches."""
+    from app import router_cache
+    from app.quality_scores import invalidate_metrics_cache
+
+    if message == _ROUTER_CACHE_MESSAGE:
+        router_cache.invalidate_router()
+    elif message == _METRICS_CACHE_MESSAGE:
+        invalidate_metrics_cache(None)
+    elif message.startswith(_METRICS_CACHE_MESSAGE + ":"):
+        invalidate_metrics_cache(message.split(":", 1)[1])
+    else:
+        log.warning("invalidation_unknown_message", message=message)
+
+
+async def _subscribe_and_apply_invalidations(redis_url: str) -> None:
+    import redis.asyncio as aioredis
+
+    global _invalidation_listener_connection
+    while True:
+        try:
+            _invalidation_listener_connection = aioredis.from_url(
+                redis_url, decode_responses=True
+            )
+            pubsub = _invalidation_listener_connection.pubsub()
+            await pubsub.subscribe(_INVALIDATION_CHANNEL)
+            log.info("invalidation_listener_ready", channel=_INVALIDATION_CHANNEL)
+            async for msg in pubsub.listen():
+                if msg.get("type") == "message":
+                    _apply_invalidation_message_locally(msg["data"])
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A dropped connection must not silently strand this worker on
+            # stale caches — reconnect after a short backoff.
+            log.warning("invalidation_listener_error", error=str(exc))
+            await asyncio.sleep(1.0)
+
+
+async def start_invalidation_listener() -> None:
+    """Spawn the per-worker background listener. No-op without REDIS_URL."""
+    global _invalidation_listener_task
+    redis_url = _configured_redis_url()
+    if not redis_url or _invalidation_listener_task is not None:
+        return
+    try:
+        import redis.asyncio  # noqa: F401 — fail fast if the extra is missing
+    except Exception as exc:
+        log.warning("invalidation_listener_unavailable", error=str(exc))
+        return
+    _invalidation_listener_task = asyncio.create_task(
+        _subscribe_and_apply_invalidations(redis_url)
+    )
+
+
+async def stop_invalidation_listener() -> None:
+    """Cancel the listener and close its connection (lifespan shutdown)."""
+    global _invalidation_listener_task, _invalidation_listener_connection
+    if _invalidation_listener_task is not None:
+        _invalidation_listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await _invalidation_listener_task
+        _invalidation_listener_task = None
+    if _invalidation_listener_connection is not None:
+        with contextlib.suppress(Exception):
+            await _invalidation_listener_connection.aclose()
+        _invalidation_listener_connection = None

--- a/app/main.py
+++ b/app/main.py
@@ -56,10 +56,15 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             log.info("seed_complete", api_key=seed.api_key)
             print(f"\n  ✓ orcarouter-lite ready. API key: {seed.api_key}\n")
 
+    from app import cache_invalidation_bus
+
+    await cache_invalidation_bus.start_invalidation_listener()
+
     log.info("lite_ready")
     yield
 
     log.info("lite_shutting_down")
+    await cache_invalidation_bus.stop_invalidation_listener()
     await dispose_engine()
 
 

--- a/app/quality_scores.py
+++ b/app/quality_scores.py
@@ -20,12 +20,13 @@ by (workspace_id, AA-key-hash); override PUT/DELETE and quality refresh
 routes invalidate the relevant entries so operator changes are visible
 immediately, not after a TTL.
 
-Multi-worker note: cache is module-local. Multi-worker uvicorn or k8s
-replicas each hold their own — a worker that didn't see the override
-mutation serves stale until its own TTL expires. Acceptable for the
-single-tenant Lite default (1 worker); cross-worker invalidation
-(pubsub / shared cache) belongs to a future PR if multi-worker
-deployment becomes a real use case.
+Multi-worker note: cache is module-local. On a single worker (the Lite
+default) the mutation route dropping its own entry is enough. Under
+multiple uvicorn workers / k8s replicas, cross-worker invalidation is
+handled by app.cache_invalidation_bus (Redis pub/sub) when REDIS_URL is
+set — mutation routes call broadcast_metrics_cache_invalidation() so
+siblings drop their entries too instead of waiting out the TTL. Without
+REDIS_URL a sibling still serves stale until its own TTL expires.
 """
 
 from __future__ import annotations

--- a/app/routes/providers.py
+++ b/app/routes/providers.py
@@ -42,7 +42,7 @@ from sqlalchemy import delete as sql_delete
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import router_cache
+from app import cache_invalidation_bus
 from app.config import get_settings
 from app.deps import get_db, get_key_context
 from app.router_cache import usable_providers_from_db
@@ -184,7 +184,7 @@ async def set_provider_key(
         db.add(existing)
 
     await db.commit()
-    router_cache.invalidate_router()
+    await cache_invalidation_bus.broadcast_router_cache_invalidation()
 
     return ProviderKeyOut(
         provider=existing.provider,
@@ -228,5 +228,5 @@ async def delete_provider_key(
                 ),
             )
         raise HTTPException(status_code=404, detail="Provider key not found")
-    router_cache.invalidate_router()
+    await cache_invalidation_bus.broadcast_router_cache_invalidation()
     return Response(status_code=204)

--- a/app/routes/quality.py
+++ b/app/routes/quality.py
@@ -31,10 +31,10 @@ from app.auto_routing import (
     choose_auto_model,
     litellm_routing_strategy,
 )
+from app.cache_invalidation_bus import broadcast_metrics_cache_invalidation
 from app.deps import get_db, get_key_context
 from app.quality_scores import (
     fetch_aa_index,
-    invalidate_metrics_cache,
     load_overrides,
     resolve_model_metrics,
 )
@@ -175,7 +175,7 @@ async def quality_refresh(
     aa = await fetch_aa_index(
         db=db, workspace_id=str(kc.workspace_id), force_refresh=True,
     )
-    invalidate_metrics_cache()  # global — AA fetch refreshes for all workspaces
+    await broadcast_metrics_cache_invalidation()  # global — AA fetch refreshes all workspaces
     return {"aa_index": _serialize_aa_index(aa)}
 
 
@@ -453,7 +453,7 @@ async def upsert_override(
         ).scalar_one()
     # Drop the resolver cache so balanced + quality routing see the new
     # override on the very next request (otherwise stale up to 60s TTL).
-    invalidate_metrics_cache(workspace_id)
+    await broadcast_metrics_cache_invalidation(workspace_id)
     return _serialize_override(row)
 
 
@@ -474,4 +474,4 @@ async def delete_override(
         )
     )
     await db.commit()
-    invalidate_metrics_cache(workspace_id)
+    await broadcast_metrics_cache_invalidation(workspace_id)

--- a/app/routes/routing.py
+++ b/app/routes/routing.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel, field_validator
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app import router_cache
+from app import cache_invalidation_bus
 from app.deps import get_db, get_key_context
 from app.seed import DEFAULT_WORKSPACE_ID
 from packages.auth.types import KeyContext
@@ -74,7 +74,7 @@ async def update_routing(
         row.preferred_models = body.preferred_models
 
     await db.commit()
-    router_cache.invalidate_router()
+    await cache_invalidation_bus.broadcast_router_cache_invalidation()
 
     return {
         "strategy": row.strategy,

--- a/tests/unit/test_cache_invalidation_bus.py
+++ b/tests/unit/test_cache_invalidation_bus.py
@@ -1,0 +1,50 @@
+"""Cross-worker cache invalidation bus (issue #53).
+
+Transport is Redis; the testable core is message parsing/dispatch and the
+no-Redis no-op path. Both are exercised without a real Redis.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app import cache_invalidation_bus as bus
+
+
+def test_apply_invalidation_message_routes_to_local_invalidators(monkeypatch):
+    router_hits: list[bool] = []
+    metrics_hits: list[str | None] = []
+
+    from app import quality_scores, router_cache
+
+    monkeypatch.setattr(router_cache, "invalidate_router",
+                        lambda: router_hits.append(True))
+    monkeypatch.setattr(quality_scores, "invalidate_metrics_cache",
+                        lambda wid=None: metrics_hits.append(wid))
+
+    bus._apply_invalidation_message_locally("router")
+    bus._apply_invalidation_message_locally("metrics")
+    bus._apply_invalidation_message_locally("metrics:ws-1")
+    bus._apply_invalidation_message_locally("garbage")  # unknown → ignored
+
+    assert router_hits == [True]
+    assert metrics_hits == [None, "ws-1"]
+
+
+@pytest.mark.asyncio
+async def test_broadcast_is_noop_publish_without_redis(monkeypatch):
+    """No REDIS_URL → local invalidation still runs, publish is skipped."""
+    monkeypatch.setattr(bus, "_configured_redis_url", lambda: None)
+    bus._redis_publisher_client = None
+    bus._redis_publisher_initialized = False
+
+    router_hits: list[bool] = []
+    from app import router_cache
+
+    monkeypatch.setattr(router_cache, "invalidate_router",
+                        lambda: router_hits.append(True))
+
+    await bus.broadcast_router_cache_invalidation()  # must not raise
+
+    assert router_hits == [True]
+    assert await bus._get_redis_publisher_client() is None


### PR DESCRIPTION
Fix #53: Cross-worker cache invalidation via Redis pub/sub

Under multiple uvicorn workers / k8s replicas, config mutations only invalidated the cache in the worker that served the request. Siblings kept serving stale router clients (e.g. an old provider key → 401s) and stale metrics until their TTL or a restart.

What this does
- Adds app/cache_invalidation_bus.py — a thin Redis pub/sub transport. Mutation routes now call broadcast_*_cache_invalidation(), which drops the local cache and publishes on one channel; a per-worker background listener applies invalidations from siblings by reusing the existing local invalidate_*() functions.
- Wires the broadcast into all mutation sites (providers, routing, quality) and starts/stops the listener in the app lifespan (main.py).
- Reconnects with backoff so a dropped Redis connection can't silently strand a worker on stale caches.

No behavior change without Redis: when REDIS_URL is unset, every broadcast is a no-op and the single-worker Lite default is unchanged.

Tests: added test_cache_invalidation_bus.py (message dispatch + no-Redis no-op path); full suite green, ruff clean.
