### PR TITLE
feat(protocols): add native Anthropic Messages and Gemini API ingress

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -93,3 +93,20 @@ Most LLM router pitches show a config table. This shows **a failure happening
 in real time and being absorbed transparently**. The viewer's brain resolves
 "so this is what would have prevented my 3am pager last month" and that's the
 share-worthy moment.
+
+## Bonus: native-protocol smoke (Anthropic + Gemini ingress)
+
+With the same running server, verify the native endpoints end-to-end — the
+Anthropic Messages API (`/v1/messages`, what Claude Code speaks) and the
+Gemini API (`/v1beta`):
+
+```bash
+ORCA_API_KEY="sk-orca-..." PYTHONPATH=. python scripts/smoke_native.py
+# 9/9 checks passed
+```
+
+The script exercises blocking, streaming, tool use, and count_tokens over
+raw HTTP, and — when `pip install anthropic google-genai` is present — the
+official SDKs pointed straight at Lite. See
+[integrations/claude-code.md](./integrations/claude-code.md) and
+[integrations/gemini-sdk.md](./integrations/gemini-sdk.md).

--- a/README.de.md
+++ b/README.de.md
@@ -5,7 +5,7 @@ OpenAI-kompatibel. BYOK. Einzelner Workspace. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Native Protokoll-Endpunkte (Anthropic + Gemini)
+
+Lite spricht drei eingehende Protokolle über eine einzige Routing-Pipeline. Clients, die nur die Anthropic- oder Gemini-Wire-Formate sprechen, verbinden sich direkt — kein OpenAI-SDK erforderlich:
+
+```bash
+# Claude Code, auf Lite gerichtet (kein /v1-Suffix in der Basis-URL)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai-SDK, auf Lite gerichtet
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Anfragen werden am Eingang in dieselbe interne Pipeline übersetzt, sodass `model="auto"`, der provider-übergreifende Prompt-Cache (über alle Protokolle geteilt), die Routing-Strategien und das Analytics-Dashboard identisch funktionieren. Anleitungen: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Modellkatalog
 
 Beim Start werden über 100 Chat-Modelle aus [LiteLLMs von der Community gepflegter Preisdatenbank](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) geladen — keine Modellliste, die manuell gepflegt werden muss. Jeder Eintrag enthält:
@@ -194,6 +216,8 @@ Beim Start werden über 100 Chat-Modelle aus [LiteLLMs von der Community gepfleg
 ## Was ist enthalten
 
 - `POST /v1/chat/completions` — Proxy + Streaming + `model="auto"` + provider-übergreifender Prompt-Cache
+- `POST /v1/messages` — **Anthropic-Messages-API-Ingress** (Claude Code / Anthropic-SDKs verbinden sich direkt; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **Gemini-API-Ingress** (google-genai-SDK verbindet sich direkt; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — auffindbarer Modellkatalog (100+ Modelle aus `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — verschlüsselte Provider-Schlüssel setzen / auflisten / widerrufen
 - `GET/PUT /v1/routing` — Strategie ändern (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← aus dem Cache, kein Upstream-Aufruf
 
 ### Integrationen
 
-Drop-in-Konfigurationen für [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) und jedes Tool, das das OpenAI-Chat-Completions-Protokoll spricht. Siehe [`integrations/`](./integrations/).
+Drop-in-Konfigurationen für [Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) und jedes Tool, das das OpenAI-Chat-Completions-Protokoll spricht — plus native Anthropic- und Gemini-Wire-Formate. Siehe [`integrations/`](./integrations/).
 
 ## Was bewusst nicht enthalten ist
 
@@ -244,7 +268,7 @@ Test-First entwickelt. Jedes hier ausgelieferte Verhalten hatte zuerst einen feh
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Tests | Was |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Hosted-Status | 7 | `/v1/hosted` Config-Source + Signup-URL-Surface |
 | 17. Hosted-Auto-Einsparungen | 3 | `_hosted_auto_savings`-Edge-Cases auf synthetischen Katalogen |
 | 18. Unerreichbare Modelle | 7 | "Modelle, die du nicht erreichen kannst"-Kachel verschwindet, wenn Hosted aktiv ist |
-| **Gesamt** | **127** | |
+| 19. Multi-Protokoll-Auth | 6 | Scoping von x-api-key / x-goog-api-key / ?key=, /v1beta-Guard, 401-Envelopes pro Protokoll |
+| 20. Anthropic `/v1/messages` | 53 | Request-/Response-/Stream-Übersetzung + Ingress-Integration |
+| 21. Gemini `/v1beta` | 40 | Übersetzung inkl. Schema-Enum-Normalisierung + generateContent/Stream-Ingress |
+| **Gesamt** | **403** | |
+
+Die Slice-Zeilen zeigen die Tests, die beim Ausliefern des jeweiligen Slices hinzukamen; die Gesamtzahl ist die aktuelle vollständige Suite.
 
 ## Architektur
 

--- a/README.es.md
+++ b/README.es.md
@@ -5,7 +5,7 @@ Compatible con OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Endpoints de protocolos nativos (Anthropic + Gemini)
+
+Lite habla tres protocolos de entrada sobre un único pipeline de enrutamiento. Los clientes que solo hablan los formatos wire de Anthropic o Gemini se conectan directamente — sin necesidad de un SDK de OpenAI:
+
+```bash
+# Claude Code, apuntando a Lite (sin sufijo /v1 en la URL base)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# SDK google-genai, apuntando a Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Las solicitudes se traducen en la entrada hacia el mismo pipeline interno, así que `model="auto"`, la caché de prompts entre proveedores (compartida entre protocolos), las estrategias de enrutamiento y el panel de analítica funcionan todos de forma idéntica. Guías: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Catálogo de modelos
 
 Se cargan más de 100 modelos de chat al arrancar desde la [base de datos de precios mantenida por la comunidad de LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — sin lista de modelos que mantener manualmente. Cada entrada expone:
@@ -194,6 +216,8 @@ Se cargan más de 100 modelos de chat al arrancar desde la [base de datos de pre
 ## Qué incluye
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + caché de prompts entre proveedores
+- `POST /v1/messages` — **ingress de la API Messages de Anthropic** (Claude Code / los SDK de Anthropic se conectan directamente; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ingress de la API de Gemini** (el SDK google-genai se conecta directamente; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — catálogo de modelos descubrible (100+ modelos desde `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — crea / lista / revoca claves de proveedor cifradas
 - `GET/PUT /v1/routing` — cambia la estrategia (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← servido desde caché, sin llamada upstream
 
 ### Integraciones
 
-Configuraciones drop-in para [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) y cualquier herramienta que hable el protocolo de Chat Completions de OpenAI. Consulta [`integrations/`](./integrations/).
+Configuraciones drop-in para [Claude Code](./integrations/claude-code.md), [SDK de Gemini](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) y cualquier herramienta que hable el protocolo de Chat Completions de OpenAI — además de los formatos wire nativos de Anthropic y Gemini. Consulta [`integrations/`](./integrations/).
 
 ## Lo que deliberadamente no incluye
 
@@ -244,7 +268,7 @@ Construido con test-first. Cada comportamiento entregado aquí tuvo primero un t
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Tests | Qué |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Estado de hosted | 7 | `/v1/hosted` config-source + superficie de URL de signup |
 | 17. Ahorros de hosted-auto | 3 | casos límite de `_hosted_auto_savings` en catálogos sintéticos |
 | 18. Modelos inalcanzables | 7 | la tarjeta "modelos que no puedes alcanzar" se vacía cuando hosted está activo |
-| **Total** | **127** | |
+| 19. Auth multiprotocolo | 6 | scoping de x-api-key / x-goog-api-key / ?key=, guard de /v1beta, sobres 401 por protocolo |
+| 20. Anthropic `/v1/messages` | 53 | traducción de solicitud/respuesta/stream + integración del ingress |
+| 21. Gemini `/v1beta` | 40 | traducción incl. normalización de schema-enum + ingress de generateContent/stream |
+| **Total** | **403** | |
+
+Las filas de slice muestran los tests añadidos cuando se entregó cada slice; el total es la suite completa actual.
 
 ## Arquitectura
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -5,7 +5,7 @@ Compatible OpenAI. BYOK. Workspace unique. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Endpoints protocolaires natifs (Anthropic + Gemini)
+
+Lite parle trois protocoles entrants sur un seul pipeline de routage. Les clients qui ne parlent que les formats wire Anthropic ou Gemini se connectent directement — aucun SDK OpenAI requis :
+
+```bash
+# Claude Code, pointé sur Lite (pas de suffixe /v1 dans l'URL de base)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# SDK google-genai, pointé sur Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Les requêtes sont traduites à l'entrée vers le même pipeline interne, donc `model="auto"`, le cache de prompts inter-fournisseurs (partagé entre les protocoles), les stratégies de routage et le tableau de bord d'analytics fonctionnent tous à l'identique. Guides : [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Catalogue de modèles
 
 Plus de 100 modèles de chat sont chargés au démarrage depuis la [base de données de prix maintenue par la communauté de LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — pas de liste de modèles à maintenir à la main. Chaque entrée expose :
@@ -194,6 +216,8 @@ Plus de 100 modèles de chat sont chargés au démarrage depuis la [base de donn
 ## Ce qu'il y a dans la boîte
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache de prompts inter-fournisseurs
+- `POST /v1/messages` — **ingress de l'API Messages d'Anthropic** (Claude Code / les SDK Anthropic se connectent directement ; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ingress de l'API Gemini** (le SDK google-genai se connecte directement ; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — catalogue de modèles découvrable (100+ modèles depuis `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — définir / lister / révoquer des clés de fournisseur chiffrées
 - `GET/PUT /v1/routing` — changer la stratégie (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← servi depuis le cache, pas d'appel upstream
 
 ### Intégrations
 
-Configurations drop-in pour [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) et tout outil parlant le protocole OpenAI Chat Completions. Voir [`integrations/`](./integrations/).
+Configurations drop-in pour [Claude Code](./integrations/claude-code.md), [SDK Gemini](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) et tout outil parlant le protocole OpenAI Chat Completions — plus les formats wire natifs d'Anthropic et de Gemini. Voir [`integrations/`](./integrations/).
 
 ## Ce qui n'est délibérément pas inclus
 
@@ -244,7 +268,7 @@ Construit en test-first. Chaque comportement livré ici a d'abord eu un test qui
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Tests | Quoi |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Statut hosted | 7 | `/v1/hosted` config-source + surface URL d'inscription |
 | 17. Économies hosted-auto | 3 | cas limites de `_hosted_auto_savings` sur catalogues synthétiques |
 | 18. Modèles inaccessibles | 7 | la tuile « modèles inaccessibles » se vide quand hosted est actif |
-| **Total** | **127** | |
+| 19. Auth multi-protocole | 6 | scoping x-api-key / x-goog-api-key / ?key=, garde /v1beta, enveloppes 401 par protocole |
+| 20. Anthropic `/v1/messages` | 53 | traduction requête/réponse/stream + intégration de l'ingress |
+| 21. Gemini `/v1beta` | 40 | traduction incluant la normalisation schema-enum + ingress generateContent/stream |
+| **Total** | **403** | |
+
+Les lignes de slice montrent les tests ajoutés à la livraison de chaque slice ; le total est la suite complète actuelle.
 
 ## Architecture
 

--- a/README.hi.md
+++ b/README.hi.md
@@ -5,7 +5,7 @@ OpenAI-compatible। BYOK। एकल-वर्कस्पेस। स्ट�
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## नेटिव प्रोटोकॉल एंडपॉइंट (Anthropic + Gemini)
+
+Lite एक ही रूटिंग पाइपलाइन पर तीन इनबाउंड प्रोटोकॉल बोलता है। जो क्लाइंट केवल Anthropic या Gemini wire फ़ॉर्मेट बोलते हैं, वे सीधे कनेक्ट होते हैं — किसी OpenAI SDK की आवश्यकता नहीं:
+
+```bash
+# Claude Code, Lite पर पॉइंट किया गया (बेस URL में /v1 सफ़िक्स नहीं)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK, Lite पर पॉइंट किया गया
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Requests को एज पर उसी आंतरिक पाइपलाइन में अनुवादित किया जाता है, इसलिए `model="auto"`, cross-provider प्रॉम्प्ट कैश (सभी प्रोटोकॉल में साझा), रूटिंग रणनीतियाँ और analytics डैशबोर्ड सभी एक जैसे काम करते हैं। गाइड: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md)।
+
 ## मॉडल कैटलॉग
 
 स्टार्टअप पर 100+ चैट मॉडल [LiteLLM के समुदाय-संचालित मूल्य डेटाबेस](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) से लोड किए जाते हैं — कोई मॉडल सूची मैनुअली बनाए रखने के लिए नहीं। प्रत्येक प्रविष्टि उजागर करती है:
@@ -194,6 +216,8 @@ for chunk in client.chat.completions.create(
 ## बॉक्स में क्या है
 
 - `POST /v1/chat/completions` — proxy + स्ट्रीमिंग + `model="auto"` + cross-provider प्रॉम्प्ट कैश
+- `POST /v1/messages` — **Anthropic Messages API इनग्रेस** (Claude Code / Anthropic SDK सीधे कनेक्ट होते हैं; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **Gemini API इनग्रेस** (google-genai SDK सीधे कनेक्ट होता है; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — खोज योग्य मॉडल कैटलॉग (`litellm.model_cost` से 100+ मॉडल)
 - `GET/PUT/DELETE /v1/providers/{provider}` — एन्क्रिप्टेड provider कुंजियाँ सेट / सूचीबद्ध / रद्द करें
 - `GET/PUT /v1/routing` — रणनीति बदलें (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← कैश से सर्व, कोई upstream
 
 ### इंटीग्रेशन
 
-[Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) और किसी भी टूल के लिए drop-in कॉन्फ़िगरेशन जो OpenAI Chat Completions प्रोटोकॉल बोलता है। देखें [`integrations/`](./integrations/)।
+[Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) और किसी भी टूल के लिए drop-in कॉन्फ़िगरेशन जो OpenAI Chat Completions प्रोटोकॉल बोलता है — साथ ही नेटिव Anthropic और Gemini wire फ़ॉर्मेट भी। देखें [`integrations/`](./integrations/)।
 
 ## जो जानबूझकर नहीं है
 
@@ -244,7 +268,7 @@ x-orca-cache: HIT          ← कैश से सर्व, कोई upstream
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | स्लाइस | टेस्ट | क्या |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Hosted स्थिति | 7 | `/v1/hosted` config-source + signup-URL surface |
 | 17. Hosted-auto बचत | 3 | सिंथेटिक कैटलॉग पर `_hosted_auto_savings` एज केस |
 | 18. अनुपलब्ध मॉडल | 7 | "जिन मॉडलों तक नहीं पहुँच सकते" टाइल hosted चालू होने पर खाली हो जाती है |
-| **कुल** | **127** | |
+| 19. मल्टी-प्रोटोकॉल auth | 6 | x-api-key / x-goog-api-key / ?key= स्कोपिंग, /v1beta guard, प्रति-प्रोटोकॉल 401 envelopes |
+| 20. Anthropic `/v1/messages` | 53 | request/response/stream अनुवाद + इनग्रेस एकीकरण |
+| 21. Gemini `/v1beta` | 40 | schema-enum सामान्यीकरण सहित अनुवाद + generateContent/stream इनग्रेस |
+| **कुल** | **403** | |
+
+स्लाइस पंक्तियाँ प्रत्येक स्लाइस के शिप होने पर जोड़े गए टेस्ट दिखाती हैं; कुल वर्तमान पूर्ण टेस्ट सुइट है।
 
 ## आर्किटेक्चर
 

--- a/README.it.md
+++ b/README.it.md
@@ -5,7 +5,7 @@ Compatibile con OpenAI. BYOK. Workspace singolo. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Endpoint di protocollo nativi (Anthropic + Gemini)
+
+Lite parla tre protocolli in ingresso su un'unica pipeline di routing. I client che parlano solo i formati wire di Anthropic o Gemini si connettono direttamente — nessun SDK OpenAI richiesto:
+
+```bash
+# Claude Code, puntato su Lite (nessun suffisso /v1 nell'URL base)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# SDK google-genai, puntato su Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Le richieste vengono tradotte all'ingresso nella stessa pipeline interna, quindi `model="auto"`, la cache prompt cross-provider (condivisa tra i protocolli), le strategie di routing e la dashboard analytics funzionano tutti in modo identico. Guide: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Catalogo modelli
 
 Oltre 100 modelli di chat vengono caricati all'avvio dal [database di prezzi mantenuto dalla community di LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — nessuna lista di modelli da mantenere a mano. Ogni voce espone:
@@ -194,6 +216,8 @@ Oltre 100 modelli di chat vengono caricati all'avvio dal [database di prezzi man
 ## Cosa c'è nella scatola
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache prompt cross-provider
+- `POST /v1/messages` — **ingress dell'API Messages di Anthropic** (Claude Code / gli SDK Anthropic si connettono direttamente; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ingress dell'API Gemini** (l'SDK google-genai si connette direttamente; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — catalogo modelli scopribile (100+ modelli da `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — imposta / lista / revoca chiavi provider cifrate
 - `GET/PUT /v1/routing` — cambia strategia (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← servito dalla cache, nessuna chiamata upstream
 
 ### Integrazioni
 
-Configurazioni drop-in per [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualsiasi tool che parli il protocollo OpenAI Chat Completions. Vedi [`integrations/`](./integrations/).
+Configurazioni drop-in per [Claude Code](./integrations/claude-code.md), [SDK Gemini](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualsiasi tool che parli il protocollo OpenAI Chat Completions — più i formati wire nativi di Anthropic e Gemini. Vedi [`integrations/`](./integrations/).
 
 ## Cosa volutamente non c'è
 
@@ -244,7 +268,7 @@ Costruito test-first. Ogni comportamento spedito qui ha avuto prima un test che 
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Test | Cosa |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Stato hosted | 7 | `/v1/hosted` config-source + superficie URL di signup |
 | 17. Risparmi hosted-auto | 3 | edge case di `_hosted_auto_savings` su cataloghi sintetici |
 | 18. Modelli irraggiungibili | 7 | la tile "modelli che non puoi raggiungere" si svuota quando hosted è attivo |
-| **Totale** | **127** | |
+| 19. Auth multi-protocollo | 6 | scoping x-api-key / x-goog-api-key / ?key=, guard /v1beta, envelope 401 per protocollo |
+| 20. Anthropic `/v1/messages` | 53 | traduzione richiesta/risposta/stream + integrazione ingress |
+| 21. Gemini `/v1beta` | 40 | traduzione incl. normalizzazione schema-enum + ingress generateContent/stream |
+| **Totale** | **403** | |
+
+Le righe degli slice mostrano i test aggiunti quando ogni slice è stato spedito; il totale è la suite completa attuale.
 
 ## Architettura
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -5,7 +5,7 @@ OpenAI対応。ビヨク。単一のワークスペース。ストリーミン�
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![テスト](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![テスト](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![モデル](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![ライセンス](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## ネイティブ プロトコル エンドポイント (Anthropic + Gemini)
+
+Lite は 1 つのルーティング パイプラインに対して 3 つのインバウンド プロトコルを話します。Anthropic または Gemini のワイヤー フォーマットしか話さないクライアントも直接接続できます。OpenAI SDK は不要です:
+
+```bash
+# Claude Code, pointed at Lite (no /v1 suffix in the base URL)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK, pointed at Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+リクエストはエッジで同じ内部パイプラインに変換されるため、`model="auto"`、クロスプロバイダー プロンプト キャッシュ (プロトコル間で共有)、ルーティング戦略、分析ダッシュボードはすべて同じように機能します。ガイド: [integrations/claude-code.md](./integrations/claude-code.md)、[integrations/gemini-sdk.md](./integrations/gemini-sdk.md) を参照してください。
+
 ## モデルカタログ
 
 100 を超えるチャット モデルが起動時に [LiteLLM のコミュニティが管理する価格設定データベース](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) からロードされます。手動で管理するモデル リストはありません。各エントリは以下を公開します。
@@ -194,6 +216,8 @@ for chunk in client.chat.completions.create(
 ## 箱の中身は何ですか
 
 - `POST /v1/chat/completions` — プロキシ + ストリーミング + `model="auto"` + クロスプロバイダー プロンプト キャッシュ
+- `POST /v1/messages` — **Anthropic Messages API イングレス** (Claude Code / Anthropic SDK が直接接続。`+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **Gemini API イングレス** (google-genai SDK が直接接続。`+ :streamGenerateContent`、`GET /v1beta/models`)
 - `GET /v1/models` — 検出可能なモデル カタログ (`litellm.model_cost` からの 100 以上のモデル)
 - `GET/PUT/DELETE /v1/providers/{provider}` — 暗号化されたプロバイダー キーを設定 / リスト / 取り消し
 - `GET/PUT /v1/routing` — 戦略の変更 (`バランス` / `最安` / `最速` / `品質`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← served from cache, no upstream call
 
 ### 統合
 
-[Continue.dev](./integrations/ continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel AI] のドロップイン構成SDK](./integrations/vercel_ai.ts)、および OpenAI Chat Completions プロトコルを使用するツール。 [`integrations/`](./integrations/) を参照してください。
+[Claude Code](./integrations/claude-code.md)、[Gemini SDK](./integrations/gemini-sdk.md)、[Continue.dev](./integrations/ continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel AI] のドロップイン構成SDK](./integrations/vercel_ai.ts)、および OpenAI Chat Completions プロトコルを使用するツール — さらにネイティブの Anthropic および Gemini ワイヤー フォーマットにも対応します。 [`integrations/`](./integrations/) を参照してください。
 
 ## 意図的にそうでないもの
 
@@ -244,7 +268,7 @@ x-orca-cache: HIT          ← served from cache, no upstream call
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 |スライス |テスト |何を |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. ホストのステータス | 7 | `/v1/hosted` 設定ソース + サインアップ URL 表面 |
 | 17. ホスト型自動節約 | 3 |合成カタログの「_hosted_auto_ Savings」エッジケース |
 | 18. 到達不可能なモデル | 7 |ホストがオンになっていると「アクセスできないモデル」タイルが消去される |
-| **合計** | **127** | |
+| 19. マルチプロトコル認証 | 6 |x-api-key / x-goog-api-key / ?key= のスコープ、/v1beta ガード、プロトコルごとの 401 エンベロープ |
+| 20. Anthropic `/v1/messages` | 53 |リクエスト/レスポンス/ストリームの変換 + イングレス統合 |
+| 21. Gemini `/v1beta` | 40 |schema-enum 正規化を含む変換 + generateContent/ストリーム イングレス |
+| **合計** | **403** | |
+
+スライス行は各スライスの出荷時に追加されたテストを示します。合計は現在の完全なテスト スイートです。
 
 ＃＃ 建築
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -5,7 +5,7 @@ OpenAI 호환. BYOK. 단일 작업 공간. 스트리밍. `모델="자동"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![테스트](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![테스트](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![모델](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![라이센스](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## 네이티브 프로토콜 엔드포인트(Anthropic + Gemini)
+
+Lite는 하나의 라우팅 파이프라인에 대해 세 가지 수신 프로토콜을 말합니다. Anthropic 또는 Gemini 와이어 형식만 말하는 클라이언트도 직접 연결됩니다. OpenAI SDK가 필요하지 않습니다:
+
+```bash
+# Claude Code, pointed at Lite (no /v1 suffix in the base URL)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK, pointed at Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+요청은 에지에서 동일한 내부 파이프라인으로 변환되므로 `model="auto"`, 교차 제공자 프롬프트 캐시(프로토콜 간 공유), 라우팅 전략, 분석 대시보드가 모두 동일하게 작동합니다. 가이드: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md)를 참조하세요.
+
 ## 모델 카탈로그
 
 시작 시 [LiteLLM의 커뮤니티에서 유지 관리하는 가격 데이터베이스](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json)에서 100개 이상의 채팅 모델이 로드됩니다. 수동으로 유지 관리할 모델 목록이 없습니다. 각 항목은 다음을 노출합니다.
@@ -194,6 +216,8 @@ for chunk in client.chat.completions.create(
 ## 상자 안에 무엇이 들어있나요?
 
 - `POST /v1/chat/completions` — 프록시 + 스트리밍 + `model="auto"` + 교차 제공자 프롬프트 캐시
+- `POST /v1/messages` — **Anthropic Messages API 인그레스**(Claude Code / Anthropic SDK가 직접 연결, `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **Gemini API 인그레스**(google-genai SDK가 직접 연결, `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET /v1/models` — 검색 가능한 모델 카탈로그(`litellm.model_cost`의 100개 이상의 모델)
 - `GET/PUT/DELETE /v1/providers/{provider}` — 암호화된 공급자 키 설정/목록/해지
 - `GET/PUT /v1/routing` — 전략 변경(`균형` / `가장 저렴함` / `가장 빠름` / `품질`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← served from cache, no upstream call
 
 ### 통합
 
-[Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI에 대한 드롭인 구성 SDK](./integrations/vercel_ai.ts) 및 OpenAI Chat Completions 프로토콜을 말하는 모든 도구입니다. [`통합/`](./integrations/)을 참조하세요.
+[Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI에 대한 드롭인 구성 SDK](./integrations/vercel_ai.ts) 및 OpenAI Chat Completions 프로토콜을 말하는 모든 도구입니다 — 여기에 네이티브 Anthropic 및 Gemini 와이어 형식도 추가됩니다. [`통합/`](./integrations/)을 참조하세요.
 
 ## 고의로 하지 않은 것
 
@@ -244,7 +268,7 @@ x-orca-cache: HIT          ← served from cache, no upstream call
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | 슬라이스 | 테스트 | 무엇 |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. 호스팅 상태 | 7 | `/v1/hosted` config-source + signup-URL 표면 |
 | 17. 호스팅 자동 절약 | 3 | 합성 카탈로그의 `_hosted_auto_savings` 극단적인 경우 |
 | 18. 연결할 수 없는 모델 | 7 | 호스팅이 켜져 있으면 "접근할 수 없는 모델" 타일이 지워집니다 |
-| **합계** | **127** | |
+| 19. 다중 프로토콜 인증 | 6 | x-api-key / x-goog-api-key / ?key= 범위 지정, /v1beta 가드, 프로토콜별 401 봉투 |
+| 20. Anthropic `/v1/messages` | 53 | 요청/응답/스트림 변환 + 인그레스 통합 |
+| 21. Gemini `/v1beta` | 40 | schema-enum 정규화를 포함한 변환 + generateContent/스트림 인그레스 |
+| **합계** | **403** | |
+
+슬라이스 행은 각 슬라이스가 출시될 때 추가된 테스트를 보여줍니다. 합계는 현재 전체 테스트 스위트입니다.
 
 ## 건축학
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ OpenAI-compatible. BYOK. Single-workspace. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,34 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Native protocol endpoints (Anthropic + Gemini)
+
+Lite speaks three inbound protocols against one routing pipeline. Clients that
+only talk Anthropic or Gemini wire formats connect directly — no OpenAI SDK
+required:
+
+```bash
+# Claude Code, pointed at Lite (no /v1 suffix in the base URL)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK, pointed at Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Requests are translated at the edge into the same internal pipeline, so
+`model="auto"`, the cross-provider prompt cache (shared across protocols),
+routing strategies, and the analytics dashboard all work identically. Guides:
+[integrations/claude-code.md](./integrations/claude-code.md),
+[integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Model catalog
 
 100+ chat models are loaded at startup from [LiteLLM's community-maintained pricing database](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — no model list to maintain manually. Each entry exposes:
@@ -194,6 +222,8 @@ for chunk in client.chat.completions.create(
 ## What's in the box
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cross-provider prompt cache
+- `POST /v1/messages` — **Anthropic Messages API ingress** (Claude Code / Anthropic SDKs connect directly; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **Gemini API ingress** (google-genai SDK connects directly; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — discoverable model catalog (100+ models from `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — set / list / revoke encrypted provider keys
 - `GET/PUT /v1/routing` — change strategy (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +254,7 @@ x-orca-cache: HIT          ← served from cache, no upstream call
 
 ### Integrations
 
-Drop-in configs for [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts), and any tool that speaks the OpenAI Chat Completions protocol. See [`integrations/`](./integrations/).
+Drop-in configs for [Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts), and any tool that speaks the OpenAI Chat Completions protocol — plus native Anthropic and Gemini wire formats. See [`integrations/`](./integrations/).
 
 ## What's deliberately not
 
@@ -244,7 +274,7 @@ Built test-first. Every behaviour shipped here had a failing test first.
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Tests | What |
@@ -267,7 +297,12 @@ PYTHONPATH=. pytest -v
 | 16. Hosted status | 7 | `/v1/hosted` config-source + signup-URL surface |
 | 17. Hosted-auto savings | 3 | `_hosted_auto_savings` edge cases on synthetic catalogs |
 | 18. Unreachable models | 7 | "models you can't reach" tile clears when hosted is on |
-| **Total** | **127** | |
+| 19. Multi-protocol auth | 6 | x-api-key / x-goog-api-key / ?key= scoping, /v1beta guard, per-protocol 401 envelopes |
+| 20. Anthropic `/v1/messages` | 53 | request/response/stream translation + ingress integration |
+| 21. Gemini `/v1beta` | 40 | translation incl. schema-enum normalization + generateContent/stream ingress |
+| **Total** | **403** | |
+
+Slice rows show the tests added when each slice shipped; the total is the current full suite.
 
 ## Architecture
 

--- a/README.pt.md
+++ b/README.pt.md
@@ -5,7 +5,7 @@ Compatível com OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Endpoints de protocolo nativos (Anthropic + Gemini)
+
+O Lite fala três protocolos de entrada sobre um único pipeline de roteamento. Clientes que só falam os wire formats da Anthropic ou do Gemini se conectam diretamente — sem necessidade de SDK OpenAI:
+
+```bash
+# Claude Code, apontado para o Lite (sem o sufixo /v1 na URL base)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# SDK google-genai, apontado para o Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+As requisições são traduzidas na borda para o mesmo pipeline interno, então `model="auto"`, o cache de prompt cross-provider (compartilhado entre protocolos), as estratégias de roteamento e o dashboard de analytics funcionam de forma idêntica. Guias: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Catálogo de modelos
 
 Mais de 100 modelos de chat são carregados na inicialização a partir do [banco de preços mantido pela comunidade do LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — sem lista de modelos para manter manualmente. Cada entrada expõe:
@@ -194,6 +216,8 @@ Mais de 100 modelos de chat são carregados na inicialização a partir do [banc
 ## O que vem na caixa
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache de prompt cross-provider
+- `POST /v1/messages` — **ingress da Anthropic Messages API** (Claude Code / SDKs Anthropic se conectam diretamente; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ingress da Gemini API** (o SDK google-genai se conecta diretamente; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — catálogo de modelos descobrível (100+ modelos de `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — define / lista / revoga chaves de provider criptografadas
 - `GET/PUT /v1/routing` — muda a estratégia (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← servido do cache, sem chamada upstream
 
 ### Integrações
 
-Configurações drop-in para [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualquer ferramenta que fale o protocolo OpenAI Chat Completions. Veja [`integrations/`](./integrations/).
+Configurações drop-in para [Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) e qualquer ferramenta que fale o protocolo OpenAI Chat Completions — além dos wire formats nativos da Anthropic e do Gemini. Veja [`integrations/`](./integrations/).
 
 ## O que deliberadamente não tem
 
@@ -244,7 +268,7 @@ Construído test-first. Cada comportamento entregue aqui teve antes um teste fal
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Testes | O quê |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Status do hospedado | 7 | `/v1/hosted` config-source + superfície da URL de signup |
 | 17. Economias hosted-auto | 3 | edge cases de `_hosted_auto_savings` em catálogos sintéticos |
 | 18. Modelos inalcançáveis | 7 | o tile "modelos que você não pode alcançar" se esvazia quando hosted está ligado |
-| **Total** | **127** | |
+| 19. Auth multi-protocolo | 6 | scoping de x-api-key / x-goog-api-key / ?key=, guard do /v1beta, envelopes 401 por protocolo |
+| 20. Anthropic `/v1/messages` | 53 | tradução de request/response/stream + integração do ingress |
+| 21. Gemini `/v1beta` | 40 | tradução incl. normalização de schema-enum + ingress de generateContent/stream |
+| **Total** | **403** | |
+
+As linhas de slice mostram os testes adicionados quando cada slice foi entregue; o total é a suíte completa atual.
 
 ## Arquitetura
 

--- a/README.ru.md
+++ b/README.ru.md
@@ -5,7 +5,7 @@ OpenAI-совместимый. BYOK. Один рабочий пространс�
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Нативные протокольные эндпоинты (Anthropic + Gemini)
+
+Lite говорит на трёх входящих протоколах поверх одного пайплайна маршрутизации. Клиенты, которые говорят только на wire-форматах Anthropic или Gemini, подключаются напрямую — OpenAI SDK не требуется:
+
+```bash
+# Claude Code, направленный на Lite (без суффикса /v1 в базовом URL)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK, направленный на Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Запросы транслируются на входе в тот же внутренний пайплайн, поэтому `model="auto"`, кросс-провайдерный кэш промптов (общий для всех протоколов), стратегии маршрутизации и аналитический дашборд работают одинаково. Гайды: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Каталог моделей
 
 При старте загружается более 100 чат-моделей из [community-поддерживаемой базы цен LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — никакого списка моделей вручную. Каждая запись содержит:
@@ -194,6 +216,8 @@ for chunk in client.chat.completions.create(
 ## Что в коробке
 
 - `POST /v1/chat/completions` — proxy + стриминг + `model="auto"` + кросс-провайдерный кэш промптов
+- `POST /v1/messages` — **ingress для Anthropic Messages API** (Claude Code / Anthropic SDK подключаются напрямую; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ingress для Gemini API** (google-genai SDK подключается напрямую; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — обнаруживаемый каталог моделей (100+ моделей из `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — установка / список / отзыв зашифрованных ключей провайдеров
 - `GET/PUT /v1/routing` — смена стратегии (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← из кэша, без запроса к upstream
 
 ### Интеграции
 
-Готовые конфиги для [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) и любого инструмента, говорящего на протоколе OpenAI Chat Completions. См. [`integrations/`](./integrations/).
+Готовые конфиги для [Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) и любого инструмента, говорящего на протоколе OpenAI Chat Completions, — плюс нативные wire-форматы Anthropic и Gemini. См. [`integrations/`](./integrations/).
 
 ## Чего намеренно нет
 
@@ -244,7 +268,7 @@ x-orca-cache: HIT          ← из кэша, без запроса к upstream
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Слайс | Тесты | Что |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Hosted-статус | 7 | `/v1/hosted` config-source + signup-URL surface |
 | 17. Hosted-auto-экономия | 3 | edge cases `_hosted_auto_savings` на синтетических каталогах |
 | 18. Недоступные модели | 7 | плитка «модели, до которых вы не дотянетесь» очищается, когда hosted включён |
-| **Всего** | **127** | |
+| 19. Мульти-протокольная аутентификация | 6 | скоупинг x-api-key / x-goog-api-key / ?key=, guard для /v1beta, 401-конверты для каждого протокола |
+| 20. Anthropic `/v1/messages` | 53 | трансляция request/response/stream + ingress-интеграция |
+| 21. Gemini `/v1beta` | 40 | трансляция, вкл. нормализацию schema-enum + ingress для generateContent/stream |
+| **Всего** | **403** | |
+
+Строки слайсов показывают тесты, добавленные при выпуске каждого слайса; итог — текущий полный набор тестов.
 
 ## Архитектура
 

--- a/README.vi.md
+++ b/README.vi.md
@@ -5,7 +5,7 @@ Tương thích OpenAI. BYOK. Workspace đơn. Streaming. `model="auto"`.
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## Các endpoint giao thức native (Anthropic + Gemini)
+
+Lite nói ba giao thức đầu vào trên cùng một pipeline định tuyến. Các client chỉ nói định dạng wire của Anthropic hoặc Gemini có thể kết nối trực tiếp — không cần OpenAI SDK:
+
+```bash
+# Claude Code trỏ vào Lite (URL gốc không có hậu tố /v1)
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK trỏ vào Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+Request được chuyển đổi ngay ở biên vào cùng một pipeline nội bộ, nên `model="auto"`, cache prompt liên-provider (dùng chung giữa các giao thức), các chiến lược định tuyến và dashboard analytics đều hoạt động y hệt nhau. Hướng dẫn: [integrations/claude-code.md](./integrations/claude-code.md), [integrations/gemini-sdk.md](./integrations/gemini-sdk.md).
+
 ## Danh mục mô hình
 
 Hơn 100 mô hình chat được nạp khi khởi động từ [cơ sở dữ liệu giá do cộng đồng duy trì của LiteLLM](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) — không có danh sách mô hình nào phải bảo trì thủ công. Mỗi mục cung cấp:
@@ -194,6 +216,8 @@ Hơn 100 mô hình chat được nạp khi khởi động từ [cơ sở dữ li
 ## Có gì trong hộp
 
 - `POST /v1/chat/completions` — proxy + streaming + `model="auto"` + cache prompt liên-provider
+- `POST /v1/messages` — **ngõ vào Anthropic Messages API** (Claude Code / các Anthropic SDK kết nối trực tiếp; `+ /count_tokens`)
+- `POST /v1beta/models/{model}:generateContent` — **ngõ vào Gemini API** (google-genai SDK kết nối trực tiếp; `+ :streamGenerateContent`, `GET /v1beta/models`)
 - `GET  /v1/models` — danh mục mô hình có thể khám phá (100+ mô hình từ `litellm.model_cost`)
 - `GET/PUT/DELETE /v1/providers/{provider}` — đặt / liệt kê / thu hồi khoá provider được mã hoá
 - `GET/PUT /v1/routing` — đổi chiến lược (`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← phục vụ từ cache, không gọi upstream
 
 ### Tích hợp
 
-Cấu hình drop-in cho [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) và bất kỳ công cụ nào nói giao thức OpenAI Chat Completions. Xem [`integrations/`](./integrations/).
+Cấu hình drop-in cho [Claude Code](./integrations/claude-code.md), [Gemini SDK](./integrations/gemini-sdk.md), [Continue.dev](./integrations/continue.json), [Aider](./integrations/aider.md), [Cursor](./integrations/cursor.md), [LangChain](./integrations/langchain_orcarouter.py), [LlamaIndex](./integrations/llamaindex_orcarouter.py), [Vercel AI SDK](./integrations/vercel_ai.ts) và bất kỳ công cụ nào nói giao thức OpenAI Chat Completions — cộng thêm các định dạng wire native của Anthropic và Gemini. Xem [`integrations/`](./integrations/).
 
 ## Những gì cố ý không có
 
@@ -244,7 +268,7 @@ Xây dựng theo test-first. Mỗi hành vi giao ở đây đều có một test
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | Slice | Tests | Cái gì |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. Trạng thái hosted | 7 | `/v1/hosted` config-source + bề mặt URL signup |
 | 17. Tiết kiệm hosted-auto | 3 | trường hợp biên `_hosted_auto_savings` trên catalog tổng hợp |
 | 18. Mô hình không tới được | 7 | tile "mô hình bạn không tới được" rỗng khi hosted bật |
-| **Tổng** | **127** | |
+| 19. Auth đa giao thức | 6 | scoping x-api-key / x-goog-api-key / ?key=, guard /v1beta, envelope 401 theo từng giao thức |
+| 20. Anthropic `/v1/messages` | 53 | chuyển đổi request/response/stream + tích hợp ngõ vào |
+| 21. Gemini `/v1beta` | 40 | chuyển đổi gồm cả chuẩn hoá schema-enum + ngõ vào generateContent/stream |
+| **Tổng** | **403** | |
+
+Các hàng slice hiển thị số test được thêm khi từng slice ra mắt; tổng là bộ test đầy đủ hiện tại.
 
 ## Kiến trúc
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -5,7 +5,7 @@
 
 ![OrcaRouter Lite Logo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/design/OrcaRouter%20Lite.png?raw=true)
 
-[![tests](https://img.shields.io/badge/tests-127_passing-brightgreen)](#testing)
+[![tests](https://img.shields.io/badge/tests-403_passing-brightgreen)](#testing)
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
@@ -171,6 +171,28 @@ for chunk in client.chat.completions.create(
     print(chunk.choices[0].delta.content or "", end="", flush=True)
 ```
 
+## 原生协议端点（Anthropic + Gemini）
+
+Lite 用同一条路由流水线对外支持三种入站协议。只使用 Anthropic 或 Gemini 传输格式的客户端可以直接连接 —— 无需 OpenAI SDK：
+
+```bash
+# Claude Code 指向 Lite（base URL 不带 /v1 后缀）
+export ANTHROPIC_BASE_URL=http://localhost:8000
+export ANTHROPIC_API_KEY=sk-orca-...
+claude
+```
+
+```python
+# google-genai SDK 指向 Lite
+from google import genai
+from google.genai.types import HttpOptions
+client = genai.Client(api_key="sk-orca-...",
+                      http_options=HttpOptions(base_url="http://localhost:8000"))
+client.models.generate_content(model="auto", contents="Hello!")
+```
+
+请求在边缘层被转换进同一条内部流水线，因此 `model="auto"`、跨 provider 提示缓存（跨协议共享）、路由策略和分析仪表板全都以完全相同的方式工作。指南：[integrations/claude-code.md](./integrations/claude-code.md)、[integrations/gemini-sdk.md](./integrations/gemini-sdk.md)。
+
 ## 模型目录
 
 启动时会从 [LiteLLM 社区维护的定价数据库](https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json) 加载 100+ 个聊天模型 —— 没有需要手动维护的模型清单。每条记录都包含：
@@ -194,6 +216,8 @@ for chunk in client.chat.completions.create(
 ## 盒子里都有什么
 
 - `POST /v1/chat/completions` —— 代理 + 流式传输 + `model="auto"` + 跨 provider 提示缓存
+- `POST /v1/messages` —— **Anthropic Messages API 入口**（Claude Code / Anthropic SDK 可直接连接；`+ /count_tokens`）
+- `POST /v1beta/models/{model}:generateContent` —— **Gemini API 入口**（google-genai SDK 可直接连接；`+ :streamGenerateContent`、`GET /v1beta/models`）
 - `GET  /v1/models` —— 可发现的模型目录（来自 `litellm.model_cost` 的 100+ 模型）
 - `GET/PUT/DELETE /v1/providers/{provider}` —— 设置 / 列出 / 撤销加密的 provider 密钥
 - `GET/PUT /v1/routing` —— 切换策略（`balanced` / `cheapest` / `fastest` / `quality`)
@@ -224,7 +248,7 @@ x-orca-cache: HIT          ← 来自缓存，无上游调用
 
 ### 集成
 
-为 [Continue.dev](./integrations/continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel AI SDK](./integrations/vercel_ai.ts) 以及任何使用 OpenAI Chat Completions 协议的工具提供即插即用的配置。详见 [`integrations/`](./integrations/)。
+为 [Claude Code](./integrations/claude-code.md)、[Gemini SDK](./integrations/gemini-sdk.md)、[Continue.dev](./integrations/continue.json)、[Aider](./integrations/aider.md)、[Cursor](./integrations/cursor.md)、[LangChain](./integrations/langchain_orcarouter.py)、[LlamaIndex](./integrations/llamaindex_orcarouter.py)、[Vercel AI SDK](./integrations/vercel_ai.ts) 以及任何使用 OpenAI Chat Completions 协议的工具提供即插即用的配置 —— 外加原生的 Anthropic 和 Gemini 传输格式。详见 [`integrations/`](./integrations/)。
 
 ## 刻意不做的事情
 
@@ -244,7 +268,7 @@ x-orca-cache: HIT          ← 来自缓存，无上游调用
 ```bash
 pip install -e ".[dev]"
 PYTHONPATH=. pytest -v
-# 127 passed
+# 403 passed
 ```
 
 | 切片 | 测试数 | 内容 |
@@ -267,7 +291,12 @@ PYTHONPATH=. pytest -v
 | 16. 托管状态 | 7 | `/v1/hosted` 配置来源 + 注册 URL |
 | 17. 托管自动节省 | 3 | 合成目录上的 `_hosted_auto_savings` 边界用例 |
 | 18. 不可达模型 | 7 | 当托管开启时，「你够不到的模型」磁贴会清空 |
-| **合计** | **127** | |
+| 19. 多协议鉴权 | 6 | x-api-key / x-goog-api-key / ?key= 作用域、/v1beta 守卫、按协议的 401 信封 |
+| 20. Anthropic `/v1/messages` | 53 | 请求/响应/流的转换 + 入口集成 |
+| 21. Gemini `/v1beta` | 40 | 转换（含 schema-enum 归一化）+ generateContent/流式入口 |
+| **合计** | **403** | |
+
+切片行显示的是各切片交付时新增的测试；合计是当前的完整测试套件。
 
 ## 架构
 

--- a/app/main.py
+++ b/app/main.py
@@ -54,7 +54,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         seed = await seed_initial_state(s)
         if seed.created and seed.api_key:
             log.info("seed_complete", api_key=seed.api_key)
-            print(f"\n  ✓ orcarouter-lite ready. API key: {seed.api_key}\n")
+            try:
+                print(f"\n  ✓ orcarouter-lite ready. API key: {seed.api_key}\n")
+            except UnicodeEncodeError:
+                # Non-UTF-8 consoles (e.g. GBK-codepage Windows) can't
+                # encode "✓" — the banner must never kill startup.
+                print(f"\n  orcarouter-lite ready. API key: {seed.api_key}\n")
 
     log.info("lite_ready")
     yield
@@ -119,7 +124,9 @@ def create_app() -> FastAPI:
 
     from app.routes import (
         analytics,
+        anthropic_compat,
         chat,
+        gemini_compat,
         health,
         hosted,
         keys,
@@ -132,6 +139,8 @@ def create_app() -> FastAPI:
     app.include_router(health.router)
     app.include_router(providers.router)
     app.include_router(chat.router)
+    app.include_router(anthropic_compat.router)
+    app.include_router(gemini_compat.router)
     app.include_router(analytics.router)
     app.include_router(models.router)
     app.include_router(keys.router)

--- a/app/main.py
+++ b/app/main.py
@@ -11,9 +11,10 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 import structlog
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 
 @asynccontextmanager
@@ -76,8 +77,34 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
 
-    @app.exception_handler(HTTPException)
-    async def http_exc_handler(_req, exc: HTTPException):
+    def _native_error(request, status: int, message: str) -> JSONResponse | None:
+        """The native surfaces promise their own error envelope on every
+        non-200. Failures that never reach a route body — an unknown
+        /v1beta path, a 405 on GET /v1/messages, a validation error on a
+        native route — land in these app-wide handlers, so they must speak
+        the caller's protocol too (same signals the auth middleware uses)."""
+        from app.middleware.auth import protocol_for_scope
+
+        protocol = protocol_for_scope(request.scope)
+        if protocol == "anthropic":
+            from app.protocols import anthropic as proto
+
+            return proto.error_response(status, message)
+        if protocol == "gemini":
+            from app.protocols import gemini as proto
+
+            return proto.error_response(status, message)
+        return None
+
+    # Registered on Starlette's base class: routing-level 404/405 are raised
+    # as starlette.exceptions.HTTPException, which a handler keyed on the
+    # FastAPI subclass never sees (they would fall to Starlette's bare
+    # {"detail": ...} body — neither envelope).
+    @app.exception_handler(StarletteHTTPException)
+    async def http_exc_handler(request, exc: StarletteHTTPException):
+        native = _native_error(request, exc.status_code, str(exc.detail))
+        if native is not None:
+            return native
         type_map = {
             401: "auth_error",
             403: "forbidden",
@@ -97,17 +124,23 @@ def create_app() -> FastAPI:
         )
 
     @app.exception_handler(RequestValidationError)
-    async def val_exc_handler(_req, exc: RequestValidationError):
+    async def val_exc_handler(request, exc: RequestValidationError):
         msg = "; ".join(
             f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()
         )
+        native = _native_error(request, 422, msg)
+        if native is not None:
+            return native
         return JSONResponse(
             status_code=422,
             content={"error": {"message": msg, "type": "validation_error"}},
         )
 
     @app.exception_handler(Exception)
-    async def unhandled(_req, exc: Exception):
+    async def unhandled(request, exc: Exception):
+        native = _native_error(request, 500, "Internal server error")
+        if native is not None:
+            return native
         return JSONResponse(
             status_code=500,
             content={

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -53,7 +53,11 @@ def _is_static(path: str) -> bool:
 def _get_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str:
     for k, v in headers:
         if k == name:
-            return v.decode()
+            # Lenient decode: a raw non-UTF-8 byte in a credential header is
+            # an unauthenticated, remotely reachable input — it must end as
+            # a clean 401 for a key that can never validate, not as an
+            # unhandled 500 out of the middleware.
+            return v.decode("utf-8", "replace")
     return ""
 
 
@@ -97,7 +101,7 @@ _ANTHROPIC_ERROR_TYPES = {401: "authentication_error", 403: "permission_error"}
 _GOOGLE_STATUSES = {401: "UNAUTHENTICATED", 403: "PERMISSION_DENIED", 503: "UNAVAILABLE"}
 
 
-def _protocol_for(scope) -> str:
+def protocol_for_scope(scope) -> str:
     """Which error envelope the caller's SDK parses: "anthropic" for the
     /v1/messages surface AND for any request carrying `anthropic-version`
     (the Anthropic SDK / Claude Code always send it — that is how
@@ -135,7 +139,7 @@ def _error_payload(protocol: str, status: int, message: str, error_type: str) ->
 
 
 async def _send_error(send, scope, status: int, message: str, error_type: str) -> None:
-    body = _error_payload(_protocol_for(scope), status, message, error_type)
+    body = _error_payload(protocol_for_scope(scope), status, message, error_type)
     await send({
         "type": "http.response.start",
         "status": status,

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -97,9 +97,23 @@ _ANTHROPIC_ERROR_TYPES = {401: "authentication_error", 403: "permission_error"}
 _GOOGLE_STATUSES = {401: "UNAUTHENTICATED", 403: "PERMISSION_DENIED", 503: "UNAVAILABLE"}
 
 
-def _error_payload(path: str, status: int, message: str, error_type: str) -> bytes:
+def _protocol_for(scope) -> str:
+    """Which error envelope the caller's SDK parses: "anthropic" for the
+    /v1/messages surface AND for any request carrying `anthropic-version`
+    (the Anthropic SDK / Claude Code always send it — that is how
+    GET /v1/models serves them the Anthropic listing, so its auth failures
+    must speak the same envelope), "gemini" for /v1beta/, else "openai"."""
+    path = scope.get("path", "")
+    if path.startswith("/v1/messages") or _get_header(scope.get("headers", []), b"anthropic-version"):
+        return "anthropic"
+    if path.startswith("/v1beta/"):
+        return "gemini"
+    return "openai"
+
+
+def _error_payload(protocol: str, status: int, message: str, error_type: str) -> bytes:
     """Render the auth error in the envelope the caller's SDK expects."""
-    if path.startswith("/v1/messages"):
+    if protocol == "anthropic":
         body: dict = {
             "type": "error",
             "error": {
@@ -107,7 +121,7 @@ def _error_payload(path: str, status: int, message: str, error_type: str) -> byt
                 "message": message,
             },
         }
-    elif path.startswith("/v1beta/"):
+    elif protocol == "gemini":
         body = {
             "error": {
                 "code": status,
@@ -120,8 +134,8 @@ def _error_payload(path: str, status: int, message: str, error_type: str) -> byt
     return json.dumps(body).encode()
 
 
-async def _send_error(send, path: str, status: int, message: str, error_type: str) -> None:
-    body = _error_payload(path, status, message, error_type)
+async def _send_error(send, scope, status: int, message: str, error_type: str) -> None:
+    body = _error_payload(_protocol_for(scope), status, message, error_type)
     await send({
         "type": "http.response.start",
         "status": status,
@@ -150,7 +164,7 @@ class AuthMiddleware:
         candidates = _extract_credentials(scope)
         if not candidates:
             await _send_error(
-                send, path, 401,
+                send, scope, 401,
                 "Missing or invalid API key. Send it as 'Authorization: Bearer', "
                 "'x-api-key', or 'x-goog-api-key'.",
                 "auth_error",
@@ -184,13 +198,13 @@ class AuthMiddleware:
                     except AuthError as e:
                         auth_error = e
         except Exception:
-            await _send_error(send, path, 503, "Service temporarily unavailable", "server_error")
+            await _send_error(send, scope, 503, "Service temporarily unavailable", "server_error")
             return
 
         if key_context is None:
             status = auth_error.status_code if auth_error else 401
             message = auth_error.message if auth_error else "Invalid API key"
-            await _send_error(send, path, status, message, "auth_error")
+            await _send_error(send, scope, status, message, "auth_error")
             return
         scope.setdefault("state", {})["key_context"] = key_context
         scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -1,14 +1,23 @@
-"""Auth middleware — bearer-token validation against the api_keys table.
+"""Auth middleware — API-key validation against the api_keys table.
 
 Single-tenant edition: drops the SaaS middleware's session-token branch,
 admin lookup, and per-IP fail-closed throttle. The brute-force surface
 is the operator's own machine, so the throttle would block legitimate
 local development for no security benefit.
+
+Native-protocol support: the same sk-orca-* key is accepted from every
+location the major SDKs put credentials in — `Authorization: Bearer`
+(OpenAI SDKs, Claude Code's ANTHROPIC_AUTH_TOKEN), `x-api-key`
+(Anthropic SDK / Claude Code), `x-goog-api-key` (google-genai SDK), and
+`?key=` (legacy google-generativeai style; scoped to /v1beta/ so
+credentials stay out of URLs everywhere else). Auth failures render in
+the error envelope the caller's SDK expects (see `_error_payload`).
 """
 
 from __future__ import annotations
 
 import json
+from urllib.parse import parse_qs
 
 from packages.auth.key_validator import AuthError, validate_api_key
 from packages.db import session as session_mod
@@ -24,6 +33,12 @@ SKIP_AUTH_PATHS: set[str] = {
 
 SKIP_AUTH_PREFIXES: tuple[str, ...] = ("/static",)
 
+# Prefixes that REQUIRE auth; anything else (outside the public allowlist)
+# is static-SPA territory. NOTE: "/v1/" does NOT match "/v1beta/..." — the
+# Gemini surface needs its own entry or it would be waved through as
+# "static" with no credential check at all.
+GUARDED_PREFIXES: tuple[str, ...] = ("/api/", "/v1/", "/v1beta/")
+
 
 def _is_public(path: str) -> bool:
     if path in SKIP_AUTH_PATHS:
@@ -32,7 +47,7 @@ def _is_public(path: str) -> bool:
 
 
 def _is_static(path: str) -> bool:
-    return not (path.startswith("/api/") or path.startswith("/v1/"))
+    return not any(path.startswith(p) for p in GUARDED_PREFIXES)
 
 
 def _get_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str:
@@ -42,8 +57,58 @@ def _get_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str:
     return ""
 
 
-async def _send_error(send, status: int, message: str, error_type: str) -> None:
-    body = json.dumps({"error": {"message": message, "type": error_type}}).encode()
+def _extract_credential(scope) -> str | None:
+    """Pull the sk-orca-* key from wherever the client's SDK put it.
+
+    Precedence: `Authorization: Bearer` → `x-api-key` → `x-goog-api-key`
+    → `?key=` (the query-param form only on /v1beta/ paths, matching the
+    legacy Google SDK that uses it, so credentials-in-URL stays contained).
+    """
+    headers = scope.get("headers", [])
+    auth_header = _get_header(headers, b"authorization")
+    if auth_header.startswith("Bearer "):
+        return auth_header[7:] or None
+    for name in (b"x-api-key", b"x-goog-api-key"):
+        val = _get_header(headers, name)
+        if val:
+            return val
+    if scope.get("path", "").startswith("/v1beta/"):
+        qs = parse_qs(scope.get("query_string", b"").decode("latin-1"))
+        vals = qs.get("key")
+        if vals and vals[0]:
+            return vals[0]
+    return None
+
+
+_ANTHROPIC_ERROR_TYPES = {401: "authentication_error", 403: "permission_error"}
+_GOOGLE_STATUSES = {401: "UNAUTHENTICATED", 403: "PERMISSION_DENIED", 503: "UNAVAILABLE"}
+
+
+def _error_payload(path: str, status: int, message: str, error_type: str) -> bytes:
+    """Render the auth error in the envelope the caller's SDK expects."""
+    if path.startswith("/v1/messages"):
+        body: dict = {
+            "type": "error",
+            "error": {
+                "type": _ANTHROPIC_ERROR_TYPES.get(status, "api_error"),
+                "message": message,
+            },
+        }
+    elif path.startswith("/v1beta/"):
+        body = {
+            "error": {
+                "code": status,
+                "message": message,
+                "status": _GOOGLE_STATUSES.get(status, "INTERNAL"),
+            }
+        }
+    else:
+        body = {"error": {"message": message, "type": error_type}}
+    return json.dumps(body).encode()
+
+
+async def _send_error(send, path: str, status: int, message: str, error_type: str) -> None:
+    body = _error_payload(path, status, message, error_type)
     await send({
         "type": "http.response.start",
         "status": status,
@@ -69,12 +134,15 @@ class AuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        auth_header = _get_header(scope.get("headers", []), b"authorization")
-        if not auth_header.startswith("Bearer "):
-            await _send_error(send, 401, "Missing or invalid Authorization header", "auth_error")
+        raw_key = _extract_credential(scope)
+        if not raw_key:
+            await _send_error(
+                send, path, 401,
+                "Missing or invalid API key. Send it as 'Authorization: Bearer', "
+                "'x-api-key', or 'x-goog-api-key'.",
+                "auth_error",
+            )
             return
-
-        raw_key = auth_header[7:]
 
         # Use the session factory directly with `async with` so the
         # session is GUARANTEED to close on every exit path (success,
@@ -92,10 +160,10 @@ class AuthMiddleware:
             scope.setdefault("state", {})["key_context"] = key_context
             scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id
         except AuthError as e:
-            await _send_error(send, e.status_code, e.message, "auth_error")
+            await _send_error(send, path, e.status_code, e.message, "auth_error")
             return
         except Exception:
-            await _send_error(send, 503, "Service temporarily unavailable", "server_error")
+            await _send_error(send, path, 503, "Service temporarily unavailable", "server_error")
             return
 
         await self.app(scope, receive, send)

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -63,11 +63,13 @@ def _extract_credential(scope) -> str | None:
     Precedence: `Authorization: Bearer` → `x-api-key` → `x-goog-api-key`
     → `?key=` (the query-param form only on /v1beta/ paths, matching the
     legacy Google SDK that uses it, so credentials-in-URL stays contained).
+    An empty Bearer token (e.g. a proxy that blanks the header) falls
+    through to the other locations instead of short-circuiting the chain.
     """
     headers = scope.get("headers", [])
     auth_header = _get_header(headers, b"authorization")
-    if auth_header.startswith("Bearer "):
-        return auth_header[7:] or None
+    if auth_header.startswith("Bearer ") and auth_header[7:]:
+        return auth_header[7:]
     for name in (b"x-api-key", b"x-goog-api-key"):
         val = _get_header(headers, name)
         if val:

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -103,15 +103,26 @@ _GOOGLE_STATUSES = {401: "UNAUTHENTICATED", 403: "PERMISSION_DENIED", 503: "UNAV
 
 def protocol_for_scope(scope) -> str:
     """Which error envelope the caller's SDK parses: "anthropic" for the
-    /v1/messages surface AND for any request carrying `anthropic-version`
-    (the Anthropic SDK / Claude Code always send it — that is how
-    GET /v1/models serves them the Anthropic listing, so its auth failures
-    must speak the same envelope), "gemini" for /v1beta/, else "openai"."""
+    /v1/messages surface, "gemini" for /v1beta/, else "openai".
+
+    A request carrying `anthropic-version` (the Anthropic SDK and Claude
+    Code always send it) also gets the Anthropic envelope — that is how
+    GET /v1/models serves them the Anthropic listing, so its failures must
+    speak the same language. The header signal is scoped to /v1 paths
+    OTHER than /v1/chat/completions: an OpenAI-surface caller that happens
+    to send the header must keep the OpenAI envelope and its statuses, and
+    the dashboard/admin routes under /api are never rewritten."""
     path = scope.get("path", "")
-    if path.startswith("/v1/messages") or _get_header(scope.get("headers", []), b"anthropic-version"):
+    if path.startswith("/v1/messages"):
         return "anthropic"
     if path.startswith("/v1beta/"):
         return "gemini"
+    if (
+        path.startswith("/v1/")
+        and not path.startswith("/v1/chat/completions")
+        and _get_header(scope.get("headers", []), b"anthropic-version")
+    ):
+        return "anthropic"
     return "openai"
 
 

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -57,29 +57,40 @@ def _get_header(headers: list[tuple[bytes, bytes]], name: bytes) -> str:
     return ""
 
 
-def _extract_credential(scope) -> str | None:
-    """Pull the sk-orca-* key from wherever the client's SDK put it.
+def _extract_credentials(scope) -> list[str]:
+    """Collect the candidate sk-orca-* keys the client's SDK may have
+    sent, in precedence order, deduped.
 
-    Precedence: `Authorization: Bearer` → `x-api-key` → `x-goog-api-key`
-    → `?key=` (the query-param form only on /v1beta/ paths, matching the
-    legacy Google SDK that uses it, so credentials-in-URL stays contained).
-    An empty Bearer token (e.g. a proxy that blanks the header) falls
-    through to the other locations instead of short-circuiting the chain.
+    Order: `Authorization: Bearer` → `x-api-key` → `x-goog-api-key` →
+    `?key=` (the query-param form only on /v1beta/ paths, matching the
+    legacy Google SDK that uses it, so credentials-in-URL stays
+    contained).
+
+    Every location is a CANDIDATE, not a commitment. The caller controls
+    which header its SDK fills, but a reverse proxy or SSO gateway in
+    front of it may add an `Authorization` header of its own — blank, or
+    carrying the gateway's own token. Returning only the first location
+    found would 401 those requests even though the caller's real key is
+    sitting in `x-api-key`, so the middleware tries each in turn.
     """
     headers = scope.get("headers", [])
+    candidates: list[str] = []
+
+    def _add(value: str) -> None:
+        if value and value not in candidates:
+            candidates.append(value)
+
     auth_header = _get_header(headers, b"authorization")
-    if auth_header.startswith("Bearer ") and auth_header[7:]:
-        return auth_header[7:]
+    if auth_header.startswith("Bearer "):
+        _add(auth_header[7:])
     for name in (b"x-api-key", b"x-goog-api-key"):
-        val = _get_header(headers, name)
-        if val:
-            return val
+        _add(_get_header(headers, name))
     if scope.get("path", "").startswith("/v1beta/"):
         qs = parse_qs(scope.get("query_string", b"").decode("latin-1"))
         vals = qs.get("key")
-        if vals and vals[0]:
-            return vals[0]
-    return None
+        if vals:
+            _add(vals[0])
+    return candidates
 
 
 _ANTHROPIC_ERROR_TYPES = {401: "authentication_error", 403: "permission_error"}
@@ -136,8 +147,8 @@ class AuthMiddleware:
             await self.app(scope, receive, send)
             return
 
-        raw_key = _extract_credential(scope)
-        if not raw_key:
+        candidates = _extract_credentials(scope)
+        if not candidates:
             await _send_error(
                 send, path, 401,
                 "Missing or invalid API key. Send it as 'Authorization: Bearer', "
@@ -156,16 +167,32 @@ class AuthMiddleware:
         if session_mod._session_factory is None:
             from app.config import get_settings
             session_mod.init_session_factory(get_settings().database_url)
+        key_context = None
+        auth_error: AuthError | None = None
         try:
             async with session_mod._session_factory() as session:
-                key_context = await validate_api_key(raw_key, session)
-            scope.setdefault("state", {})["key_context"] = key_context
-            scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id
-        except AuthError as e:
-            await _send_error(send, path, e.status_code, e.message, "auth_error")
-            return
+                # Try every candidate location before giving up — a
+                # rejected proxy-injected token must not mask the caller's
+                # valid key in another header. A non-AuthError (DB down,
+                # decryption failure) is infrastructure, not a bad key, so
+                # it aborts the whole chain below rather than falling
+                # through to the next candidate.
+                for raw_key in candidates:
+                    try:
+                        key_context = await validate_api_key(raw_key, session)
+                        break
+                    except AuthError as e:
+                        auth_error = e
         except Exception:
             await _send_error(send, path, 503, "Service temporarily unavailable", "server_error")
             return
+
+        if key_context is None:
+            status = auth_error.status_code if auth_error else 401
+            message = auth_error.message if auth_error else "Invalid API key"
+            await _send_error(send, path, status, message, "auth_error")
+            return
+        scope.setdefault("state", {})["key_context"] = key_context
+        scope.setdefault("state", {})["workspace_id"] = key_context.workspace_id
 
         await self.app(scope, receive, send)

--- a/app/prompt_cache.py
+++ b/app/prompt_cache.py
@@ -38,6 +38,8 @@ def cache_key(
     tool_choice: str | dict | None = None,
     top_p: float | None = None,
     n: int | None = None,
+    presence_penalty: float | None = None,
+    frequency_penalty: float | None = None,
 ) -> str:
     """Deterministic SHA-256 key over every input that shapes the output.
 
@@ -66,6 +68,10 @@ def cache_key(
         "tool_choice": tool_choice,
         "top_p": top_p,
         "n": n,
+        # Both shift the logits before decoding, so they change the output
+        # even at temperature 0 — exactly when a request is cacheable.
+        "presence_penalty": presence_penalty,
+        "frequency_penalty": frequency_penalty,
     }
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()
@@ -76,16 +82,23 @@ def is_cacheable(body: dict) -> bool:
 
     - Streaming responses are skipped (caching SSE chunks correctly is more
       trouble than it's worth for v1).
-    - Non-zero temperature without an explicit seed → non-deterministic, skip.
+    - temperature == 0 → deterministic.
+    - Any other temperature, INCLUDING AN ABSENT ONE, needs an explicit
+      seed. Every upstream this proxies defaults temperature to 1.0 —
+      OpenAI, Anthropic and Gemini alike — so a request that omits it is
+      sampled, not deterministic, and caching it would replay one
+      arbitrary sample to every later caller. That is not a hypothetical
+      on the native surfaces: their translators only set temperature when
+      the wire request carried it, and Claude Code never sends one, so
+      omission is the norm there. An agent retrying an identical call
+      would keep getting the same stale answer.
     - With a seed, any temperature is fine — the seed pins the output.
     """
     if body.get("stream"):
         return False
-    temperature = body.get("temperature", 0.0) or 0.0
-    seed = body.get("seed")
-    if temperature == 0.0:
+    if body.get("temperature") == 0:
         return True
-    return seed is not None
+    return body.get("seed") is not None
 
 
 # ── Backends ──────────────────────────────────────────────────────────

--- a/app/prompt_cache.py
+++ b/app/prompt_cache.py
@@ -59,7 +59,12 @@ def cache_key(
     payload = {
         "model": model,
         "messages": messages,
-        "temperature": temperature if temperature is not None else 0.0,
+        # Keyed on the true wire value: an ABSENT temperature is not the
+        # same computation as an explicit 0. Both are cacheable when a
+        # seed pins them, but the upstream defaults an absent one to 1.0
+        # (a seeded sample) while 0 is the greedy argmax — normalizing
+        # None to 0.0 here would serve one caller the other's response.
+        "temperature": temperature,
         "tools": tools or None,
         "response_format": response_format or None,
         "seed": seed,

--- a/app/prompt_cache.py
+++ b/app/prompt_cache.py
@@ -1,9 +1,9 @@
 """Cross-provider prompt cache.
 
 LiteLLM only does prompt caching for Anthropic. This module ships an
-exact-match cache that works for any provider — same `(model, messages,
-temperature, tools, response_format, seed)` → cached response, no upstream
-call.
+exact-match cache that works for any provider — same request inputs →
+cached response, no upstream call. "Same inputs" means every parameter
+that shapes the completion (see `cache_key`), not just the prompt.
 
 Two backends, picked at startup:
   - Redis (when REDIS_URL is set) — survives restarts, works across pods.
@@ -33,8 +33,27 @@ def cache_key(
     tools: list[dict] | None,
     response_format: dict | None,
     seed: int | None,
+    max_tokens: int | None = None,
+    stop: str | list[str] | None = None,
+    tool_choice: str | dict | None = None,
+    top_p: float | None = None,
+    n: int | None = None,
 ) -> str:
-    """Deterministic SHA-256 key for the cacheable inputs."""
+    """Deterministic SHA-256 key over every input that shapes the output.
+
+    All the output-shaping parameters belong here, not just the prompt:
+    two requests that differ only in `max_tokens` (64 vs 4096), `stop`, or
+    `tool_choice` (auto vs a forced function) produce genuinely different
+    completions, so sharing one cache entry between them would serve a
+    truncated answer, or prose where the caller demanded a tool call. The
+    native Anthropic surface sends `max_tokens` on every request and both
+    native surfaces pass stop/tool_choice through, so a narrower key is
+    reachable in normal use.
+
+    `user` is deliberately excluded: it is an abuse-monitoring hint that
+    does not change the completion, and keying on it would fragment the
+    cache per caller for no correctness gain.
+    """
     payload = {
         "model": model,
         "messages": messages,
@@ -42,6 +61,11 @@ def cache_key(
         "tools": tools or None,
         "response_format": response_format or None,
         "seed": seed,
+        "max_tokens": max_tokens,
+        "stop": stop,
+        "tool_choice": tool_choice,
+        "top_p": top_p,
+        "n": n,
     }
     blob = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
     return hashlib.sha256(blob).hexdigest()

--- a/app/protocols/__init__.py
+++ b/app/protocols/__init__.py
@@ -3,7 +3,9 @@
 Each module translates its wire format to/from the internal OpenAI format
 consumed by the shared chat engine (`app.routes.chat.execute_chat`). The
 translators are pure functions / pure async transformers so they unit-test
-without an app or mocks. See PLAN-NATIVE-PROTOCOLS.md.
+without an app or mocks. Each module's docstring records its own mapping
+decisions; the caller-visible limitations are listed in
+integrations/claude-code.md and integrations/gemini-sdk.md.
 """
 
 from __future__ import annotations

--- a/app/protocols/__init__.py
+++ b/app/protocols/__init__.py
@@ -11,11 +11,31 @@ integrations/claude-code.md and integrations/gemini-sdk.md.
 from __future__ import annotations
 
 import structlog
+from fastapi import HTTPException
 
 logger = structlog.get_logger()
 
 # The OpenAI wire format caps `stop` at 4; both native surfaces accept more.
 _OPENAI_STOP_CAP = 4
+
+
+def invalid_request(message: str) -> HTTPException:
+    """A 400 in the engine's HTTPException form; each surface's route
+    renders it in that surface's native error envelope."""
+    return HTTPException(status_code=400, detail=message)
+
+
+def require_text(value, *, field: str) -> str:
+    """Coerce a wire `text` value: absent (None) is "", a string passes,
+    anything else is a native 400. Left unchecked, a non-string either
+    crashes the join that assembles the message (a 500 the SDKs retry) or
+    reaches the upstream and comes back as a retryable error — for a
+    request that can never succeed."""
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise invalid_request(f"{field} must be a string")
+    return value
 
 
 def clamp_stop_sequences(stop: list, *, event: str) -> list:

--- a/app/protocols/__init__.py
+++ b/app/protocols/__init__.py
@@ -5,3 +5,22 @@ consumed by the shared chat engine (`app.routes.chat.execute_chat`). The
 translators are pure functions / pure async transformers so they unit-test
 without an app or mocks. See PLAN-NATIVE-PROTOCOLS.md.
 """
+
+from __future__ import annotations
+
+import structlog
+
+logger = structlog.get_logger()
+
+# The OpenAI wire format caps `stop` at 4; both native surfaces accept more.
+_OPENAI_STOP_CAP = 4
+
+
+def clamp_stop_sequences(stop: list, *, event: str) -> list:
+    """Truncate stop sequences to the OpenAI wire cap of 4 (documented
+    limitation, warning logged) rather than reject a request that is valid
+    on the native surface."""
+    if len(stop) <= _OPENAI_STOP_CAP:
+        return stop
+    logger.warning(event, dropped=len(stop) - _OPENAI_STOP_CAP)
+    return stop[:_OPENAI_STOP_CAP]

--- a/app/protocols/__init__.py
+++ b/app/protocols/__init__.py
@@ -1,0 +1,7 @@
+"""Native-protocol adapters (Anthropic Messages API, Gemini generateContent).
+
+Each module translates its wire format to/from the internal OpenAI format
+consumed by the shared chat engine (`app.routes.chat.execute_chat`). The
+translators are pure functions / pure async transformers so they unit-test
+without an app or mocks. See PLAN-NATIVE-PROTOCOLS.md.
+"""

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -54,7 +54,11 @@ class AnthropicMessagesRequest(BaseModel):
 
     model: str
     messages: list[AnthropicMessage] = Field(min_length=1)
-    max_tokens: int
+    # The real API rejects max_tokens < 1 with a 400. Enforce it here or
+    # the upstream's own BadRequest comes back through the engine as a
+    # retryable 500 api_error, which SDKs back off and retry forever for
+    # a request that can never succeed.
+    max_tokens: int = Field(gt=0)
     system: str | list[dict] | None = None
     tools: list[dict] | None = None
     tool_choice: dict | None = None
@@ -345,17 +349,31 @@ def _ev(name: str, data: dict) -> str:
     return f"event: {name}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
-# Engine SSE error-frame `type` (packages/litellm_adapter/client.py
-# _translate_error) → Anthropic error taxonomy. Retry semantics matter:
-# a context overflow or missing model must not surface as a retryable
-# api_error. upstream_auth_error stays api_error — it's OUR provider
-# credential that failed, not the caller's key.
-_STREAM_ERROR_TYPE_MAP = {
-    "rate_limit_error": "rate_limit_error",
-    "overloaded_error": "overloaded_error",
-    "context_length_exceeded": "invalid_request_error",
-    "model_not_found": "not_found_error",
+# Engine error types (packages/litellm_adapter/client.py _translate_error,
+# reported on SSE error frames and via the x-orca-error-type header) → the
+# HTTP status this surface reports them as. The Anthropic error *type* is
+# then derived from the status through _STATUS_TO_ERROR_TYPE below, so the
+# streaming and blocking paths cannot drift apart.
+#
+# Retryability is the load-bearing part. Anthropic SDKs back off and retry
+# 429/500/529 but not 4xx, so a failure that can never succeed on retry
+# has to land on a 4xx: a context overflow or a missing model must not
+# read as a transient api_error. upstream_auth_error is OUR provider
+# credential failing — permanent until the operator fixes it — so it maps
+# to 403 permission_error, matching the Gemini surface. Deliberately NOT
+# 401 authentication_error: the caller's own key is fine.
+_ENGINE_ERROR_STATUS = {
+    "rate_limit_error": 429,
+    "overloaded_error": 529,
+    "context_length_exceeded": 400,
+    "model_not_found": 404,
+    "upstream_auth_error": 403,
 }
+
+
+def _anthropic_error_type(engine_type: str | None) -> str:
+    status = _ENGINE_ERROR_STATUS.get(engine_type or "", 500)
+    return _STATUS_TO_ERROR_TYPE.get(status, "api_error")
 
 
 async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None]:
@@ -406,7 +424,7 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                 yield _ev("error", {
                     "type": "error",
                     "error": {
-                        "type": _STREAM_ERROR_TYPE_MAP.get(etype, "api_error"),
+                        "type": _anthropic_error_type(etype),
                         "message": err.get("message", "Upstream provider error"),
                     },
                 })
@@ -520,13 +538,11 @@ _STATUS_TO_ERROR_TYPE = {
 def native_status(status: int, error_type: str | None) -> int:
     """Correct the engine's generic HTTP status using its translated
     error_type (relayed via the x-orca-error-type header) where the plain
-    status would misrepresent the failure on this surface: the engine uses
-    422 for model_not_found but Anthropic's contract is 404
-    not_found_error. Mirrors _STREAM_ERROR_TYPE_MAP so stream and blocking
-    agree."""
-    if error_type == "model_not_found":
-        return 404
-    return status
+    status would misrepresent the failure on this surface — e.g. the
+    engine uses 422 for model_not_found but Anthropic's contract is 404
+    not_found_error. Reads _ENGINE_ERROR_STATUS, the same table the
+    streaming path derives its error type from, so the two cannot drift."""
+    return _ENGINE_ERROR_STATUS.get(error_type or "", status)
 
 
 def error_response(status: int, message: str) -> JSONResponse:

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -31,6 +31,7 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.protocols import clamp_stop_sequences
 from app.protocols.sse import aclose_quietly
 
 logger = structlog.get_logger()
@@ -256,7 +257,9 @@ def to_openai_request(req: AnthropicMessagesRequest) -> dict:
     if req.top_p is not None:
         out["top_p"] = req.top_p
     if req.stop_sequences:
-        out["stop"] = req.stop_sequences
+        out["stop"] = clamp_stop_sequences(
+            req.stop_sequences, event="anthropic_stop_sequences_truncated"
+        )
     if req.metadata and isinstance(req.metadata.get("user_id"), str):
         out["user"] = req.metadata["user_id"]
     if req.tools is not None:
@@ -512,6 +515,18 @@ _STATUS_TO_ERROR_TYPE = {
     500: "api_error",
     529: "overloaded_error",
 }
+
+
+def native_status(status: int, error_type: str | None) -> int:
+    """Correct the engine's generic HTTP status using its translated
+    error_type (relayed via the x-orca-error-type header) where the plain
+    status would misrepresent the failure on this surface: the engine uses
+    422 for model_not_found but Anthropic's contract is 404
+    not_found_error. Mirrors _STREAM_ERROR_TYPE_MAP so stream and blocking
+    agree."""
+    if error_type == "model_not_found":
+        return 404
+    return status
 
 
 def error_response(status: int, message: str) -> JSONResponse:

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -337,6 +337,22 @@ def _parse_json_object(raw) -> dict:
     return parsed if isinstance(parsed, dict) else {}
 
 
+def flatten_openai_content(content) -> str:
+    """An OpenAI response message's `content` is normally a string, but the
+    wire format also permits the multi-part list form. Both native response
+    formats need a plain string here (Anthropic text blocks and Gemini text
+    parts are strings), so a list is flattened to its text; emitting the
+    list verbatim would put an array where the SDKs require a string."""
+    if content is None or isinstance(content, str):
+        return content or ""
+    if isinstance(content, list):
+        return "".join(
+            p.get("text", "") for p in content
+            if isinstance(p, dict) and p.get("type") == "text"
+        )
+    return str(content)
+
+
 def _message_id(raw: str | None) -> str:
     if raw and raw.startswith("msg_"):
         return raw
@@ -349,7 +365,7 @@ def to_anthropic_response(resp: dict) -> dict:
     msg = choice.get("message") or {}
 
     content: list[dict] = []
-    text = msg.get("content")
+    text = flatten_openai_content(msg.get("content"))
     if text:
         content.append({"type": "text", "text": text})
     for tc in msg.get("tool_calls") or []:

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -217,10 +217,14 @@ def _translate_user_message(blocks: list[dict]) -> list[dict]:
             })
             parts.extend(images)
         elif btype == "text":
-            parts.append({
-                "type": "text",
-                "text": require_text(block.get("text"), field="messages[].content[].text"),
-            })
+            text = require_text(block.get("text"), field="messages[].content[].text")
+            if text:
+                # An empty text block carries nothing. Keeping it would emit
+                # `{"role": "user", "content": ""}`, which upstreams reject
+                # as a BadRequest — reported back as a retryable 5xx for a
+                # request that can never succeed. A turn left with no
+                # content at all is rejected below, as `content: []` is.
+                parts.append({"type": "text", "text": text})
         elif btype == "image":
             parts.append(_image_part(block))
         elif btype in _DROPPED_BLOCK_TYPES:
@@ -258,6 +262,12 @@ def _translate_message(m: AnthropicMessage) -> list[dict]:
     if m.role not in ("user", "assistant"):
         raise _invalid(f"Unsupported message role: {m.role!r}")
     if isinstance(m.content, str):
+        if m.role == "user" and not m.content:
+            # Same rule as the block form below: the real API rejects empty
+            # user content, and forwarding it earns a retryable 5xx from the
+            # upstream. (An empty ASSISTANT turn is deliberately kept — see
+            # _translate_assistant_message.)
+            raise _invalid("user message 'content' must be non-empty")
         return [{"role": m.role, "content": m.content}]
     if m.role == "assistant":
         return [_translate_assistant_message(m.content)]
@@ -478,6 +488,13 @@ _ENGINE_ERROR_STATUS = {
     "upstream_auth_error": 403,
     "no_providers_configured": 403,
     "no_capable_provider": 403,
+    # A provider timeout is transient by definition. The Anthropic taxonomy
+    # has no 503, and the generic 5xx collapse below would render it as a
+    # 500 api_error indistinguishable from a fault in THIS server — so it
+    # takes the taxonomy's own "busy, come back" status, which SDKs retry.
+    # `upstream_error` deliberately stays generic (500 api_error): it is the
+    # bucket for failures we could not classify at all.
+    "upstream_timeout": 529,
 }
 
 

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -1,7 +1,8 @@
 """Anthropic Messages API ↔ internal OpenAI format translation.
 
-Pure functions + one pure async stream transformer. Mapping decisions are
-documented in PLAN-NATIVE-PROTOCOLS.md §3; the load-bearing ones:
+Pure functions + one pure async stream transformer. The caller-visible
+limitations are listed in integrations/claude-code.md; the load-bearing
+mapping decisions are:
 
 - `thinking` (request param and history blocks) is DROPPED with a log
   warning, never rejected — Claude Code sends it whenever extended
@@ -32,7 +33,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.protocols import clamp_stop_sequences
-from app.protocols.sse import aclose_quietly
+from app.protocols.sse import finish_quietly
 
 logger = structlog.get_logger()
 
@@ -62,9 +63,13 @@ class AnthropicMessagesRequest(BaseModel):
     system: str | list[dict] | None = None
     tools: list[dict] | None = None
     tool_choice: dict | None = None
-    temperature: float | None = None
-    top_p: float | None = None
-    top_k: int | None = None
+    # Ranges are the Anthropic API's own. Out-of-range values would be
+    # rejected by the upstream as a BadRequest, which the engine reports
+    # as a retryable 500 api_error — so bound them here, where the failure
+    # is still an honest 400 invalid_request_error.
+    temperature: float | None = Field(default=None, ge=0.0, le=1.0)
+    top_p: float | None = Field(default=None, ge=0.0, le=1.0)
+    top_k: int | None = Field(default=None, ge=0)
     stop_sequences: list[str] | None = None
     stream: bool = False
     metadata: dict | None = None
@@ -78,13 +83,24 @@ def _invalid(message: str) -> HTTPException:
 
 
 def _system_text(system: str | list[dict]) -> str:
+    """The `system` param is text-only per the Anthropic API (string or
+    text blocks). Anything else — an image block a client tucked into a
+    role:"system" message inside messages[], which this surface tolerates
+    — has no OpenAI system-message equivalent, so it is dropped with a
+    log rather than silently vanishing."""
     if isinstance(system, str):
         return system
-    parts = [
-        b.get("text", "") for b in system
-        if isinstance(b, dict) and b.get("type") == "text"
-    ]
-    return "\n\n".join(p for p in parts if p)
+    parts: list[str] = []
+    dropped = 0
+    for b in system:
+        if isinstance(b, dict) and b.get("type") == "text":
+            if b.get("text"):
+                parts.append(b["text"])
+        else:
+            dropped += 1
+    if dropped:
+        logger.warning("anthropic_non_text_system_block_dropped", count=dropped)
+    return "\n\n".join(parts)
 
 
 def _image_part(block: dict) -> dict:
@@ -101,19 +117,33 @@ def _image_part(block: dict) -> dict:
     raise _invalid(f"Unsupported image source type: {stype!r}")
 
 
-def _flatten_tool_result_content(content) -> str:
-    """tool_result.content is a string or a list of blocks — flatten to text."""
+def _split_tool_result_content(content) -> tuple[str, list[dict]]:
+    """Split tool_result.content into (text, image parts).
+
+    tool_result.content is a string or a list of text/image blocks. An
+    OpenAI `role: "tool"` message carries a plain string, so the text is
+    flattened into it and any images are handed back for the caller to
+    attach to the user message that follows the tool results — a tool
+    returning a screenshot is the common case, and dropping it would
+    silently compute the answer without context the caller supplied.
+    """
     if content is None:
-        return ""
+        return "", []
     if isinstance(content, str):
-        return content
-    if isinstance(content, list):
-        texts = [
-            b.get("text", "") for b in content
-            if isinstance(b, dict) and b.get("type") == "text"
-        ]
-        return "\n\n".join(t for t in texts if t)
-    return str(content)
+        return content, []
+    if not isinstance(content, list):
+        return str(content), []
+    texts: list[str] = []
+    images: list[dict] = []
+    for b in content:
+        if not isinstance(b, dict):
+            continue
+        if b.get("type") == "text":
+            if b.get("text"):
+                texts.append(b["text"])
+        elif b.get("type") == "image":
+            images.append(_image_part(b))
+    return "\n\n".join(texts), images
 
 
 _DROPPED_BLOCK_TYPES = {"thinking", "redacted_thinking"}
@@ -155,17 +185,21 @@ def _translate_assistant_message(blocks: list[dict]) -> dict:
 def _translate_user_message(blocks: list[dict]) -> list[dict]:
     """One Anthropic user message may carry tool_result blocks plus regular
     content. OpenAI needs the tool results as their own `role: "tool"`
-    messages (first), then the remaining content as a user message."""
+    messages (first), then the remaining content as a user message —
+    which is also where images returned by a tool end up, since an OpenAI
+    tool message can only hold text."""
     tool_messages: list[dict] = []
     parts: list[dict] = []
     for block in blocks:
         btype = block.get("type")
         if btype == "tool_result":
+            text, images = _split_tool_result_content(block.get("content"))
             tool_messages.append({
                 "role": "tool",
                 "tool_call_id": block.get("tool_use_id", ""),
-                "content": _flatten_tool_result_content(block.get("content")),
+                "content": text,
             })
+            parts.extend(images)
         elif btype == "text":
             parts.append({"type": "text", "text": block.get("text", "")})
         elif btype == "image":
@@ -358,16 +392,19 @@ def _ev(name: str, data: dict) -> str:
 # Retryability is the load-bearing part. Anthropic SDKs back off and retry
 # 429/500/529 but not 4xx, so a failure that can never succeed on retry
 # has to land on a 4xx: a context overflow or a missing model must not
-# read as a transient api_error. upstream_auth_error is OUR provider
-# credential failing — permanent until the operator fixes it — so it maps
-# to 403 permission_error, matching the Gemini surface. Deliberately NOT
-# 401 authentication_error: the caller's own key is fine.
+# read as a transient api_error. The two operator-side conditions —
+# upstream_auth_error (OUR provider credential rejected) and
+# no_providers_configured (no key set at all) — are permanent until the
+# operator acts, so they map to 403 permission_error, matching the Gemini
+# surface. Deliberately NOT 401 authentication_error: the caller's own key
+# is fine.
 _ENGINE_ERROR_STATUS = {
     "rate_limit_error": 429,
     "overloaded_error": 529,
     "context_length_exceeded": 400,
     "model_not_found": 404,
     "upstream_auth_error": 403,
+    "no_providers_configured": 403,
 }
 
 
@@ -376,7 +413,9 @@ def _anthropic_error_type(engine_type: str | None) -> str:
     return _STATUS_TO_ERROR_TYPE.get(status, "api_error")
 
 
-async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None]:
+async def stream_events(
+    frames: AsyncIterable[dict], *, input_tokens: int = 0,
+) -> AsyncGenerator[str, None]:
     """Transform the engine's OpenAI chunk-dict stream into Anthropic SSE
     events. Stateful: tracks the open text block, the mapped stop_reason
     (arrives before usage), and the usage frame (arrives last). Tool-call
@@ -384,7 +423,14 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
     blocks at end-of-stream — OpenAI-format streams may interleave
     fragments of concurrent calls, Anthropic blocks are strictly
     sequential, so per-fragment emission would scatter one call's JSON
-    across several nameless blocks."""
+    across several nameless blocks.
+
+    `input_tokens` is the caller's prompt-size estimate, reported in
+    message_start where the protocol puts it (SDKs read the input count
+    from there). The engine only knows the true count at end-of-stream —
+    its usage frame arrives after the last content — so the exact value
+    additionally goes out in message_delta.usage, which SDKs that merge
+    both events pick up."""
     started = False
     text_open = False
     block_index = -1
@@ -403,13 +449,7 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                 "content": [],
                 "stop_reason": None,
                 "stop_sequence": None,
-                # The real API counts the prompt up front; here the engine's
-                # usage frame only arrives at end-of-stream, so the input
-                # count is unknowable at message_start time. 0 is a
-                # placeholder — the true counts are reported in
-                # message_delta.usage (input_tokens included, which the
-                # real API omits there).
-                "usage": {"input_tokens": 0, "output_tokens": 0},
+                "usage": {"input_tokens": input_tokens, "output_tokens": 0},
             },
         })
 
@@ -428,11 +468,11 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                         "message": err.get("message", "Upstream provider error"),
                     },
                 })
-                # Drain, don't return-and-aclose: the engine follows the
-                # error frame with [DONE] and completes normally, logging
-                # 503 + the real error type. aclose() would raise
-                # GeneratorExit at its suspended yield and the engine would
-                # mislog this as a 499 client disconnect.
+                # Read on to the [DONE] the engine sends after its error
+                # frame, so `finish()` below drains it to a normal
+                # completion and it logs 503 + the real error type.
+                # Returning here without that would leave it suspended and
+                # `finish()` would close it, mislogging a 499 disconnect.
                 async for _ in frames:
                     pass
                 return
@@ -482,7 +522,7 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
             if frame.get("usage"):
                 usage = frame["usage"]
 
-        # Normal end of stream ([DONE] consumed by iter_openai_frames).
+        # Normal end of stream ([DONE] consumed by the frame source).
         if not started:
             yield _start_event({})
         if text_open:
@@ -516,9 +556,12 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
         })
         yield _ev("message_stop", {"type": "message_stop"})
     finally:
-        # Forward client-side close down the chain so the engine's own
-        # disconnect handling (upstream aclose + log writeback) runs.
-        await aclose_quietly(frames)
+        # Last, deliberately: this drains the engine to completion (or
+        # forwards a close), which runs its RequestLog commit. Doing it
+        # here rather than mid-transform keeps that DB write behind the
+        # terminal events above, so the client always has message_stop
+        # before the writeback happens. See OpenAIFrameStream.
+        await finish_quietly(frames)
 
 
 # ── Error envelope ──────────────────────────────────────────────────────

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -236,6 +236,14 @@ def _translate_user_message(blocks: list[dict]) -> list[dict]:
             out.append({"role": "user", "content": parts[0]["text"]})
         else:
             out.append({"role": "user", "content": parts})
+    if not out:
+        # `content: []`, or a turn whose every block was dropped metadata.
+        # Returning [] would delete the turn from the conversation sent
+        # upstream — the model would answer a history the caller never
+        # sent, with no signal. The real API rejects empty content, so
+        # this is a 400 rather than a synthesized empty turn (which
+        # Anthropic upstreams reject in turn, as a retryable 5xx).
+        raise _invalid("user message content produced no content; 'content' must be non-empty")
     return out
 
 
@@ -707,13 +715,31 @@ def native_status(status: int, error_type: str | None) -> int:
     return _ENGINE_ERROR_STATUS.get(error_type or "", status)
 
 
+def _envelope_status(status: int) -> int:
+    """The status the Anthropic envelope can actually carry: the API has no
+    422 (bad requests are 400) and generic 5xx upstream failures collapse
+    to 500."""
+    if status == 422:
+        return 400
+    if status >= 500 and status != 529:
+        return 500
+    return status
+
+
+def delivered_status(status: int, error_type: str | None) -> int:
+    """The status this surface really puts on the wire for an engine
+    failure: native_status's remapping followed by the envelope's own
+    collapsing. Handed to `execute_chat(log_status=...)` so the RequestLog
+    row records what the client received — for the mapped types (404/403/
+    429/400) native_status alone suffices, but an unmapped generic 5xx is
+    delivered as 500 while the engine calls it 503."""
+    return _envelope_status(native_status(status, error_type))
+
+
 def error_response(status: int, message: str) -> JSONResponse:
     """Render an error in the Anthropic envelope. The API has no 422 (bad
     requests are 400) and we collapse 5xx upstream failures to 500."""
-    if status == 422:
-        status = 400
-    if status >= 500 and status != 529:
-        status = 500
+    status = _envelope_status(status)
     return JSONResponse(
         status_code=status,
         content={

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -1,0 +1,494 @@
+"""Anthropic Messages API ↔ internal OpenAI format translation.
+
+Pure functions + one pure async stream transformer. Mapping decisions are
+documented in PLAN-NATIVE-PROTOCOLS.md §3; the load-bearing ones:
+
+- `thinking` (request param and history blocks) is DROPPED with a log
+  warning, never rejected — Claude Code sends it whenever extended
+  thinking is on, and a 400 would make the whole client unusable.
+- `tool_result` blocks in a user message split into separate OpenAI
+  `role: "tool"` messages (emitted first, matching OpenAI's requirement
+  that tool results directly follow the assistant tool_calls turn).
+- Anthropic has no 422: invalid requests are 400 `invalid_request_error`.
+- Streaming relies on the engine's auto-injected
+  `stream_options.include_usage`: the usage-bearing frame arrives AFTER
+  the finish_reason frame, so `message_delta` (stop_reason + usage) is
+  emitted at end-of-stream from recorded state.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import AsyncGenerator, AsyncIterable
+
+import structlog
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.protocols.sse import aclose_quietly
+
+logger = structlog.get_logger()
+
+
+# ── Request schema ─────────────────────────────────────────────────────
+
+class AnthropicMessage(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    role: str
+    content: str | list[dict]
+
+
+class AnthropicMessagesRequest(BaseModel):
+    """Wire schema for POST /v1/messages. Extra fields tolerated (the real
+    API grows fields regularly; unknown ones are ignored, not rejected)."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str
+    messages: list[AnthropicMessage] = Field(min_length=1)
+    max_tokens: int
+    system: str | list[dict] | None = None
+    tools: list[dict] | None = None
+    tool_choice: dict | None = None
+    temperature: float | None = None
+    top_p: float | None = None
+    top_k: int | None = None
+    stop_sequences: list[str] | None = None
+    stream: bool = False
+    metadata: dict | None = None
+    thinking: dict | None = None
+
+
+# ── Request translation (Anthropic → OpenAI) ───────────────────────────
+
+def _invalid(message: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=message)
+
+
+def _system_text(system: str | list[dict]) -> str:
+    if isinstance(system, str):
+        return system
+    parts = [
+        b.get("text", "") for b in system
+        if isinstance(b, dict) and b.get("type") == "text"
+    ]
+    return "\n\n".join(p for p in parts if p)
+
+
+def _image_part(block: dict) -> dict:
+    source = block.get("source") or {}
+    stype = source.get("type")
+    if stype == "base64":
+        media = source.get("media_type", "application/octet-stream")
+        return {
+            "type": "image_url",
+            "image_url": {"url": f"data:{media};base64,{source.get('data', '')}"},
+        }
+    if stype == "url":
+        return {"type": "image_url", "image_url": {"url": source.get("url", "")}}
+    raise _invalid(f"Unsupported image source type: {stype!r}")
+
+
+def _flatten_tool_result_content(content) -> str:
+    """tool_result.content is a string or a list of blocks — flatten to text."""
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        texts = [
+            b.get("text", "") for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        return "\n\n".join(t for t in texts if t)
+    return str(content)
+
+
+_DROPPED_BLOCK_TYPES = {"thinking", "redacted_thinking"}
+
+
+def _translate_assistant_message(blocks: list[dict]) -> dict:
+    texts: list[str] = []
+    tool_calls: list[dict] = []
+    for block in blocks:
+        btype = block.get("type")
+        if btype == "text":
+            texts.append(block.get("text", ""))
+        elif btype == "tool_use":
+            tool_calls.append({
+                "id": block.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
+                "type": "function",
+                "function": {
+                    "name": block.get("name", ""),
+                    "arguments": json.dumps(block.get("input") or {}),
+                },
+            })
+        elif btype in _DROPPED_BLOCK_TYPES:
+            continue
+        else:
+            raise _invalid(f"Unsupported content block type in assistant message: {btype!r}")
+    out: dict = {"role": "assistant", "content": "".join(texts) or None}
+    if tool_calls:
+        out["tool_calls"] = tool_calls
+    return out
+
+
+def _translate_user_message(blocks: list[dict]) -> list[dict]:
+    """One Anthropic user message may carry tool_result blocks plus regular
+    content. OpenAI needs the tool results as their own `role: "tool"`
+    messages (first), then the remaining content as a user message."""
+    tool_messages: list[dict] = []
+    parts: list[dict] = []
+    for block in blocks:
+        btype = block.get("type")
+        if btype == "tool_result":
+            tool_messages.append({
+                "role": "tool",
+                "tool_call_id": block.get("tool_use_id", ""),
+                "content": _flatten_tool_result_content(block.get("content")),
+            })
+        elif btype == "text":
+            parts.append({"type": "text", "text": block.get("text", "")})
+        elif btype == "image":
+            parts.append(_image_part(block))
+        elif btype in _DROPPED_BLOCK_TYPES:
+            continue
+        elif btype == "document":
+            raise _invalid("'document' content blocks are not supported by this endpoint")
+        else:
+            raise _invalid(f"Unsupported content block type: {btype!r}")
+
+    out = tool_messages
+    if parts:
+        if len(parts) == 1 and parts[0]["type"] == "text":
+            out.append({"role": "user", "content": parts[0]["text"]})
+        else:
+            out.append({"role": "user", "content": parts})
+    return out
+
+
+def _translate_message(m: AnthropicMessage) -> list[dict]:
+    if m.role == "system":
+        # Spec-wise `system` is a top-level param, but real clients (Claude
+        # Code 2.x internal requests) also put role:"system" entries inside
+        # messages[]. OpenAI's format allows system messages there, so
+        # translate instead of rejecting — a 400 here breaks Claude Code.
+        text = m.content if isinstance(m.content, str) else _system_text(m.content)
+        return [{"role": "system", "content": text}]
+    if m.role not in ("user", "assistant"):
+        raise _invalid(f"Unsupported message role: {m.role!r}")
+    if isinstance(m.content, str):
+        return [{"role": m.role, "content": m.content}]
+    if m.role == "assistant":
+        return [_translate_assistant_message(m.content)]
+    return _translate_user_message(m.content)
+
+
+_SERVER_TOOL_HINT = (
+    "server-side tools (web search, computer use, ...) are not supported "
+    "by this endpoint; only custom function tools are"
+)
+
+
+def _translate_tool(tool: dict) -> dict:
+    ttype = tool.get("type")
+    if ttype not in (None, "custom"):
+        raise _invalid(f"Unsupported tool type {ttype!r}: {_SERVER_TOOL_HINT}")
+    if not tool.get("name"):
+        raise _invalid("Tool definition is missing 'name'")
+    fn: dict = {
+        "name": tool["name"],
+        "parameters": tool.get("input_schema") or {"type": "object", "properties": {}},
+    }
+    if tool.get("description"):
+        fn["description"] = tool["description"]
+    return {"type": "function", "function": fn}
+
+
+def _translate_tool_choice(tc: dict) -> str | dict:
+    tctype = tc.get("type")
+    if tctype == "auto":
+        return "auto"
+    if tctype == "any":
+        return "required"
+    if tctype == "none":
+        return "none"
+    if tctype == "tool":
+        if not tc.get("name"):
+            raise _invalid("tool_choice of type 'tool' requires 'name'")
+        return {"type": "function", "function": {"name": tc["name"]}}
+    raise _invalid(f"Unsupported tool_choice type: {tctype!r}")
+
+
+def to_openai_request(req: AnthropicMessagesRequest) -> dict:
+    """Translate a validated Anthropic Messages request into the internal
+    OpenAI chat.completions dict consumed by the chat engine."""
+    messages: list[dict] = []
+    if req.system is not None:
+        text = _system_text(req.system)
+        if text:
+            messages.append({"role": "system", "content": text})
+    for m in req.messages:
+        messages.extend(_translate_message(m))
+
+    out: dict = {
+        "model": req.model,
+        "messages": messages,
+        "max_tokens": req.max_tokens,
+        "stream": req.stream,
+    }
+    if req.temperature is not None:
+        out["temperature"] = req.temperature
+    if req.top_p is not None:
+        out["top_p"] = req.top_p
+    if req.stop_sequences:
+        out["stop"] = req.stop_sequences
+    if req.metadata and isinstance(req.metadata.get("user_id"), str):
+        out["user"] = req.metadata["user_id"]
+    if req.tools is not None:
+        out["tools"] = [_translate_tool(t) for t in req.tools]
+    if req.tool_choice is not None:
+        out["tool_choice"] = _translate_tool_choice(req.tool_choice)
+    if req.thinking is not None:
+        # Claude Code sends this whenever extended thinking is on. There is
+        # no internal-schema equivalent yet — drop it so the request still
+        # works (documented limitation), never 400.
+        logger.warning("anthropic_thinking_param_dropped")
+    if req.top_k is not None:
+        logger.info("anthropic_top_k_dropped")
+    return out
+
+
+# ── Response translation (OpenAI → Anthropic) ──────────────────────────
+
+_STOP_REASON_MAP = {
+    "stop": "end_turn",
+    "length": "max_tokens",
+    "tool_calls": "tool_use",
+    "function_call": "tool_use",
+    "content_filter": "refusal",
+}
+
+
+def _parse_json_object(raw) -> dict:
+    if isinstance(raw, dict):
+        return raw
+    if not raw:
+        return {}
+    try:
+        parsed = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _message_id(raw: str | None) -> str:
+    if raw and raw.startswith("msg_"):
+        return raw
+    return f"msg_{raw or uuid.uuid4().hex}"
+
+
+def to_anthropic_response(resp: dict) -> dict:
+    choices = resp.get("choices") or [{}]
+    choice = choices[0] if choices else {}
+    msg = choice.get("message") or {}
+
+    content: list[dict] = []
+    text = msg.get("content")
+    if text:
+        content.append({"type": "text", "text": text})
+    for tc in msg.get("tool_calls") or []:
+        fn = tc.get("function") or {}
+        content.append({
+            "type": "tool_use",
+            "id": tc.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
+            "name": fn.get("name", ""),
+            "input": _parse_json_object(fn.get("arguments")),
+        })
+
+    usage = resp.get("usage") or {}
+    return {
+        "id": _message_id(resp.get("id")),
+        "type": "message",
+        "role": "assistant",
+        "model": resp.get("model", ""),
+        "content": content,
+        "stop_reason": _STOP_REASON_MAP.get(choice.get("finish_reason"), "end_turn"),
+        "stop_sequence": None,
+        "usage": {
+            "input_tokens": usage.get("prompt_tokens", 0) or 0,
+            "output_tokens": usage.get("completion_tokens", 0) or 0,
+        },
+    }
+
+
+# ── Stream translation (OpenAI chunk frames → Anthropic SSE events) ────
+
+def _ev(name: str, data: dict) -> str:
+    return f"event: {name}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
+
+
+_STREAM_ERROR_TYPES = {"rate_limit_error", "overloaded_error", "api_error"}
+
+
+async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None]:
+    """Transform the engine's OpenAI chunk-dict stream into Anthropic SSE
+    events. Stateful: tracks the open content block, the mapped stop_reason
+    (arrives before usage), and the usage frame (arrives last)."""
+    started = False
+    block_type: str | None = None   # None | "text" | "tool_use"
+    block_index = -1
+    current_tool_key: int | None = None
+    stop_reason: str | None = None
+    usage: dict = {}
+
+    def _start_event(frame: dict) -> str:
+        return _ev("message_start", {
+            "type": "message_start",
+            "message": {
+                "id": _message_id(frame.get("id")),
+                "type": "message",
+                "role": "assistant",
+                "model": frame.get("model", ""),
+                "content": [],
+                "stop_reason": None,
+                "stop_sequence": None,
+                "usage": {"input_tokens": 0, "output_tokens": 0},
+            },
+        })
+
+    def _block_stop() -> str:
+        return _ev("content_block_stop", {"type": "content_block_stop", "index": block_index})
+
+    try:
+        async for frame in frames:
+            if "error" in frame and "choices" not in frame:
+                err = frame.get("error") or {}
+                etype = err.get("type")
+                yield _ev("error", {
+                    "type": "error",
+                    "error": {
+                        "type": etype if etype in _STREAM_ERROR_TYPES else "api_error",
+                        "message": err.get("message", "Upstream provider error"),
+                    },
+                })
+                return
+
+            if not started:
+                started = True
+                yield _start_event(frame)
+
+            choices = frame.get("choices") or []
+            choice = choices[0] if choices else {}
+            delta = choice.get("delta") or {}
+
+            text = delta.get("content")
+            if text:
+                if block_type != "text":
+                    if block_type is not None:
+                        yield _block_stop()
+                    block_index += 1
+                    block_type = "text"
+                    current_tool_key = None
+                    yield _ev("content_block_start", {
+                        "type": "content_block_start",
+                        "index": block_index,
+                        "content_block": {"type": "text", "text": ""},
+                    })
+                yield _ev("content_block_delta", {
+                    "type": "content_block_delta",
+                    "index": block_index,
+                    "delta": {"type": "text_delta", "text": text},
+                })
+
+            for tcd in delta.get("tool_calls") or []:
+                key = tcd.get("index", 0)
+                fn = tcd.get("function") or {}
+                if block_type != "tool_use" or key != current_tool_key:
+                    if block_type is not None:
+                        yield _block_stop()
+                    block_index += 1
+                    block_type = "tool_use"
+                    current_tool_key = key
+                    yield _ev("content_block_start", {
+                        "type": "content_block_start",
+                        "index": block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tcd.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
+                            "name": fn.get("name", ""),
+                            "input": {},
+                        },
+                    })
+                args = fn.get("arguments")
+                if args:
+                    yield _ev("content_block_delta", {
+                        "type": "content_block_delta",
+                        "index": block_index,
+                        "delta": {"type": "input_json_delta", "partial_json": args},
+                    })
+
+            if choice.get("finish_reason"):
+                stop_reason = _STOP_REASON_MAP.get(choice["finish_reason"], "end_turn")
+                if block_type is not None:
+                    yield _block_stop()
+                    block_type = None
+                    current_tool_key = None
+
+            if frame.get("usage"):
+                usage = frame["usage"]
+
+        # Normal end of stream ([DONE] consumed by iter_openai_frames).
+        if not started:
+            yield _start_event({})
+        if block_type is not None:
+            yield _block_stop()
+        delta_usage: dict = {"output_tokens": usage.get("completion_tokens", 0) or 0}
+        if usage.get("prompt_tokens"):
+            delta_usage["input_tokens"] = usage["prompt_tokens"]
+        yield _ev("message_delta", {
+            "type": "message_delta",
+            "delta": {"stop_reason": stop_reason or "end_turn", "stop_sequence": None},
+            "usage": delta_usage,
+        })
+        yield _ev("message_stop", {"type": "message_stop"})
+    finally:
+        # Forward client-side close down the chain so the engine's own
+        # disconnect handling (upstream aclose + log writeback) runs.
+        await aclose_quietly(frames)
+
+
+# ── Error envelope ──────────────────────────────────────────────────────
+
+_STATUS_TO_ERROR_TYPE = {
+    400: "invalid_request_error",
+    401: "authentication_error",
+    403: "permission_error",
+    404: "not_found_error",
+    413: "request_too_large",
+    429: "rate_limit_error",
+    500: "api_error",
+    529: "overloaded_error",
+}
+
+
+def error_response(status: int, message: str) -> JSONResponse:
+    """Render an error in the Anthropic envelope. The API has no 422 (bad
+    requests are 400) and we collapse 5xx upstream failures to 500."""
+    if status == 422:
+        status = 400
+    if status >= 500 and status != 529:
+        status = 500
+    return JSONResponse(
+        status_code=status,
+        content={
+            "type": "error",
+            "error": {
+                "type": _STATUS_TO_ERROR_TYPE.get(status, "api_error"),
+                "message": message,
+            },
+        },
+    )

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -162,11 +162,16 @@ def _translate_assistant_message(blocks: list[dict]) -> dict:
         if btype == "text":
             texts.append(require_text(block.get("text"), field="messages[].content[].text"))
         elif btype == "tool_use":
+            name = block.get("name")
+            if not isinstance(name, str) or not name:
+                # The upstream rejects an empty function name with a 400
+                # the engine would report as a retryable 503 — fail here.
+                raise _invalid("tool_use block requires a non-empty string 'name'")
             tool_calls.append({
                 "id": block.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
                 "type": "function",
                 "function": {
-                    "name": block.get("name", ""),
+                    "name": name,
                     "arguments": json.dumps(block.get("input") or {}),
                 },
             })
@@ -198,10 +203,16 @@ def _translate_user_message(blocks: list[dict]) -> list[dict]:
     for block in blocks:
         btype = block.get("type")
         if btype == "tool_result":
+            tool_use_id = block.get("tool_use_id")
+            if not isinstance(tool_use_id, str) or not tool_use_id:
+                # Same rule as tool definitions: an empty/missing id reaches
+                # the upstream as a malformed tool message and comes back
+                # as a retryable 503 for a request that can never succeed.
+                raise _invalid("tool_result block requires a non-empty string 'tool_use_id'")
             text, images = _split_tool_result_content(block.get("content"))
             tool_messages.append({
                 "role": "tool",
-                "tool_call_id": block.get("tool_use_id", ""),
+                "tool_call_id": tool_use_id,
                 "content": text,
             })
             parts.extend(images)

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -137,6 +137,13 @@ def _translate_assistant_message(blocks: list[dict]) -> dict:
     out: dict = {"role": "assistant", "content": "".join(texts) or None}
     if tool_calls:
         out["tool_calls"] = tool_calls
+    if out["content"] is None and not tool_calls:
+        # Every block was dropped (thinking-only turn — Claude Code sends
+        # these on extended-thinking/compacted histories). The engine's
+        # `exclude_none` dump would strip the None and upstreams reject a
+        # bare {"role": "assistant"}; keep the turn with empty content
+        # rather than leaking dropped thinking text or losing the turn.
+        out["content"] = ""
     return out
 
 
@@ -335,7 +342,17 @@ def _ev(name: str, data: dict) -> str:
     return f"event: {name}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
-_STREAM_ERROR_TYPES = {"rate_limit_error", "overloaded_error", "api_error"}
+# Engine SSE error-frame `type` (packages/litellm_adapter/client.py
+# _translate_error) → Anthropic error taxonomy. Retry semantics matter:
+# a context overflow or missing model must not surface as a retryable
+# api_error. upstream_auth_error stays api_error — it's OUR provider
+# credential that failed, not the caller's key.
+_STREAM_ERROR_TYPE_MAP = {
+    "rate_limit_error": "rate_limit_error",
+    "overloaded_error": "overloaded_error",
+    "context_length_exceeded": "invalid_request_error",
+    "model_not_found": "not_found_error",
+}
 
 
 async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None]:
@@ -386,7 +403,7 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                 yield _ev("error", {
                     "type": "error",
                     "error": {
-                        "type": etype if etype in _STREAM_ERROR_TYPES else "api_error",
+                        "type": _STREAM_ERROR_TYPE_MAP.get(etype, "api_error"),
                         "message": err.get("message", "Upstream provider error"),
                     },
                 })

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -16,9 +16,11 @@ mapping decisions are:
   the finish_reason frame, so `message_delta` (stop_reason + usage) is
   emitted at end-of-stream from recorded state.
 - Streamed tool-call fragments are buffered per tool-call index and
-  flushed as complete `tool_use` blocks at end-of-stream: OpenAI-format
-  streams may interleave fragments of concurrent tool calls, while
-  Anthropic content blocks are strictly sequential.
+  flushed as complete `tool_use` blocks — as soon as the model moves on
+  to text again, or at end-of-stream: OpenAI-format streams may
+  interleave fragments of concurrent tool calls, while Anthropic content
+  blocks are strictly sequential, and the client must still see text and
+  tool calls in the order the model produced them.
 """
 
 from __future__ import annotations
@@ -32,7 +34,7 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.protocols import clamp_stop_sequences
+from app.protocols import clamp_stop_sequences, require_text
 from app.protocols.sse import finish_quietly
 
 logger = structlog.get_logger()
@@ -94,8 +96,9 @@ def _system_text(system: str | list[dict]) -> str:
     dropped = 0
     for b in system:
         if isinstance(b, dict) and b.get("type") == "text":
-            if b.get("text"):
-                parts.append(b["text"])
+            text = require_text(b.get("text"), field="system[].text")
+            if text:
+                parts.append(text)
         else:
             dropped += 1
     if dropped:
@@ -139,8 +142,9 @@ def _split_tool_result_content(content) -> tuple[str, list[dict]]:
         if not isinstance(b, dict):
             continue
         if b.get("type") == "text":
-            if b.get("text"):
-                texts.append(b["text"])
+            text = require_text(b.get("text"), field="tool_result.content[].text")
+            if text:
+                texts.append(text)
         elif b.get("type") == "image":
             images.append(_image_part(b))
     return "\n\n".join(texts), images
@@ -155,7 +159,7 @@ def _translate_assistant_message(blocks: list[dict]) -> dict:
     for block in blocks:
         btype = block.get("type")
         if btype == "text":
-            texts.append(block.get("text", ""))
+            texts.append(require_text(block.get("text"), field="messages[].content[].text"))
         elif btype == "tool_use":
             tool_calls.append({
                 "id": block.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
@@ -201,7 +205,10 @@ def _translate_user_message(blocks: list[dict]) -> list[dict]:
             })
             parts.extend(images)
         elif btype == "text":
-            parts.append({"type": "text", "text": block.get("text", "")})
+            parts.append({
+                "type": "text",
+                "text": require_text(block.get("text"), field="messages[].content[].text"),
+            })
         elif btype == "image":
             parts.append(_image_part(block))
         elif btype in _DROPPED_BLOCK_TYPES:
@@ -244,17 +251,29 @@ _SERVER_TOOL_HINT = (
 
 
 def _translate_tool(tool: dict) -> dict:
+    """The wire schema types `tools` as list[dict] with no inner validation,
+    so the field types are checked here: a numeric name or a string
+    input_schema would pass every layer, reach the upstream verbatim and
+    come back as a BadRequest the engine reports as a retryable 503 — which
+    SDKs back off and retry for a request that can never succeed."""
     ttype = tool.get("type")
     if ttype not in (None, "custom"):
         raise _invalid(f"Unsupported tool type {ttype!r}: {_SERVER_TOOL_HINT}")
-    if not tool.get("name"):
-        raise _invalid("Tool definition is missing 'name'")
+    name = tool.get("name")
+    if not isinstance(name, str) or not name:
+        raise _invalid("Tool definition requires a non-empty string 'name'")
+    schema = tool.get("input_schema")
+    if schema is not None and not isinstance(schema, dict):
+        raise _invalid(f"Tool '{name}' has a non-object input_schema")
+    description = tool.get("description")
+    if description is not None and not isinstance(description, str):
+        raise _invalid(f"Tool '{name}' has a non-string description")
     fn: dict = {
-        "name": tool["name"],
-        "parameters": tool.get("input_schema") or {"type": "object", "properties": {}},
+        "name": name,
+        "parameters": schema or {"type": "object", "properties": {}},
     }
-    if tool.get("description"):
-        fn["description"] = tool["description"]
+    if description:
+        fn["description"] = description
     return {"type": "function", "function": fn}
 
 
@@ -267,9 +286,10 @@ def _translate_tool_choice(tc: dict) -> str | dict:
     if tctype == "none":
         return "none"
     if tctype == "tool":
-        if not tc.get("name"):
-            raise _invalid("tool_choice of type 'tool' requires 'name'")
-        return {"type": "function", "function": {"name": tc["name"]}}
+        name = tc.get("name")
+        if not isinstance(name, str) or not name:
+            raise _invalid("tool_choice of type 'tool' requires a non-empty string 'name'")
+        return {"type": "function", "function": {"name": name}}
     raise _invalid(f"Unsupported tool_choice type: {tctype!r}")
 
 
@@ -399,6 +419,18 @@ def _ev(name: str, data: dict) -> str:
     return f"event: {name}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n"
 
 
+def _args_complete(args: str) -> bool:
+    """True when a buffered tool call's argument fragments form whole JSON
+    (or nothing has arrived yet) — i.e. the call is safe to flush."""
+    if not args:
+        return True
+    try:
+        json.loads(args)
+    except json.JSONDecodeError:
+        return False
+    return True
+
+
 # Engine error types (packages/litellm_adapter/client.py _translate_error,
 # reported on SSE error frames and via the x-orca-error-type header) → the
 # HTTP status this surface reports them as. The Anthropic error *type* is
@@ -408,12 +440,13 @@ def _ev(name: str, data: dict) -> str:
 # Retryability is the load-bearing part. Anthropic SDKs back off and retry
 # 429/500/529 but not 4xx, so a failure that can never succeed on retry
 # has to land on a 4xx: a context overflow or a missing model must not
-# read as a transient api_error. The two operator-side conditions —
-# upstream_auth_error (OUR provider credential rejected) and
-# no_providers_configured (no key set at all) — are permanent until the
-# operator acts, so they map to 403 permission_error, matching the Gemini
-# surface. Deliberately NOT 401 authentication_error: the caller's own key
-# is fine.
+# read as a transient api_error. The operator-side conditions —
+# upstream_auth_error (OUR provider credential rejected),
+# no_providers_configured (no key set at all) and no_capable_provider
+# (keys set, but no deployable model has the capability the request
+# needs) — are permanent until the operator acts, so they map to 403
+# permission_error, matching the Gemini surface. Deliberately NOT 401
+# authentication_error: the caller's own key is fine.
 _ENGINE_ERROR_STATUS = {
     "rate_limit_error": 429,
     "overloaded_error": 529,
@@ -421,6 +454,7 @@ _ENGINE_ERROR_STATUS = {
     "model_not_found": 404,
     "upstream_auth_error": 403,
     "no_providers_configured": 403,
+    "no_capable_provider": 403,
 }
 
 
@@ -436,10 +470,14 @@ async def stream_events(
     events. Stateful: tracks the open text block, the mapped stop_reason
     (arrives before usage), and the usage frame (arrives last). Tool-call
     fragments are buffered per index and flushed as complete tool_use
-    blocks at end-of-stream — OpenAI-format streams may interleave
-    fragments of concurrent calls, Anthropic blocks are strictly
-    sequential, so per-fragment emission would scatter one call's JSON
-    across several nameless blocks.
+    blocks — OpenAI-format streams may interleave fragments of concurrent
+    calls, Anthropic blocks are strictly sequential, so per-fragment
+    emission would scatter one call's JSON across several nameless
+    blocks. The flush happens the moment a text delta follows the
+    fragments (the model finished its calls and moved on) or at
+    end-of-stream, so blocks reach the client in the order the model
+    produced them: text the model wrote AFTER a tool call must not be
+    delivered before it.
 
     `input_tokens` is the caller's prompt-size estimate, reported in
     message_start where the protocol puts it (SDKs read the input count
@@ -472,11 +510,57 @@ async def stream_events(
     def _block_stop() -> str:
         return _ev("content_block_stop", {"type": "content_block_stop", "index": block_index})
 
+    def _tool_block_events(*, only_complete: bool = False) -> list[str]:
+        """Buffered tool calls as complete tool_use blocks (start → one
+        input_json_delta → stop), in index order, removed from the buffer.
+
+        `only_complete` (the mid-stream flush) keeps back any call whose
+        arguments are not yet whole JSON: a text delta landing BETWEEN two
+        argument fragments of one call must not split that call across two
+        blocks — it stays buffered to end-of-stream instead."""
+        nonlocal block_index
+        out: list[str] = []
+        for idx, slot in sorted(tool_buf.items()):
+            if only_complete and not _args_complete(slot["args"]):
+                continue
+            del tool_buf[idx]
+            block_index += 1
+            out.append(_ev("content_block_start", {
+                "type": "content_block_start",
+                "index": block_index,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": slot["id"] or f"toolu_{uuid.uuid4().hex[:24]}",
+                    "name": slot["name"],
+                    "input": {},
+                },
+            }))
+            if slot["args"]:
+                out.append(_ev("content_block_delta", {
+                    "type": "content_block_delta",
+                    "index": block_index,
+                    "delta": {"type": "input_json_delta", "partial_json": slot["args"]},
+                }))
+            out.append(_block_stop())
+        return out
+
     try:
         async for frame in frames:
             if "error" in frame and "choices" not in frame:
                 err = frame.get("error") or {}
                 etype = err.get("type")
+                # Read on to the [DONE] the engine sends right after its
+                # error frame BEFORE handing the error event to the client.
+                # With the sentinel consumed, `finish()` in the finally
+                # below DRAINS the engine to a normal completion whether we
+                # are resumed after the yield or closed at it (client gone
+                # while the event was in flight), and the engine logs
+                # 503 + the real error type either way. Yielding first
+                # would leave that classification hanging on our being
+                # resumed before the client disconnects: a close at the
+                # yield would forward as aclose() into the engine instead.
+                async for _ in frames:
+                    pass
                 yield _ev("error", {
                     "type": "error",
                     "error": {
@@ -484,13 +568,6 @@ async def stream_events(
                         "message": err.get("message", "Upstream provider error"),
                     },
                 })
-                # Read on to the [DONE] the engine sends after its error
-                # frame, so `finish()` below drains it to a normal
-                # completion and it logs 503 + the real error type.
-                # Returning here without that would leave it suspended and
-                # `finish()` would close it, mislogging a 499 disconnect.
-                async for _ in frames:
-                    pass
                 return
 
             if not started:
@@ -503,6 +580,13 @@ async def stream_events(
 
             text = delta.get("content")
             if text:
+                # Text after tool-call fragments: the model finished those
+                # calls and moved on, so flush them now. Holding them to
+                # end-of-stream would hand the client this text BEFORE the
+                # tool call it followed, and SDKs process blocks in order.
+                if tool_buf:
+                    for ev in _tool_block_events(only_complete=True):
+                        yield ev
                 if not text_open:
                     text_open = True
                     block_index += 1
@@ -517,7 +601,13 @@ async def stream_events(
                     "delta": {"type": "text_delta", "text": text},
                 })
 
-            for tcd in delta.get("tool_calls") or []:
+            tool_deltas = delta.get("tool_calls") or []
+            if tool_deltas and text_open:
+                # The text that preceded this call is complete: close its
+                # block so the tool_use block keeps the model's order.
+                yield _block_stop()
+                text_open = False
+            for tcd in tool_deltas:
                 slot = tool_buf.setdefault(
                     tcd.get("index", 0), {"id": "", "name": "", "args": ""}
                 )
@@ -543,25 +633,8 @@ async def stream_events(
             yield _start_event({})
         if text_open:
             yield _block_stop()
-        for _, slot in sorted(tool_buf.items()):
-            block_index += 1
-            yield _ev("content_block_start", {
-                "type": "content_block_start",
-                "index": block_index,
-                "content_block": {
-                    "type": "tool_use",
-                    "id": slot["id"] or f"toolu_{uuid.uuid4().hex[:24]}",
-                    "name": slot["name"],
-                    "input": {},
-                },
-            })
-            if slot["args"]:
-                yield _ev("content_block_delta", {
-                    "type": "content_block_delta",
-                    "index": block_index,
-                    "delta": {"type": "input_json_delta", "partial_json": slot["args"]},
-                })
-            yield _block_stop()
+        for ev in _tool_block_events():
+            yield ev
         delta_usage: dict = {"output_tokens": usage.get("completion_tokens", 0) or 0}
         if usage.get("prompt_tokens"):
             delta_usage["input_tokens"] = usage["prompt_tokens"]

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -14,6 +14,10 @@ documented in PLAN-NATIVE-PROTOCOLS.md §3; the load-bearing ones:
   `stream_options.include_usage`: the usage-bearing frame arrives AFTER
   the finish_reason frame, so `message_delta` (stop_reason + usage) is
   emitted at end-of-stream from recorded state.
+- Streamed tool-call fragments are buffered per tool-call index and
+  flushed as complete `tool_use` blocks at end-of-stream: OpenAI-format
+  streams may interleave fragments of concurrent tool calls, while
+  Anthropic content blocks are strictly sequential.
 """
 
 from __future__ import annotations
@@ -336,12 +340,17 @@ _STREAM_ERROR_TYPES = {"rate_limit_error", "overloaded_error", "api_error"}
 
 async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None]:
     """Transform the engine's OpenAI chunk-dict stream into Anthropic SSE
-    events. Stateful: tracks the open content block, the mapped stop_reason
-    (arrives before usage), and the usage frame (arrives last)."""
+    events. Stateful: tracks the open text block, the mapped stop_reason
+    (arrives before usage), and the usage frame (arrives last). Tool-call
+    fragments are buffered per index and flushed as complete tool_use
+    blocks at end-of-stream — OpenAI-format streams may interleave
+    fragments of concurrent calls, Anthropic blocks are strictly
+    sequential, so per-fragment emission would scatter one call's JSON
+    across several nameless blocks."""
     started = False
-    block_type: str | None = None   # None | "text" | "tool_use"
+    text_open = False
     block_index = -1
-    current_tool_key: int | None = None
+    tool_buf: dict[int, dict] = {}  # tool_calls[].index → {id, name, args}
     stop_reason: str | None = None
     usage: dict = {}
 
@@ -356,6 +365,12 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                 "content": [],
                 "stop_reason": None,
                 "stop_sequence": None,
+                # The real API counts the prompt up front; here the engine's
+                # usage frame only arrives at end-of-stream, so the input
+                # count is unknowable at message_start time. 0 is a
+                # placeholder — the true counts are reported in
+                # message_delta.usage (input_tokens included, which the
+                # real API omits there).
                 "usage": {"input_tokens": 0, "output_tokens": 0},
             },
         })
@@ -375,6 +390,13 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                         "message": err.get("message", "Upstream provider error"),
                     },
                 })
+                # Drain, don't return-and-aclose: the engine follows the
+                # error frame with [DONE] and completes normally, logging
+                # 503 + the real error type. aclose() would raise
+                # GeneratorExit at its suspended yield and the engine would
+                # mislog this as a 499 client disconnect.
+                async for _ in frames:
+                    pass
                 return
 
             if not started:
@@ -387,12 +409,9 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
 
             text = delta.get("content")
             if text:
-                if block_type != "text":
-                    if block_type is not None:
-                        yield _block_stop()
+                if not text_open:
+                    text_open = True
                     block_index += 1
-                    block_type = "text"
-                    current_tool_key = None
                     yield _ev("content_block_start", {
                         "type": "content_block_start",
                         "index": block_index,
@@ -405,38 +424,22 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
                 })
 
             for tcd in delta.get("tool_calls") or []:
-                key = tcd.get("index", 0)
+                slot = tool_buf.setdefault(
+                    tcd.get("index", 0), {"id": "", "name": "", "args": ""}
+                )
+                if tcd.get("id"):
+                    slot["id"] = tcd["id"]
                 fn = tcd.get("function") or {}
-                if block_type != "tool_use" or key != current_tool_key:
-                    if block_type is not None:
-                        yield _block_stop()
-                    block_index += 1
-                    block_type = "tool_use"
-                    current_tool_key = key
-                    yield _ev("content_block_start", {
-                        "type": "content_block_start",
-                        "index": block_index,
-                        "content_block": {
-                            "type": "tool_use",
-                            "id": tcd.get("id") or f"toolu_{uuid.uuid4().hex[:24]}",
-                            "name": fn.get("name", ""),
-                            "input": {},
-                        },
-                    })
-                args = fn.get("arguments")
-                if args:
-                    yield _ev("content_block_delta", {
-                        "type": "content_block_delta",
-                        "index": block_index,
-                        "delta": {"type": "input_json_delta", "partial_json": args},
-                    })
+                if fn.get("name"):
+                    slot["name"] = fn["name"]
+                if fn.get("arguments"):
+                    slot["args"] += fn["arguments"]
 
             if choice.get("finish_reason"):
                 stop_reason = _STOP_REASON_MAP.get(choice["finish_reason"], "end_turn")
-                if block_type is not None:
+                if text_open:
                     yield _block_stop()
-                    block_type = None
-                    current_tool_key = None
+                    text_open = False
 
             if frame.get("usage"):
                 usage = frame["usage"]
@@ -444,7 +447,26 @@ async def stream_events(frames: AsyncIterable[dict]) -> AsyncGenerator[str, None
         # Normal end of stream ([DONE] consumed by iter_openai_frames).
         if not started:
             yield _start_event({})
-        if block_type is not None:
+        if text_open:
+            yield _block_stop()
+        for _, slot in sorted(tool_buf.items()):
+            block_index += 1
+            yield _ev("content_block_start", {
+                "type": "content_block_start",
+                "index": block_index,
+                "content_block": {
+                    "type": "tool_use",
+                    "id": slot["id"] or f"toolu_{uuid.uuid4().hex[:24]}",
+                    "name": slot["name"],
+                    "input": {},
+                },
+            })
+            if slot["args"]:
+                yield _ev("content_block_delta", {
+                    "type": "content_block_delta",
+                    "index": block_index,
+                    "delta": {"type": "input_json_delta", "partial_json": slot["args"]},
+                })
             yield _block_stop()
         delta_usage: dict = {"output_tokens": usage.get("completion_tokens", 0) or 0}
         if usage.get("prompt_tokens"):

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -512,8 +512,10 @@ async def stream_events(
     text_open = False
     block_index = -1
     tool_buf: dict[int, dict] = {}  # tool_calls[].index → {id, name, args}
+    flushed_names: dict[int, str] = {}  # index → name, for already-closed blocks
     stop_reason: str | None = None
     usage: dict = {}
+    failed = False
 
     def _start_event(frame: dict) -> str:
         return _ev("message_start", {
@@ -547,6 +549,8 @@ async def stream_events(
             if only_complete and not _args_complete(slot["args"]):
                 continue
             del tool_buf[idx]
+            if only_complete:
+                flushed_names[idx] = slot["name"]
             block_index += 1
             out.append(_ev("content_block_start", {
                 "type": "content_block_start",
@@ -631,8 +635,19 @@ async def stream_events(
                 yield _block_stop()
                 text_open = False
             for tcd in tool_deltas:
+                idx = tcd.get("index", 0)
+                if idx not in tool_buf and idx in flushed_names:
+                    # More fragments for a call we already flushed (its
+                    # arguments happened to parse at that point and text
+                    # followed). We cannot reopen a closed block, so the
+                    # remainder becomes its own block — carry the name over
+                    # so it is at least identifiable, and say so in the log.
+                    logger.warning(
+                        "anthropic_tool_fragments_after_flush",
+                        index=idx, name=flushed_names[idx],
+                    )
                 slot = tool_buf.setdefault(
-                    tcd.get("index", 0), {"id": "", "name": "", "args": ""}
+                    idx, {"id": "", "name": flushed_names.get(idx, ""), "args": ""}
                 )
                 if tcd.get("id"):
                     slot["id"] = tcd["id"]
@@ -667,6 +682,12 @@ async def stream_events(
             "usage": delta_usage,
         })
         yield _ev("message_stop", {"type": "message_stop"})
+    except Exception:
+        # Our own fault, not the client's: mark it so the cleanup below
+        # aborts the engine (503/adapter_error) instead of closing it,
+        # which the engine cannot tell apart from a client disconnect.
+        failed = True
+        raise
     finally:
         # Last, deliberately: this drains the engine to completion (or
         # forwards a close), which runs its RequestLog commit. Doing it
@@ -681,7 +702,7 @@ async def stream_events(
         # writeback would wait for GC finalization (or never run). Same
         # reason the engine shields its own cleanup.
         with anyio.CancelScope(shield=True):
-            await finish_quietly(frames)
+            await finish_quietly(frames, failed=failed)
 
 
 def stream_error_event(message: str) -> str:

--- a/app/protocols/anthropic.py
+++ b/app/protocols/anthropic.py
@@ -29,6 +29,7 @@ import json
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable
 
+import anyio
 import structlog
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -420,10 +421,13 @@ def _ev(name: str, data: dict) -> str:
 
 
 def _args_complete(args: str) -> bool:
-    """True when a buffered tool call's argument fragments form whole JSON
-    (or nothing has arrived yet) — i.e. the call is safe to flush."""
+    """True when a buffered tool call's argument fragments form whole,
+    non-empty JSON — i.e. the call is safe to flush mid-stream. Empty is
+    NOT complete: the standard first fragment carries only id + name with
+    `arguments: ""`, and flushing on it would emit an empty tool_use block
+    and then a second, nameless one for the arguments that follow."""
     if not args:
-        return True
+        return False
     try:
         json.loads(args)
     except json.JSONDecodeError:
@@ -650,7 +654,22 @@ async def stream_events(
         # here rather than mid-transform keeps that DB write behind the
         # terminal events above, so the client always has message_stop
         # before the writeback happens. See OpenAIFrameStream.
-        await finish_quietly(frames)
+        #
+        # Shielded: this generator IS the response body, so a client
+        # disconnect lands here as Starlette's task-group cancellation.
+        # Unshielded, the first await would re-raise it and the forwarding
+        # would never reach the engine — its upstream aclose() and 499
+        # writeback would wait for GC finalization (or never run). Same
+        # reason the engine shields its own cleanup.
+        with anyio.CancelScope(shield=True):
+            await finish_quietly(frames)
+
+
+def stream_error_event(message: str) -> str:
+    """The in-stream error event for a failure inside the adapter itself
+    (after headers went out a non-200 is impossible); api_error, since the
+    fault is ours, not the caller's."""
+    return _ev("error", {"type": "error", "error": {"type": "api_error", "message": message}})
 
 
 # ── Error envelope ──────────────────────────────────────────────────────

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -271,8 +271,19 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
                 "image_url": {"url": f"data:{mime};base64,{blob.get('data', '')}"},
             })
         elif "functionCall" in part or "function_call" in part:
+            if not is_model:
+                # Only a model turn can carry calls; in a user turn the
+                # call would have nowhere to go and the turn would vanish
+                # from the upstream conversation without a trace — a wrong
+                # answer, not a rejection. Reject like fileData/unknown keys.
+                raise _invalid(
+                    "functionCall parts are only valid in a role:'model' content; "
+                    "return results as functionResponse parts"
+                )
             fc = _alias(part, "functionCall", "function_call") or {}
-            name = fc.get("name", "")
+            name = fc.get("name")
+            if not isinstance(name, str) or not name:
+                raise _invalid("functionCall part requires a non-empty string 'name'")
             tool_calls.append({
                 "id": ids.new_call(name),
                 "type": "function",

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -280,7 +280,22 @@ def _apply_generation_config(gc: dict, out: dict) -> None:
         out["top_p"] = top_p
     max_tokens = _alias(gc, "maxOutputTokens", "max_output_tokens")
     if max_tokens is not None:
-        out["max_tokens"] = max_tokens
+        # generationConfig is free-form on the wire. A 0/negative budget
+        # can never succeed upstream, and the upstream's BadRequest would
+        # come back through the engine as a retryable 500 INTERNAL that
+        # SDKs back off and retry forever — reject it as a native 400
+        # instead. JSON numbers may arrive as an integral float (100.0).
+        if isinstance(max_tokens, bool):
+            valid = False
+        elif isinstance(max_tokens, int):
+            valid = max_tokens >= 1
+        elif isinstance(max_tokens, float):
+            valid = max_tokens.is_integer() and max_tokens >= 1
+        else:
+            valid = False
+        if not valid:
+            raise _invalid("maxOutputTokens must be an integer >= 1")
+        out["max_tokens"] = int(max_tokens)
     stop = _alias(gc, "stopSequences", "stop_sequences")
     if stop:
         if isinstance(stop, list):

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -118,10 +118,18 @@ def _translate_tools(tools: list[dict]) -> list[dict]:
     return out
 
 
-def _translate_tool_config(tc: dict) -> str | dict | None:
+def _translate_tool_config(tc: dict) -> tuple[str | dict | None, list[str] | None]:
+    """Returns (tool_choice, allowed_function_names).
+
+    `allowed` is non-None only for mode ANY with MULTIPLE names: OpenAI's
+    "required" means "must call SOME tool", so the caller must also
+    constrain the tools list to the allowed subset — otherwise the model
+    may call a function the Gemini caller explicitly excluded. The
+    single-name case needs no filtering (a specific-function tool_choice
+    already pins the call)."""
     fcc = _alias(tc, "functionCallingConfig", "function_calling_config")
     if not isinstance(fcc, dict):
-        return None
+        return None, None
     # tool_config is free-form in the wire schema — validate the field
     # types here so malformed input renders as a native 400, not a 500.
     mode_raw = fcc.get("mode")
@@ -129,16 +137,18 @@ def _translate_tool_config(tc: dict) -> str | dict | None:
         raise _invalid("functionCallingConfig.mode must be a string")
     mode = (mode_raw or "").upper()
     if mode in ("", "MODE_UNSPECIFIED", "AUTO", "VALIDATED"):
-        return "auto"
+        return "auto", None
     if mode == "NONE":
-        return "none"
+        return "none", None
     if mode == "ANY":
         allowed = _alias(fcc, "allowedFunctionNames", "allowed_function_names") or []
         if not isinstance(allowed, list) or not all(isinstance(n, str) for n in allowed):
             raise _invalid("functionCallingConfig.allowedFunctionNames must be a list of strings")
         if len(allowed) == 1:
-            return {"type": "function", "function": {"name": allowed[0]}}
-        return "required"
+            return {"type": "function", "function": {"name": allowed[0]}}, None
+        if allowed:
+            return "required", allowed
+        return "required", None
     raise _invalid(f"Unsupported functionCallingConfig mode: {mode!r}")
 
 
@@ -308,7 +318,23 @@ def to_openai_request(req: GeminiGenerateRequest, *, model: str, stream: bool) -
         if tools:
             out["tools"] = tools
     if req.tool_config:
-        tc = _translate_tool_config(req.tool_config)
+        tc, allowed = _translate_tool_config(req.tool_config)
+        if allowed is not None:
+            # ANY + multiple allowedFunctionNames: Google's contract is
+            # "must call one of THESE"; OpenAI's "required" alone is only
+            # "must call some tool", so restrict the declared tools to the
+            # allowed subset (undeclared allowed names are ignored, matching
+            # this module's lenient stance elsewhere).
+            allowed_set = set(allowed)
+            subset = [
+                t for t in out.get("tools") or []
+                if t["function"]["name"] in allowed_set
+            ]
+            if not subset:
+                raise _invalid(
+                    "allowedFunctionNames does not match any declared functionDeclaration"
+                )
+            out["tools"] = subset
         if tc is not None:
             out["tool_choice"] = tc
     if req.generation_config:

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -321,6 +321,12 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
             out_messages.append({"role": "user", "content": parts_out[0]["text"]})
         else:
             out_messages.append({"role": "user", "content": parts_out})
+    if not out_messages:
+        # Same rule as the Anthropic sibling: an empty `parts` (or a turn
+        # of nothing but dropped thought metadata) would vanish from the
+        # conversation sent upstream, changing the model's input with no
+        # signal to the caller. Reject it instead.
+        raise _invalid("user content produced no parts; 'parts' must be non-empty")
     return out_messages
 
 
@@ -691,6 +697,17 @@ def native_status(status: int, error_type: str | None) -> int:
     NOT_FOUND. Derived from _STREAM_ERROR_TYPE_TO_CODE (rather than a
     hand-kept mirror) so the stream and blocking paths cannot drift."""
     return _STREAM_ERROR_TYPE_TO_CODE.get(error_type, status)
+
+
+def delivered_status(status: int, error_type: str | None) -> int:
+    """The status this surface really puts on the wire for an engine
+    failure: native_status's remapping plus the envelope's 422→400
+    collapse. Handed to `execute_chat(log_status=...)` so the RequestLog
+    row records what the client received — the aggregate (non-alt=sse)
+    streaming path renders a genuine 404/429/403 from the error chunk,
+    while the engine's own status for that failure is a generic 503."""
+    status = native_status(status, error_type)
+    return 400 if status == 422 else status
 
 
 def error_response(status: int, message: str) -> JSONResponse:

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -1,0 +1,475 @@
+"""Gemini (Google AI Studio) API ↔ internal OpenAI format translation.
+
+Pure functions + one pure async stream transformer. Mapping decisions are
+documented in PLAN-NATIVE-PROTOCOLS.md §4; the load-bearing ones:
+
+- Wire fields are accepted in BOTH camelCase (REST / google-genai SDK)
+  and snake_case (some client serializations).
+- Function-declaration schemas arrive with UPPERCASE proto type enums
+  ("OBJECT", "STRING", ...) — normalized recursively to lowercase
+  JSON-Schema types before they hit the engine.
+- Gemini has no tool-call ids: history `functionCall` parts get synthetic
+  `call_<n>` ids and `functionResponse` parts pair to the earliest
+  unmatched call with the same name (the positional semantics Gemini
+  itself uses).
+- Streaming never emits a partial functionCall: tool-call argument
+  fragments are buffered and flushed as one complete part before the
+  final finishReason/usageMetadata chunk.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import deque
+from collections.abc import AsyncGenerator, AsyncIterable
+
+import structlog
+from fastapi import HTTPException
+from fastapi.responses import JSONResponse
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.protocols.anthropic import _parse_json_object
+from app.protocols.sse import aclose_quietly
+
+logger = structlog.get_logger()
+
+
+# ── Request schema ─────────────────────────────────────────────────────
+
+class GeminiGenerateRequest(BaseModel):
+    """Wire schema for :generateContent / :streamGenerateContent.
+    Field aliases accept the camelCase REST forms; `populate_by_name`
+    accepts the snake_case forms too. Extra fields tolerated."""
+
+    model_config = ConfigDict(populate_by_name=True, extra="allow")
+
+    contents: str | dict | list[dict]
+    system_instruction: str | dict | None = Field(default=None, alias="systemInstruction")
+    tools: list[dict] | None = None
+    tool_config: dict | None = Field(default=None, alias="toolConfig")
+    generation_config: dict | None = Field(default=None, alias="generationConfig")
+    safety_settings: list[dict] | None = Field(default=None, alias="safetySettings")
+    cached_content: str | None = Field(default=None, alias="cachedContent")
+
+
+def _invalid(message: str) -> HTTPException:
+    return HTTPException(status_code=400, detail=message)
+
+
+def _alias(d: dict, camel: str, snake: str, default=None):
+    if camel in d:
+        return d[camel]
+    return d.get(snake, default)
+
+
+# ── Request translation (Gemini → OpenAI) ──────────────────────────────
+
+def normalize_gemini_schema(node):
+    """Lowercase Gemini's proto type enums ("OBJECT", "STRING", ...) into
+    JSON-Schema types, recursively. Property names are dict KEYS, so a
+    property literally named "type" is untouched (its value is a schema
+    dict, and only string values under a "type" key are lowered)."""
+    if isinstance(node, list):
+        return [normalize_gemini_schema(x) for x in node]
+    if not isinstance(node, dict):
+        return node
+    out = {}
+    for k, v in node.items():
+        if k == "type" and isinstance(v, str):
+            out[k] = v.lower()
+        elif k == "type" and isinstance(v, list):
+            out[k] = [x.lower() if isinstance(x, str) else normalize_gemini_schema(x) for x in v]
+        else:
+            out[k] = normalize_gemini_schema(v)
+    return out
+
+
+_UNSUPPORTED_TOOL_KEYS = (
+    ("googleSearch", "google_search"),
+    ("googleSearchRetrieval", "google_search_retrieval"),
+    ("codeExecution", "code_execution"),
+    ("urlContext", "url_context"),
+)
+
+
+def _translate_tools(tools: list[dict]) -> list[dict]:
+    out: list[dict] = []
+    for tool in tools:
+        for camel, snake in _UNSUPPORTED_TOOL_KEYS:
+            if camel in tool or snake in tool:
+                raise _invalid(
+                    f"Tool '{camel}' is not supported by this endpoint; "
+                    "only functionDeclarations are"
+                )
+        decls = _alias(tool, "functionDeclarations", "function_declarations") or []
+        for decl in decls:
+            if not decl.get("name"):
+                raise _invalid("functionDeclaration is missing 'name'")
+            params = _alias(decl, "parameters", "parameters") \
+                or _alias(decl, "parametersJsonSchema", "parameters_json_schema")
+            fn: dict = {
+                "name": decl["name"],
+                "parameters": normalize_gemini_schema(params)
+                if params else {"type": "object", "properties": {}},
+            }
+            if decl.get("description"):
+                fn["description"] = decl["description"]
+            out.append({"type": "function", "function": fn})
+    return out
+
+
+def _translate_tool_config(tc: dict) -> str | dict | None:
+    fcc = _alias(tc, "functionCallingConfig", "function_calling_config")
+    if not isinstance(fcc, dict):
+        return None
+    mode = (fcc.get("mode") or "").upper()
+    if mode in ("", "MODE_UNSPECIFIED", "AUTO", "VALIDATED"):
+        return "auto"
+    if mode == "NONE":
+        return "none"
+    if mode == "ANY":
+        allowed = _alias(fcc, "allowedFunctionNames", "allowed_function_names") or []
+        if len(allowed) == 1:
+            return {"type": "function", "function": {"name": allowed[0]}}
+        return "required"
+    raise _invalid(f"Unsupported functionCallingConfig mode: {mode!r}")
+
+
+def _system_text(si: str | dict) -> str:
+    if isinstance(si, str):
+        return si
+    parts = si.get("parts") or []
+    if isinstance(parts, dict):
+        parts = [parts]
+    return "\n\n".join(
+        p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")
+    )
+
+
+class _CallIdAllocator:
+    """Synthesize OpenAI tool_call ids for Gemini's id-less function calls,
+    pairing functionResponse parts to the earliest unmatched call by name."""
+
+    def __init__(self):
+        self._seq = 0
+        self._pending: dict[str, deque[str]] = {}
+
+    def new_call(self, name: str) -> str:
+        self._seq += 1
+        call_id = f"call_{self._seq}"
+        self._pending.setdefault(name, deque()).append(call_id)
+        return call_id
+
+    def match_response(self, name: str) -> str:
+        queue = self._pending.get(name)
+        if queue:
+            return queue.popleft()
+        # Lenient fallback: an orphan functionResponse still translates,
+        # the upstream will surface any mismatch itself.
+        logger.warning("gemini_function_response_unmatched", name=name)
+        return f"call_{name}"
+
+
+def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
+    role = content.get("role") or "user"
+    if role not in ("user", "model"):
+        raise _invalid(f"Unsupported content role: {role!r}")
+    is_model = role == "model"
+
+    texts: list[str] = []
+    parts_out: list[dict] = []
+    tool_calls: list[dict] = []
+    tool_messages: list[dict] = []
+
+    raw_parts = content.get("parts") or []
+    if isinstance(raw_parts, dict):
+        raw_parts = [raw_parts]
+    for part in raw_parts:
+        if not isinstance(part, dict):
+            raise _invalid("Content part must be an object")
+        if "text" in part:
+            texts.append(part.get("text") or "")
+            parts_out.append({"type": "text", "text": part.get("text") or ""})
+        elif "inlineData" in part or "inline_data" in part:
+            blob = _alias(part, "inlineData", "inline_data") or {}
+            mime = _alias(blob, "mimeType", "mime_type") or "application/octet-stream"
+            parts_out.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{blob.get('data', '')}"},
+            })
+        elif "functionCall" in part or "function_call" in part:
+            fc = _alias(part, "functionCall", "function_call") or {}
+            name = fc.get("name", "")
+            tool_calls.append({
+                "id": ids.new_call(name),
+                "type": "function",
+                "function": {"name": name, "arguments": json.dumps(fc.get("args") or {})},
+            })
+        elif "functionResponse" in part or "function_response" in part:
+            fr = _alias(part, "functionResponse", "function_response") or {}
+            name = fr.get("name", "")
+            tool_messages.append({
+                "role": "tool",
+                "tool_call_id": ids.match_response(name),
+                "content": json.dumps(fr.get("response") or {}),
+            })
+        elif "fileData" in part or "file_data" in part:
+            raise _invalid("fileData parts (Files API) are not supported by this endpoint")
+        else:
+            raise _invalid(f"Unsupported content part keys: {sorted(part.keys())!r}")
+
+    if is_model:
+        out: dict = {"role": "assistant", "content": "".join(texts) or None}
+        if tool_calls:
+            out["tool_calls"] = tool_calls
+        return [out]
+
+    out_messages = tool_messages
+    if parts_out:
+        if len(parts_out) == 1 and parts_out[0]["type"] == "text":
+            out_messages.append({"role": "user", "content": parts_out[0]["text"]})
+        else:
+            out_messages.append({"role": "user", "content": parts_out})
+    return out_messages
+
+
+def _apply_generation_config(gc: dict, out: dict) -> None:
+    temperature = gc.get("temperature")
+    if temperature is not None:
+        out["temperature"] = temperature
+    top_p = _alias(gc, "topP", "top_p")
+    if top_p is not None:
+        out["top_p"] = top_p
+    max_tokens = _alias(gc, "maxOutputTokens", "max_output_tokens")
+    if max_tokens is not None:
+        out["max_tokens"] = max_tokens
+    stop = _alias(gc, "stopSequences", "stop_sequences")
+    if stop:
+        out["stop"] = stop
+    seed = gc.get("seed")
+    if seed is not None:
+        out["seed"] = seed
+    n = _alias(gc, "candidateCount", "candidate_count")
+    if n is not None and n != 1:
+        raise _invalid("candidateCount > 1 is not supported by this endpoint")
+    mime = _alias(gc, "responseMimeType", "response_mime_type")
+    if mime not in (None, "", "text/plain", "application/json"):
+        raise _invalid(f"Unsupported responseMimeType: {mime!r}")
+    if mime == "application/json":
+        out["response_format"] = {"type": "json_object"}
+        if _alias(gc, "responseSchema", "response_schema") is not None \
+                or _alias(gc, "responseJsonSchema", "response_json_schema") is not None:
+            # v1: json mode is honored, the schema constraint itself is not.
+            logger.warning("gemini_response_schema_dropped")
+    if _alias(gc, "topK", "top_k") is not None:
+        logger.info("gemini_top_k_dropped")
+    if _alias(gc, "thinkingConfig", "thinking_config") is not None:
+        logger.warning("gemini_thinking_config_dropped")
+
+
+def to_openai_request(req: GeminiGenerateRequest, *, model: str, stream: bool) -> dict:
+    """Translate a validated Gemini request into the internal OpenAI
+    chat.completions dict consumed by the chat engine. `model` comes from
+    the URL path, `stream` from the :streamGenerateContent action."""
+    if req.cached_content:
+        raise _invalid("cachedContent is not supported by this endpoint")
+    if req.safety_settings:
+        logger.warning("gemini_safety_settings_dropped")
+
+    contents = req.contents
+    if isinstance(contents, str):
+        contents = [{"role": "user", "parts": [{"text": contents}]}]
+    elif isinstance(contents, dict):
+        contents = [contents]
+
+    ids = _CallIdAllocator()
+    messages: list[dict] = []
+    if req.system_instruction is not None:
+        text = _system_text(req.system_instruction)
+        if text:
+            messages.append({"role": "system", "content": text})
+    for content in contents:
+        if not isinstance(content, dict):
+            raise _invalid("Each entry in 'contents' must be a Content object")
+        messages.extend(_translate_content(content, ids))
+    if not messages:
+        raise _invalid("'contents' produced no messages")
+
+    out: dict = {"model": model, "messages": messages, "stream": stream}
+    if req.tools:
+        tools = _translate_tools(req.tools)
+        if tools:
+            out["tools"] = tools
+    if req.tool_config:
+        tc = _translate_tool_config(req.tool_config)
+        if tc is not None:
+            out["tool_choice"] = tc
+    if req.generation_config:
+        _apply_generation_config(req.generation_config, out)
+    return out
+
+
+# ── Response translation (OpenAI → Gemini) ─────────────────────────────
+
+_FINISH_REASON_MAP = {
+    "stop": "STOP",
+    "length": "MAX_TOKENS",
+    "content_filter": "SAFETY",
+    "tool_calls": "STOP",
+    "function_call": "STOP",
+}
+
+
+def _usage_metadata(usage: dict) -> dict:
+    prompt = usage.get("prompt_tokens", 0) or 0
+    completion = usage.get("completion_tokens", 0) or 0
+    return {
+        "promptTokenCount": prompt,
+        "candidatesTokenCount": completion,
+        "totalTokenCount": usage.get("total_tokens") or (prompt + completion),
+    }
+
+
+def to_gemini_response(resp: dict) -> dict:
+    choices = resp.get("choices") or [{}]
+    choice = choices[0] if choices else {}
+    msg = choice.get("message") or {}
+
+    parts: list[dict] = []
+    if msg.get("content"):
+        parts.append({"text": msg["content"]})
+    for tc in msg.get("tool_calls") or []:
+        fn = tc.get("function") or {}
+        parts.append({
+            "functionCall": {
+                "name": fn.get("name", ""),
+                "args": _parse_json_object(fn.get("arguments")),
+            }
+        })
+
+    return {
+        "candidates": [{
+            "content": {"role": "model", "parts": parts},
+            "finishReason": _FINISH_REASON_MAP.get(choice.get("finish_reason"), "STOP"),
+            "index": 0,
+        }],
+        "usageMetadata": _usage_metadata(resp.get("usage") or {}),
+        "modelVersion": resp.get("model", ""),
+        "responseId": resp.get("id", ""),
+    }
+
+
+# ── Stream translation (OpenAI chunk frames → Gemini chunk dicts) ──────
+
+async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, None]:
+    """Transform the engine's OpenAI chunk-dict stream into
+    GenerateContentResponse-shaped chunk dicts. Text deltas stream through
+    one-to-one; tool-call argument fragments are buffered (Gemini never
+    emits a partial functionCall) and flushed complete before the final
+    finishReason + usageMetadata chunk."""
+    model = ""
+    resp_id = ""
+    finish: str | None = None
+    usage: dict = {}
+    tool_buf: dict[int, dict] = {}
+
+    def _base(extra: dict) -> dict:
+        return {"modelVersion": model, "responseId": resp_id, **extra}
+
+    try:
+        async for frame in frames:
+            if "error" in frame and "choices" not in frame:
+                err = frame.get("error") or {}
+                yield {
+                    "error": {
+                        "code": 500,
+                        "message": err.get("message", "Upstream provider error"),
+                        "status": "INTERNAL",
+                    }
+                }
+                return
+
+            model = frame.get("model") or model
+            resp_id = frame.get("id") or resp_id
+            choices = frame.get("choices") or []
+            choice = choices[0] if choices else {}
+            delta = choice.get("delta") or {}
+
+            text = delta.get("content")
+            if text:
+                yield _base({
+                    "candidates": [{
+                        "content": {"role": "model", "parts": [{"text": text}]},
+                        "index": 0,
+                    }],
+                })
+
+            for tcd in delta.get("tool_calls") or []:
+                slot = tool_buf.setdefault(tcd.get("index", 0), {"name": "", "args": ""})
+                fn = tcd.get("function") or {}
+                if fn.get("name"):
+                    slot["name"] = fn["name"]
+                if fn.get("arguments"):
+                    slot["args"] += fn["arguments"]
+
+            if choice.get("finish_reason"):
+                finish = choice["finish_reason"]
+            if frame.get("usage"):
+                usage = frame["usage"]
+
+        # Normal end of stream.
+        if tool_buf:
+            yield _base({
+                "candidates": [{
+                    "content": {
+                        "role": "model",
+                        "parts": [
+                            {"functionCall": {
+                                "name": slot["name"],
+                                "args": _parse_json_object(slot["args"]),
+                            }}
+                            for _, slot in sorted(tool_buf.items())
+                        ],
+                    },
+                    "index": 0,
+                }],
+            })
+        yield _base({
+            "candidates": [{
+                "content": {"role": "model", "parts": []},
+                "finishReason": _FINISH_REASON_MAP.get(finish, "STOP"),
+                "index": 0,
+            }],
+            "usageMetadata": _usage_metadata(usage),
+        })
+    finally:
+        await aclose_quietly(frames)
+
+
+# ── Error envelope ──────────────────────────────────────────────────────
+
+_STATUS_TO_GOOGLE_STATUS = {
+    400: "INVALID_ARGUMENT",
+    401: "UNAUTHENTICATED",
+    403: "PERMISSION_DENIED",
+    404: "NOT_FOUND",
+    429: "RESOURCE_EXHAUSTED",
+    500: "INTERNAL",
+    503: "UNAVAILABLE",
+}
+
+
+def error_response(status: int, message: str) -> JSONResponse:
+    """Render an error in the Google API envelope (422 collapses to 400)."""
+    if status == 422:
+        status = 400
+    return JSONResponse(
+        status_code=status,
+        content={
+            "error": {
+                "code": status,
+                "message": message,
+                "status": _STATUS_TO_GOOGLE_STATUS.get(status, "INTERNAL"),
+            }
+        },
+    )

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -122,13 +122,20 @@ def _translate_tool_config(tc: dict) -> str | dict | None:
     fcc = _alias(tc, "functionCallingConfig", "function_calling_config")
     if not isinstance(fcc, dict):
         return None
-    mode = (fcc.get("mode") or "").upper()
+    # tool_config is free-form in the wire schema — validate the field
+    # types here so malformed input renders as a native 400, not a 500.
+    mode_raw = fcc.get("mode")
+    if mode_raw is not None and not isinstance(mode_raw, str):
+        raise _invalid("functionCallingConfig.mode must be a string")
+    mode = (mode_raw or "").upper()
     if mode in ("", "MODE_UNSPECIFIED", "AUTO", "VALIDATED"):
         return "auto"
     if mode == "NONE":
         return "none"
     if mode == "ANY":
         allowed = _alias(fcc, "allowedFunctionNames", "allowed_function_names") or []
+        if not isinstance(allowed, list) or not all(isinstance(n, str) for n in allowed):
+            raise _invalid("functionCallingConfig.allowedFunctionNames must be a list of strings")
         if len(allowed) == 1:
             return {"type": "function", "function": {"name": allowed[0]}}
         return "required"
@@ -361,6 +368,21 @@ def to_gemini_response(resp: dict) -> dict:
 
 # ── Stream translation (OpenAI chunk frames → Gemini chunk dicts) ──────
 
+# Engine SSE error-frame `type` → HTTP-ish code for the Google envelope
+# (the Google status string derives from the code via
+# _STATUS_TO_GOOGLE_STATUS). Client retry/backoff logic keys off the
+# status, so a provider rate limit must surface as RESOURCE_EXHAUSTED,
+# not INTERNAL.
+_STREAM_ERROR_TYPE_TO_CODE = {
+    "rate_limit_error": 429,
+    "model_not_found": 404,
+    "context_length_exceeded": 400,
+    "upstream_auth_error": 503,
+    "upstream_timeout": 503,
+    "upstream_error": 503,
+}
+
+
 async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, None]:
     """Transform the engine's OpenAI chunk-dict stream into
     GenerateContentResponse-shaped chunk dicts. Text deltas stream through
@@ -380,13 +402,21 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
         async for frame in frames:
             if "error" in frame and "choices" not in frame:
                 err = frame.get("error") or {}
+                code = _STREAM_ERROR_TYPE_TO_CODE.get(err.get("type"), 500)
                 yield {
                     "error": {
-                        "code": 500,
+                        "code": code,
                         "message": err.get("message", "Upstream provider error"),
-                        "status": "INTERNAL",
+                        "status": _STATUS_TO_GOOGLE_STATUS.get(code, "INTERNAL"),
                     }
                 }
+                # Drain, don't return-and-aclose: the engine follows the
+                # error frame with [DONE] and completes normally, logging
+                # 503 + the real error type. aclose() would raise
+                # GeneratorExit at its suspended yield and the engine would
+                # mislog this as a 499 client disconnect.
+                async for _ in frames:
+                    pass
                 return
 
             model = frame.get("model") or model

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -1,7 +1,8 @@
 """Gemini (Google AI Studio) API ↔ internal OpenAI format translation.
 
-Pure functions + one pure async stream transformer. Mapping decisions are
-documented in PLAN-NATIVE-PROTOCOLS.md §4; the load-bearing ones:
+Pure functions + one pure async stream transformer. The caller-visible
+limitations are listed in integrations/gemini-sdk.md; the load-bearing
+mapping decisions are:
 
 - Wire fields are accepted in BOTH camelCase (REST / google-genai SDK)
   and snake_case (some client serializations).
@@ -30,7 +31,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from app.protocols import clamp_stop_sequences
 from app.protocols.anthropic import _parse_json_object
-from app.protocols.sse import aclose_quietly
+from app.protocols.sse import finish_quietly
 
 logger = structlog.get_logger()
 
@@ -271,31 +272,50 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
     return out_messages
 
 
+# generationConfig is free-form on the wire, so its numbers are validated
+# here against the API's documented ranges. Out-of-range values are
+# rejected by the upstream as a BadRequest, which the engine reports as a
+# retryable 500 INTERNAL / 503 UNAVAILABLE — SDKs then back off and retry
+# forever a request that can never succeed. Catching them here keeps the
+# failure an honest native 400.
+
+def _bounded_number(value, *, field: str, low: float, high: float) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise _invalid(f"{field} must be a number between {low} and {high}")
+    # NaN/inf fail the comparison and land in the same 400.
+    if not low <= value <= high:
+        raise _invalid(f"{field} must be between {low} and {high}")
+    return value
+
+
+def _positive_int(value, *, field: str) -> int:
+    """A budget < 1 can never succeed upstream. JSON numbers may decode as
+    an integral float (100.0), which is accepted and narrowed."""
+    if isinstance(value, bool):
+        ok = False
+    elif isinstance(value, int):
+        ok = value >= 1
+    elif isinstance(value, float):
+        ok = value.is_integer() and value >= 1
+    else:
+        ok = False
+    if not ok:
+        raise _invalid(f"{field} must be an integer >= 1")
+    return int(value)
+
+
 def _apply_generation_config(gc: dict, out: dict) -> None:
     temperature = gc.get("temperature")
     if temperature is not None:
-        out["temperature"] = temperature
+        out["temperature"] = _bounded_number(
+            temperature, field="temperature", low=0.0, high=2.0
+        )
     top_p = _alias(gc, "topP", "top_p")
     if top_p is not None:
-        out["top_p"] = top_p
+        out["top_p"] = _bounded_number(top_p, field="topP", low=0.0, high=1.0)
     max_tokens = _alias(gc, "maxOutputTokens", "max_output_tokens")
     if max_tokens is not None:
-        # generationConfig is free-form on the wire. A 0/negative budget
-        # can never succeed upstream, and the upstream's BadRequest would
-        # come back through the engine as a retryable 500 INTERNAL that
-        # SDKs back off and retry forever — reject it as a native 400
-        # instead. JSON numbers may arrive as an integral float (100.0).
-        if isinstance(max_tokens, bool):
-            valid = False
-        elif isinstance(max_tokens, int):
-            valid = max_tokens >= 1
-        elif isinstance(max_tokens, float):
-            valid = max_tokens.is_integer() and max_tokens >= 1
-        else:
-            valid = False
-        if not valid:
-            raise _invalid("maxOutputTokens must be an integer >= 1")
-        out["max_tokens"] = int(max_tokens)
+        out["max_tokens"] = _positive_int(max_tokens, field="maxOutputTokens")
     stop = _alias(gc, "stopSequences", "stop_sequences")
     if stop:
         if isinstance(stop, list):
@@ -443,9 +463,11 @@ _STREAM_ERROR_TYPE_TO_CODE = {
     "rate_limit_error": 429,
     "model_not_found": 404,
     "context_length_exceeded": 400,
-    # OUR provider credential failed — permanent until the operator fixes
-    # it, so it must not surface as a retryable 503/UNAVAILABLE.
+    # Operator-side and permanent until they act (credential rejected, or
+    # no provider key configured at all) — must not surface as a retryable
+    # 503/UNAVAILABLE that SDKs keep backing off against.
     "upstream_auth_error": 403,
+    "no_providers_configured": 403,
     "upstream_timeout": 503,
     "upstream_error": 503,
 }
@@ -478,11 +500,11 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
                         "status": _STATUS_TO_GOOGLE_STATUS.get(code, "INTERNAL"),
                     }
                 }
-                # Drain, don't return-and-aclose: the engine follows the
-                # error frame with [DONE] and completes normally, logging
-                # 503 + the real error type. aclose() would raise
-                # GeneratorExit at its suspended yield and the engine would
-                # mislog this as a 499 client disconnect.
+                # Read on to the [DONE] the engine sends after its error
+                # frame, so `finish()` below drains it to a normal
+                # completion and it logs 503 + the real error type.
+                # Returning here without that would leave it suspended and
+                # `finish()` would close it, mislogging a 499 disconnect.
                 async for _ in frames:
                     pass
                 return
@@ -541,7 +563,10 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
             "usageMetadata": _usage_metadata(usage),
         })
     finally:
-        await aclose_quietly(frames)
+        # Last, deliberately: this drains the engine (running its
+        # RequestLog commit), so the final chunk above always reaches the
+        # client ahead of that DB write. See OpenAIFrameStream.
+        await finish_quietly(frames)
 
 
 # ── Error envelope ──────────────────────────────────────────────────────

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -14,8 +14,10 @@ mapping decisions are:
   unmatched call with the same name (the positional semantics Gemini
   itself uses).
 - Streaming never emits a partial functionCall: tool-call argument
-  fragments are buffered and flushed as one complete part before the
-  final finishReason/usageMetadata chunk.
+  fragments are buffered and flushed as complete parts — as soon as the
+  model moves on to text again, or before the final
+  finishReason/usageMetadata chunk — so the client still sees text and
+  calls in the order the model produced them.
 """
 
 from __future__ import annotations
@@ -29,8 +31,8 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
-from app.protocols import clamp_stop_sequences
-from app.protocols.anthropic import _parse_json_object, flatten_openai_content
+from app.protocols import clamp_stop_sequences, require_text
+from app.protocols.anthropic import _args_complete, _parse_json_object, flatten_openai_content
 from app.protocols.sse import finish_quietly
 
 logger = structlog.get_logger()
@@ -124,13 +126,18 @@ def _translate_tools(tools: list[dict]) -> list[dict]:
                 raise _invalid(
                     f"functionDeclaration '{decl['name']}' has non-object parameters"
                 )
+            description = decl.get("description")
+            if description is not None and not isinstance(description, str):
+                raise _invalid(
+                    f"functionDeclaration '{decl['name']}' has a non-string description"
+                )
             fn: dict = {
                 "name": decl["name"],
                 "parameters": normalize_gemini_schema(params)
                 if params else {"type": "object", "properties": {}},
             }
-            if decl.get("description"):
-                fn["description"] = decl["description"]
+            if description:
+                fn["description"] = description
             out.append({"type": "function", "function": fn})
     return out
 
@@ -175,9 +182,17 @@ def _system_text(si: str | dict) -> str:
     parts = si.get("parts") or []
     if isinstance(parts, dict):
         parts = [parts]
-    texts = [p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")]
-    dropped = len(parts) - len(texts)
-    if dropped > 0:
+    texts: list[str] = []
+    dropped = 0
+    for p in parts:
+        if isinstance(p, dict) and "text" in p:
+            # A text part, empty text included — nothing is dropped here.
+            text = require_text(p["text"], field="systemInstruction.parts[].text")
+            if text:
+                texts.append(text)
+        else:
+            dropped += 1
+    if dropped:
         # systemInstruction is text in every documented use; anything else
         # has no system-message equivalent to translate to. Log it rather
         # than dropping caller-supplied context in silence, matching the
@@ -244,8 +259,9 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
             logger.debug("gemini_thought_part_dropped")
             continue
         if "text" in part:
-            texts.append(part.get("text") or "")
-            parts_out.append({"type": "text", "text": part.get("text") or ""})
+            text = require_text(part["text"], field="parts[].text")
+            texts.append(text)
+            parts_out.append({"type": "text", "text": text})
         elif "inlineData" in part or "inline_data" in part:
             blob = _alias(part, "inlineData", "inline_data") or {}
             mime = _alias(blob, "mimeType", "mime_type") or "application/octet-stream"
@@ -488,11 +504,13 @@ _STREAM_ERROR_TYPE_TO_CODE = {
     "rate_limit_error": 429,
     "model_not_found": 404,
     "context_length_exceeded": 400,
-    # Operator-side and permanent until they act (credential rejected, or
-    # no provider key configured at all) — must not surface as a retryable
+    # Operator-side and permanent until they act (credential rejected, no
+    # provider key configured at all, or no configured model with the
+    # capability the request needs) — must not surface as a retryable
     # 503/UNAVAILABLE that SDKs keep backing off against.
     "upstream_auth_error": 403,
     "no_providers_configured": 403,
+    "no_capable_provider": 403,
     "upstream_timeout": 503,
     "upstream_error": 503,
 }
@@ -502,8 +520,10 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
     """Transform the engine's OpenAI chunk-dict stream into
     GenerateContentResponse-shaped chunk dicts. Text deltas stream through
     one-to-one; tool-call argument fragments are buffered (Gemini never
-    emits a partial functionCall) and flushed complete before the final
-    finishReason + usageMetadata chunk."""
+    emits a partial functionCall) and flushed complete the moment a text
+    delta follows them — the model finished its calls and moved on, and
+    text it wrote after a call must not reach the client before it — or
+    before the final finishReason + usageMetadata chunk."""
     model = ""
     resp_id = ""
     finish: str | None = None
@@ -513,11 +533,54 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
     def _base(extra: dict) -> dict:
         return {"modelVersion": model, "responseId": resp_id, **extra}
 
+    def _function_call_chunk(*, only_complete: bool = False) -> dict | None:
+        """Buffered calls as complete functionCall parts, in index order,
+        removed from the buffer. `only_complete` (the mid-stream flush)
+        keeps back a call whose arguments are not yet whole JSON: a text
+        delta landing between two argument fragments of one call must not
+        split it into two parts — it waits for end-of-stream. Returns None
+        when nothing is ready."""
+        ready = [
+            (idx, slot) for idx, slot in sorted(tool_buf.items())
+            if not only_complete or _args_complete(slot["args"])
+        ]
+        if not ready:
+            return None
+        for idx, _ in ready:
+            del tool_buf[idx]
+        return _base({
+            "candidates": [{
+                "content": {
+                    "role": "model",
+                    "parts": [
+                        {"functionCall": {
+                            "name": slot["name"],
+                            "args": _parse_json_object(slot["args"]),
+                        }}
+                        for _, slot in ready
+                    ],
+                },
+                "index": 0,
+            }],
+        })
+
     try:
         async for frame in frames:
             if "error" in frame and "choices" not in frame:
                 err = frame.get("error") or {}
                 code = _STREAM_ERROR_TYPE_TO_CODE.get(err.get("type"), 500)
+                # Read on to the [DONE] the engine sends right after its
+                # error frame BEFORE handing the error chunk to the client.
+                # With the sentinel consumed, `finish()` in the finally
+                # below DRAINS the engine to a normal completion whether we
+                # are resumed after the yield or closed at it (client gone
+                # while the chunk was in flight), and the engine logs
+                # 503 + the real error type either way. Yielding first
+                # would leave that classification hanging on our being
+                # resumed before the client disconnects: a close at the
+                # yield would forward as aclose() into the engine instead.
+                async for _ in frames:
+                    pass
                 yield {
                     "error": {
                         "code": code,
@@ -525,13 +588,6 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
                         "status": _STATUS_TO_GOOGLE_STATUS.get(code, "INTERNAL"),
                     }
                 }
-                # Read on to the [DONE] the engine sends after its error
-                # frame, so `finish()` below drains it to a normal
-                # completion and it logs 503 + the real error type.
-                # Returning here without that would leave it suspended and
-                # `finish()` would close it, mislogging a 499 disconnect.
-                async for _ in frames:
-                    pass
                 return
 
             model = frame.get("model") or model
@@ -542,6 +598,18 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
 
             text = delta.get("content")
             if text:
+                # Text first, then this delta's own tool_calls: OpenAI's
+                # delta has no ordering between the two, and LiteLLM folds
+                # a Gemini chunk of [functionCall, text] and one of
+                # [text, functionCall] into the same delta — so a call the
+                # model emitted BEFORE text in the same chunk comes out
+                # after it. Not recoverable at this layer (documented in
+                # integrations/gemini-sdk.md); across chunks the order is
+                # preserved by the flush below.
+                if tool_buf:
+                    ready = _function_call_chunk(only_complete=True)
+                    if ready is not None:
+                        yield ready
                 yield _base({
                     "candidates": [{
                         "content": {"role": "model", "parts": [{"text": text}]},
@@ -564,21 +632,7 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
 
         # Normal end of stream.
         if tool_buf:
-            yield _base({
-                "candidates": [{
-                    "content": {
-                        "role": "model",
-                        "parts": [
-                            {"functionCall": {
-                                "name": slot["name"],
-                                "args": _parse_json_object(slot["args"]),
-                            }}
-                            for _, slot in sorted(tool_buf.items())
-                        ],
-                    },
-                    "index": 0,
-                }],
-            })
+            yield _function_call_chunk()
         yield _base({
             "candidates": [{
                 "content": {"role": "model", "parts": []},

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -28,6 +28,7 @@ from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
+from app.protocols import clamp_stop_sequences
 from app.protocols.anthropic import _parse_json_object
 from app.protocols.sse import aclose_quietly
 
@@ -90,6 +91,10 @@ _UNSUPPORTED_TOOL_KEYS = (
     ("codeExecution", "code_execution"),
     ("urlContext", "url_context"),
 )
+
+# Part keys that only carry thinking metadata (a part made of nothing but
+# these has no translatable payload).
+_THOUGHT_PART_KEYS = {"thought", "thoughtSignature", "thought_signature"}
 
 
 def _translate_tools(tools: list[dict]) -> list[dict]:
@@ -204,6 +209,15 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
     for part in raw_parts:
         if not isinstance(part, dict):
             raise _invalid("Content part must be an object")
+        if part.get("thought") or (part and not (set(part) - _THOUGHT_PART_KEYS)):
+            # Thought(-summary)/signature parts mirror Anthropic thinking
+            # blocks: no internal equivalent — drop, never reject. Parts
+            # that carry a real payload NEXT TO a signature (e.g. a
+            # functionCall with thoughtSignature) are not dropped.
+            # debug, not warning: agentic clients resend full history every
+            # request, so a per-part warning would grow O(n²) over a session.
+            logger.debug("gemini_thought_part_dropped")
+            continue
         if "text" in part:
             texts.append(part.get("text") or "")
             parts_out.append({"type": "text", "text": part.get("text") or ""})
@@ -239,6 +253,13 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
         out: dict = {"role": "assistant", "content": "".join(texts) or None}
         if tool_calls:
             out["tool_calls"] = tool_calls
+        if out["content"] is None and not tool_calls:
+            # Same guard as the Anthropic sibling: a model turn with no
+            # representable parts (empty parts echoed back in history,
+            # thought-only turns) must keep content "" — the engine's
+            # exclude_none dump would otherwise send a bare
+            # {"role": "assistant"}, which upstreams reject.
+            out["content"] = ""
         return [out]
 
     out_messages = tool_messages
@@ -262,6 +283,10 @@ def _apply_generation_config(gc: dict, out: dict) -> None:
         out["max_tokens"] = max_tokens
     stop = _alias(gc, "stopSequences", "stop_sequences")
     if stop:
+        if isinstance(stop, list):
+            stop = clamp_stop_sequences(
+                stop, event="gemini_stop_sequences_truncated"
+            )
         out["stop"] = stop
     seed = gc.get("seed")
     if seed is not None:
@@ -403,7 +428,9 @@ _STREAM_ERROR_TYPE_TO_CODE = {
     "rate_limit_error": 429,
     "model_not_found": 404,
     "context_length_exceeded": 400,
-    "upstream_auth_error": 503,
+    # OUR provider credential failed — permanent until the operator fixes
+    # it, so it must not surface as a retryable 503/UNAVAILABLE.
+    "upstream_auth_error": 403,
     "upstream_timeout": 503,
     "upstream_error": 503,
 }
@@ -513,6 +540,16 @@ _STATUS_TO_GOOGLE_STATUS = {
     500: "INTERNAL",
     503: "UNAVAILABLE",
 }
+
+
+def native_status(status: int, error_type: str | None) -> int:
+    """Correct the engine's generic HTTP status using its translated
+    error_type (relayed via the x-orca-error-type header) where the plain
+    status would misrepresent the failure on this surface — e.g. the
+    engine uses 422 for model_not_found but Google's contract is 404
+    NOT_FOUND. Derived from _STREAM_ERROR_TYPE_TO_CODE (rather than a
+    hand-kept mirror) so the stream and blocking paths cannot drift."""
+    return _STREAM_ERROR_TYPE_TO_CODE.get(error_type, status)
 
 
 def error_response(status: int, message: str) -> JSONResponse:

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -227,7 +227,20 @@ class _CallIdAllocator:
 
 
 def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
-    role = content.get("role") or "user"
+    raw_parts = content.get("parts") or []
+    if isinstance(raw_parts, dict):
+        raw_parts = [raw_parts]
+
+    role = content.get("role")
+    if not role:
+        # `role` is optional in the REST API. A turn carrying functionCall
+        # parts can only be the model's, so infer that instead of reading
+        # it as a user turn and rejecting the call below — the google-genai
+        # SDK always sets the role, hand-rolled history replay may not.
+        role = "model" if any(
+            isinstance(p, dict) and ("functionCall" in p or "function_call" in p)
+            for p in raw_parts
+        ) else "user"
     if role not in ("user", "model"):
         raise _invalid(f"Unsupported content role: {role!r}")
     is_model = role == "model"
@@ -236,10 +249,6 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
     parts_out: list[dict] = []
     tool_calls: list[dict] = []
     tool_messages: list[dict] = []
-
-    raw_parts = content.get("parts") or []
-    if isinstance(raw_parts, dict):
-        raw_parts = [raw_parts]
     for part in raw_parts:
         if not isinstance(part, dict):
             raise _invalid("Content part must be an object")
@@ -264,6 +273,16 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
             texts.append(text)
             parts_out.append({"type": "text", "text": text})
         elif "inlineData" in part or "inline_data" in part:
+            if is_model:
+                # An OpenAI assistant message carries text and tool calls,
+                # nothing else, so a model-turn image has no representation.
+                # Reject rather than drop it: the turn would otherwise reach
+                # the upstream missing content the caller sent, and the
+                # model would answer a history that never existed.
+                raise _invalid(
+                    "inlineData parts in a role:'model' content are not supported "
+                    "by this endpoint"
+                )
             blob = _alias(part, "inlineData", "inline_data") or {}
             mime = _alias(blob, "mimeType", "mime_type") or "application/octet-stream"
             parts_out.append({
@@ -290,6 +309,15 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
                 "function": {"name": name, "arguments": json.dumps(fc.get("args") or {})},
             })
         elif "functionResponse" in part or "function_response" in part:
+            if is_model:
+                # Mirror of the functionCall rule: a result belongs to the
+                # caller's turn. In a model turn it would be discarded with
+                # the tool messages AND consume a pending call id, so a
+                # later genuine response for the same name would pair to
+                # the wrong call.
+                raise _invalid(
+                    "functionResponse parts are only valid in a role:'user' content"
+                )
             fr = _alias(part, "functionResponse", "function_response") or {}
             name = fr.get("name", "")
             tool_messages.append({
@@ -547,6 +575,8 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
     finish: str | None = None
     usage: dict = {}
     tool_buf: dict[int, dict] = {}
+    flushed_names: dict[int, str] = {}  # index → name, for already-emitted calls
+    failed = False
 
     def _base(extra: dict) -> dict:
         return {"modelVersion": model, "responseId": resp_id, **extra}
@@ -564,8 +594,10 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
         ]
         if not ready:
             return None
-        for idx, _ in ready:
+        for idx, slot in ready:
             del tool_buf[idx]
+            if only_complete:
+                flushed_names[idx] = slot["name"]
         return _base({
             "candidates": [{
                 "content": {
@@ -636,7 +668,19 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
                 })
 
             for tcd in delta.get("tool_calls") or []:
-                slot = tool_buf.setdefault(tcd.get("index", 0), {"name": "", "args": ""})
+                idx = tcd.get("index", 0)
+                if idx not in tool_buf and idx in flushed_names:
+                    # More fragments for a call already emitted as a
+                    # complete part (its arguments parsed at that point and
+                    # text followed). The part cannot be amended, so carry
+                    # the name over to the remainder and log it.
+                    logger.warning(
+                        "gemini_tool_fragments_after_flush",
+                        index=idx, name=flushed_names[idx],
+                    )
+                slot = tool_buf.setdefault(
+                    idx, {"name": flushed_names.get(idx, ""), "args": ""}
+                )
                 fn = tcd.get("function") or {}
                 if fn.get("name"):
                     slot["name"] = fn["name"]
@@ -659,6 +703,11 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
             }],
             "usageMetadata": _usage_metadata(usage),
         })
+    except Exception:
+        # See the Anthropic twin: an adapter fault must reach the engine as
+        # one, not as a close it would file as a client disconnect.
+        failed = True
+        raise
     finally:
         # Last, deliberately: this drains the engine (running its
         # RequestLog commit), so the final chunk above always reaches the
@@ -667,7 +716,7 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
         # lands here as task-group cancellation, and an unshielded await
         # would abort the forwarding before it reaches the engine.
         with anyio.CancelScope(shield=True):
-            await finish_quietly(frames)
+            await finish_quietly(frames, failed=failed)
 
 
 def stream_error_chunk(message: str) -> dict:

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -108,11 +108,22 @@ def _translate_tools(tools: list[dict]) -> list[dict]:
                     "only functionDeclarations are"
                 )
         decls = _alias(tool, "functionDeclarations", "function_declarations") or []
+        # Repeated field on the wire, but free-form in our schema: a client
+        # sending a single declaration as a bare object would otherwise
+        # iterate its keys and blow up as a 500 the SDK retries forever.
+        if not isinstance(decls, list):
+            raise _invalid("functionDeclarations must be a list of declarations")
         for decl in decls:
-            if not decl.get("name"):
+            if not isinstance(decl, dict):
+                raise _invalid("each functionDeclaration must be an object")
+            if not isinstance(decl.get("name"), str) or not decl["name"]:
                 raise _invalid("functionDeclaration is missing 'name'")
             params = _alias(decl, "parameters", "parameters") \
                 or _alias(decl, "parametersJsonSchema", "parameters_json_schema")
+            if params is not None and not isinstance(params, dict):
+                raise _invalid(
+                    f"functionDeclaration '{decl['name']}' has non-object parameters"
+                )
             fn: dict = {
                 "name": decl["name"],
                 "parameters": normalize_gemini_schema(params)
@@ -210,11 +221,18 @@ def _translate_content(content: dict, ids: _CallIdAllocator) -> list[dict]:
     for part in raw_parts:
         if not isinstance(part, dict):
             raise _invalid("Content part must be an object")
-        if part.get("thought") or (part and not (set(part) - _THOUGHT_PART_KEYS)):
-            # Thought(-summary)/signature parts mirror Anthropic thinking
-            # blocks: no internal equivalent — drop, never reject. Parts
-            # that carry a real payload NEXT TO a signature (e.g. a
-            # functionCall with thoughtSignature) are not dropped.
+        # `thought` and `thoughtSignature` mark model-internal reasoning.
+        # Neither has an internal equivalent, so they are dropped, never
+        # rejected — but both are part METADATA that can sit alongside a
+        # real payload: Google attaches signatures to functionCall parts
+        # and requires them echoed back in history, and `thought` is a
+        # sibling flag of the data union. So only the thought itself goes;
+        # a part carrying a payload keeps it. Dropping the whole part
+        # would silently delete a tool call from the turn — a wrong
+        # answer, not a rejection.
+        if part.get("thought"):
+            part = {k: v for k, v in part.items() if k != "text"}
+        if not set(part) - _THOUGHT_PART_KEYS:
             # debug, not warning: agentic clients resend full history every
             # request, so a per-part warning would grow O(n²) over a session.
             logger.debug("gemini_thought_part_dropped")

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -30,7 +30,7 @@ from fastapi.responses import JSONResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from app.protocols import clamp_stop_sequences
-from app.protocols.anthropic import _parse_json_object
+from app.protocols.anthropic import _parse_json_object, flatten_openai_content
 from app.protocols.sse import finish_quietly
 
 logger = structlog.get_logger()
@@ -175,9 +175,15 @@ def _system_text(si: str | dict) -> str:
     parts = si.get("parts") or []
     if isinstance(parts, dict):
         parts = [parts]
-    return "\n\n".join(
-        p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")
-    )
+    texts = [p.get("text", "") for p in parts if isinstance(p, dict) and p.get("text")]
+    dropped = len(parts) - len(texts)
+    if dropped > 0:
+        # systemInstruction is text in every documented use; anything else
+        # has no system-message equivalent to translate to. Log it rather
+        # than dropping caller-supplied context in silence, matching the
+        # Anthropic sibling's anthropic_non_text_system_block_dropped.
+        logger.warning("gemini_non_text_system_part_dropped", count=dropped)
+    return "\n\n".join(texts)
 
 
 class _CallIdAllocator:
@@ -447,8 +453,9 @@ def to_gemini_response(resp: dict) -> dict:
     msg = choice.get("message") or {}
 
     parts: list[dict] = []
-    if msg.get("content"):
-        parts.append({"text": msg["content"]})
+    text = flatten_openai_content(msg.get("content"))
+    if text:
+        parts.append({"text": text})
     for tc in msg.get("tool_calls") or []:
         fn = tc.get("function") or {}
         parts.append({

--- a/app/protocols/gemini.py
+++ b/app/protocols/gemini.py
@@ -26,6 +26,7 @@ import json
 from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterable
 
+import anyio
 import structlog
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
@@ -644,8 +645,18 @@ async def stream_chunks(frames: AsyncIterable[dict]) -> AsyncGenerator[dict, Non
     finally:
         # Last, deliberately: this drains the engine (running its
         # RequestLog commit), so the final chunk above always reaches the
-        # client ahead of that DB write. See OpenAIFrameStream.
-        await finish_quietly(frames)
+        # client ahead of that DB write. See OpenAIFrameStream. Shielded
+        # for the same reason as the Anthropic twin: a client disconnect
+        # lands here as task-group cancellation, and an unshielded await
+        # would abort the forwarding before it reaches the engine.
+        with anyio.CancelScope(shield=True):
+            await finish_quietly(frames)
+
+
+def stream_error_chunk(message: str) -> dict:
+    """The in-stream error chunk for a failure inside the adapter itself
+    (headers already sent, so a non-200 is impossible)."""
+    return {"error": {"code": 500, "message": message, "status": "INTERNAL"}}
 
 
 # ── Error envelope ──────────────────────────────────────────────────────

--- a/app/protocols/sse.py
+++ b/app/protocols/sse.py
@@ -17,10 +17,10 @@ from collections.abc import AsyncGenerator, AsyncIterable
 async def aclose_quietly(obj) -> None:
     """Close an async generator if it supports it, swallowing errors.
 
-    Used in adapter `finally` blocks to forward a client-side close
-    (GeneratorExit on the outer generator) down the generator chain, so
-    the engine's own disconnect handling (upstream aclose + request-log
-    writeback) actually runs instead of waiting for GC finalization.
+    Used to forward a client-side close (GeneratorExit on the outer
+    generator) down the generator chain, so the engine's own disconnect
+    handling (upstream aclose + request-log writeback) actually runs
+    instead of waiting for GC finalization.
     """
     aclose = getattr(obj, "aclose", None)
     if aclose is None:
@@ -31,23 +31,62 @@ async def aclose_quietly(obj) -> None:
         pass
 
 
-async def iter_openai_frames(body_iterator: AsyncIterable) -> AsyncGenerator[dict, None]:
-    """Yield each OpenAI SSE frame as a dict; stop at the [DONE] sentinel.
+async def finish_quietly(source) -> None:
+    """Hand end-of-stream cleanup back to the frame source.
 
-    Completion semantics matter here: after [DONE] the source is DRAINED
-    to natural completion, not aclose()d. The engine's SSE generator is
-    suspended at the [DONE] yield with its `finally` (request-log
-    writeback) still pending — draining lets that run on the normal path,
-    while aclose() would raise GeneratorExit into it and the engine would
-    misclassify a completed stream as a 499 client disconnect. The
-    close-forwarding in `finally` therefore only fires on abnormal exit
-    (downstream cancelled/closed us before [DONE]).
+    `OpenAIFrameStream.finish()` when it is one (drain-or-close, see that
+    class), a plain close for any other async iterable — which keeps the
+    protocol transformers usable with a bare async generator of frame
+    dicts, the property that lets them be unit-tested without an app.
     """
-    buffer = ""
-    done = False
-    drained = False
-    try:
-        async for piece in body_iterator:
+    finish = getattr(source, "finish", None)
+    if finish is not None:
+        await finish()
+        return
+    await aclose_quietly(source)
+
+
+class OpenAIFrameStream:
+    """The engine's SSE body, parsed into frames, with the post-[DONE]
+    handoff under the adapter's control.
+
+    Iteration yields each parsed frame and stops at the `[DONE]` sentinel
+    WITHOUT resuming the engine past it. That ordering is the whole point.
+    The engine's `sse()` generator is suspended at its `yield "[DONE]"`
+    with its `finally` — the RequestLog writeback, a DB commit — still
+    pending, so whoever resumes it awaits that commit. The adapter
+    therefore emits its terminal protocol events first (Anthropic's
+    message_stop, Gemini's final chunk) and calls `finish()` last, from
+    its own `finally`, so a slow or wedged DB can never sit between the
+    last content the client sees and the event that ends the stream.
+
+    `finish()` is required, and does one of two things:
+      - [DONE] was reached → DRAIN the engine to natural completion, so
+        its `finally` runs on the normal path and the request is logged
+        as the 200/503 it actually was.
+      - it was not (client disconnect, cancellation) → forward the close
+        down the chain, so the engine's disconnect handling (upstream
+        aclose + 499 writeback) runs now instead of at GC finalization.
+    """
+
+    def __init__(self, body_iterator: AsyncIterable):
+        self._source = body_iterator
+        self._gen: AsyncGenerator[dict, None] | None = None
+        self._done = False
+        self._finished = False
+
+    def __aiter__(self) -> AsyncGenerator[dict, None]:
+        # One generator instance for the life of the stream: the error
+        # paths re-enter iteration to consume the frames after an engine
+        # error frame, and a fresh generator would drop whatever partial
+        # frame is sitting in the parse buffer.
+        if self._gen is None:
+            self._gen = self._iter()
+        return self._gen
+
+    async def _iter(self) -> AsyncGenerator[dict, None]:
+        buffer = ""
+        async for piece in self._source:
             if isinstance(piece, bytes):
                 piece = piece.decode("utf-8")
             buffer += piece
@@ -58,30 +97,32 @@ async def iter_openai_frames(body_iterator: AsyncIterable) -> AsyncGenerator[dic
                         continue
                     payload = line[len("data: "):]
                     if payload.strip() == "[DONE]":
-                        done = True
-                        break
+                        self._done = True
+                        return
                     try:
                         parsed = json.loads(payload)
                     except json.JSONDecodeError:
                         continue
                     yield parsed
-                if done:
-                    break
-            if done:
-                break
-        if done:
-            # Drain to completion so the source's finally block runs
-            # naturally (the engine emits nothing after [DONE]).
-            async for _ in body_iterator:
+        # Source ended without a sentinel: the engine already ran to
+        # completion, so there is nothing left to drain or close.
+        self._done = True
+
+    async def finish(self) -> None:
+        if self._finished:
+            return
+        self._finished = True
+        if not self._done:
+            await aclose_quietly(self._source)
+            return
+        try:
+            async for _ in self._source:
                 pass
-        drained = True
-    finally:
-        # not done: closed/cancelled before [DONE] — forward the close so
-        # the engine's disconnect handling runs (harmless no-op when the
-        # source simply ended without a sentinel).
-        # done but not drained: closed/cancelled DURING the post-[DONE]
-        # drain — the engine is still suspended at its [DONE] yield with
-        # the request-log writeback pending; forward the close so the
-        # writeback runs now rather than at GC finalization (or never).
-        if not done or not drained:
-            await aclose_quietly(body_iterator)
+        except BaseException:
+            # Closed or cancelled mid-drain: the engine is still suspended
+            # at its [DONE] yield with the writeback pending, so forward
+            # the close rather than leaving it to the GC finalizer (which
+            # would record a delivered stream as a 499 disconnect, or drop
+            # the row entirely if the process exits first).
+            await aclose_quietly(self._source)
+            raise

--- a/app/protocols/sse.py
+++ b/app/protocols/sse.py
@@ -1,0 +1,78 @@
+"""Parse the chat engine's OpenAI-format SSE frames back into dicts.
+
+The engine (`app.routes.chat.execute_chat`, streaming path) emits
+`data: {json}\n\n` frames with a terminal `data: [DONE]\n\n` sentinel.
+Protocol adapters consume those frames in-process and re-emit
+native-format frames. The producer is our own code, so the framing is
+fully controlled — buffering on `\n\n` boundaries here is defensive,
+not load-bearing.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncGenerator, AsyncIterable
+
+
+async def aclose_quietly(obj) -> None:
+    """Close an async generator if it supports it, swallowing errors.
+
+    Used in adapter `finally` blocks to forward a client-side close
+    (GeneratorExit on the outer generator) down the generator chain, so
+    the engine's own disconnect handling (upstream aclose + request-log
+    writeback) actually runs instead of waiting for GC finalization.
+    """
+    aclose = getattr(obj, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:
+        pass
+
+
+async def iter_openai_frames(body_iterator: AsyncIterable) -> AsyncGenerator[dict, None]:
+    """Yield each OpenAI SSE frame as a dict; stop at the [DONE] sentinel.
+
+    Completion semantics matter here: after [DONE] the source is DRAINED
+    to natural completion, not aclose()d. The engine's SSE generator is
+    suspended at the [DONE] yield with its `finally` (request-log
+    writeback) still pending — draining lets that run on the normal path,
+    while aclose() would raise GeneratorExit into it and the engine would
+    misclassify a completed stream as a 499 client disconnect. The
+    close-forwarding in `finally` therefore only fires on abnormal exit
+    (downstream cancelled/closed us before [DONE]).
+    """
+    buffer = ""
+    done = False
+    try:
+        async for piece in body_iterator:
+            if isinstance(piece, bytes):
+                piece = piece.decode("utf-8")
+            buffer += piece
+            while "\n\n" in buffer:
+                frame, buffer = buffer.split("\n\n", 1)
+                for line in frame.splitlines():
+                    if not line.startswith("data: "):
+                        continue
+                    payload = line[len("data: "):]
+                    if payload.strip() == "[DONE]":
+                        done = True
+                        break
+                    try:
+                        parsed = json.loads(payload)
+                    except json.JSONDecodeError:
+                        continue
+                    yield parsed
+                if done:
+                    break
+            if done:
+                break
+        if done:
+            # Drain to completion so the source's finally block runs
+            # naturally (the engine emits nothing after [DONE]).
+            async for _ in body_iterator:
+                pass
+    finally:
+        if not done:
+            await aclose_quietly(body_iterator)

--- a/app/protocols/sse.py
+++ b/app/protocols/sse.py
@@ -45,6 +45,7 @@ async def iter_openai_frames(body_iterator: AsyncIterable) -> AsyncGenerator[dic
     """
     buffer = ""
     done = False
+    drained = False
     try:
         async for piece in body_iterator:
             if isinstance(piece, bytes):
@@ -73,6 +74,14 @@ async def iter_openai_frames(body_iterator: AsyncIterable) -> AsyncGenerator[dic
             # naturally (the engine emits nothing after [DONE]).
             async for _ in body_iterator:
                 pass
+        drained = True
     finally:
-        if not done:
+        # not done: closed/cancelled before [DONE] — forward the close so
+        # the engine's disconnect handling runs (harmless no-op when the
+        # source simply ended without a sentinel).
+        # done but not drained: closed/cancelled DURING the post-[DONE]
+        # drain — the engine is still suspended at its [DONE] yield with
+        # the request-log writeback pending; forward the close so the
+        # writeback runs now rather than at GC finalization (or never).
+        if not done or not drained:
             await aclose_quietly(body_iterator)

--- a/app/protocols/sse.py
+++ b/app/protocols/sse.py
@@ -31,14 +31,54 @@ async def aclose_quietly(obj) -> None:
         pass
 
 
-async def finish_quietly(source) -> None:
+class AdapterError(Exception):
+    """Thrown INTO the engine's SSE generator when the protocol adapter
+    itself failed mid-stream.
+
+    A plain `aclose()` is indistinguishable from a client disconnect at the
+    engine's suspended yield, so an adapter bug used to be recorded as
+    499/client_disconnect — the user blamed for our own fault, and the
+    regression invisible in analytics. The engine recognises this
+    exception and logs the server-side failure instead.
+    """
+
+
+async def abort_quietly(source) -> None:
+    """Signal the frame source that WE failed, not the client, then close.
+
+    Falls back to a plain close for a source that cannot be thrown into
+    (a bare async iterable in the unit tests).
+    """
+    athrow = getattr(source, "athrow", None)
+    if athrow is not None:
+        try:
+            await athrow(AdapterError())
+        except (StopAsyncIteration, AdapterError, RuntimeError):
+            pass
+        except Exception:
+            pass
+    await aclose_quietly(source)
+
+
+async def finish_quietly(source, *, failed: bool = False) -> None:
     """Hand end-of-stream cleanup back to the frame source.
 
     `OpenAIFrameStream.finish()` when it is one (drain-or-close, see that
     class), a plain close for any other async iterable — which keeps the
     protocol transformers usable with a bare async generator of frame
     dicts, the property that lets them be unit-tested without an app.
+
+    `failed=True` means the transformer is unwinding on its OWN exception:
+    the source is aborted rather than closed, so the engine records an
+    adapter fault instead of a client disconnect.
     """
+    if failed:
+        abort = getattr(source, "abort", None)
+        if abort is not None:
+            await abort()
+            return
+        await abort_quietly(source)
+        return
     finish = getattr(source, "finish", None)
     if finish is not None:
         await finish()
@@ -107,6 +147,14 @@ class OpenAIFrameStream:
         # Source ended without a sentinel: the engine already ran to
         # completion, so there is nothing left to drain or close.
         self._done = True
+
+    async def abort(self) -> None:
+        """The adapter above us failed: tell the engine that, rather than
+        letting a plain close read as a client disconnect."""
+        if self._finished:
+            return
+        self._finished = True
+        await abort_quietly(self._source)
 
     async def finish(self) -> None:
         if self._finished:

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -15,7 +15,10 @@ from typing import TYPE_CHECKING
 
 from packages.auth.encryption import decrypt_credential
 from packages.litellm_adapter.catalog import models_for_provider
-from packages.litellm_adapter.hosted_catalog import HOSTED_MODELS
+from packages.litellm_adapter.hosted_catalog import (
+    HOSTED_MODEL_ALIASES,
+    HOSTED_MODELS,
+)
 from packages.litellm_adapter.types import ProviderDeployment
 
 if TYPE_CHECKING:
@@ -76,17 +79,22 @@ def build_deployments(
     hosted_key = db_provider_keys.get(HOSTED_PROVIDER_NAME) or settings.orcarouter_api_key
     if hosted_key:
         for provider, bare_id in HOSTED_MODELS:
-            deployments.append(
-                ProviderDeployment(
-                    model_name=bare_id,
-                    litellm_model=f"{provider}/{bare_id}",
-                    api_key=hosted_key,
-                    api_base=settings.orcarouter_base_url,
-                    provider=HOSTED_PROVIDER_NAME,
-                    custom_llm_provider="openai",
-                    extra_headers={"X-OrcaRouter-beta-usd": "response"},
+            wire_id = f"{provider}/{bare_id}"
+            model_groups = [bare_id]
+            if wire_id in HOSTED_MODEL_ALIASES:
+                model_groups.append(wire_id)
+            for model_group in model_groups:
+                deployments.append(
+                    ProviderDeployment(
+                        model_name=model_group,
+                        litellm_model=wire_id,
+                        api_key=hosted_key,
+                        api_base=settings.orcarouter_base_url,
+                        provider=HOSTED_PROVIDER_NAME,
+                        custom_llm_provider="openai",
+                        extra_headers={"X-OrcaRouter-beta-usd": "response"},
+                    )
                 )
-            )
 
     return deployments
 

--- a/app/router_cache.py
+++ b/app/router_cache.py
@@ -93,6 +93,12 @@ def build_deployments(
                         provider=HOSTED_PROVIDER_NAME,
                         custom_llm_provider="openai",
                         extra_headers={"X-OrcaRouter-beta-usd": "response"},
+                        # Both spellings are ONE upstream. LiteLLM derives a
+                        # deployment id per entry, so without pinning it the
+                        # two names carry independent cooldown/allowed-fails
+                        # state: a dead upstream would be probed (and paid
+                        # for) once per alias before each cooled down.
+                        deployment_id=f"hosted::{wire_id}",
                     )
                 )
 

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -122,12 +122,14 @@ async def anthropic_count_tokens(
         raw = {**raw, "max_tokens": raw.get("max_tokens") or 1}
         areq = proto.AnthropicMessagesRequest.model_validate(raw)
         openai_body = proto.to_openai_request(areq)
+        return JSONResponse({"input_tokens": _count_input_tokens(openai_body)})
     except HTTPException as exc:
         return proto.error_response(exc.status_code, str(exc.detail))
     except ValidationError as exc:
         return proto.error_response(400, _validation_message(exc))
-
-    return JSONResponse({"input_tokens": _count_input_tokens(openai_body)})
+    except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+        logger.warning("anthropic_count_tokens_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")
 
 
 def _count_input_tokens(openai_body: dict) -> int:

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.deps import get_db, get_key_context
 from app.protocols import anthropic as proto
 from app.protocols.sse import iter_openai_frames
-from app.routes.chat import execute_chat
+from app.routes.chat import ERROR_TYPE_HEADER, execute_chat
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 
@@ -78,7 +78,15 @@ async def anthropic_messages(
         openai_body = ChatCompletionRequest.model_validate(proto.to_openai_request(areq))
         inner = await execute_chat(openai_body, kc, db)
     except HTTPException as exc:
-        return proto.error_response(exc.status_code, str(exc.detail))
+        # native_status: the engine relays its translated error type in a
+        # header (e.g. model_not_found is 422 there, 404 not_found_error
+        # on this surface).
+        return proto.error_response(
+            proto.native_status(
+                exc.status_code, (exc.headers or {}).get(ERROR_TYPE_HEADER)
+            ),
+            str(exc.detail),
+        )
     except ValidationError as exc:
         return proto.error_response(400, _validation_message(exc))
     except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
@@ -96,11 +104,15 @@ async def anthropic_messages(
             },
         )
 
-    payload = json.loads(bytes(inner.body))
-    return JSONResponse(
-        proto.to_anthropic_response(payload),
-        headers=forwarded_headers(inner),
-    )
+    try:
+        payload = json.loads(bytes(inner.body))
+        return JSONResponse(
+            proto.to_anthropic_response(payload),
+            headers=forwarded_headers(inner),
+        )
+    except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+        logger.warning("anthropic_compat_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")
 
 
 @router.post("/v1/messages/count_tokens")

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -26,7 +26,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db, get_key_context
 from app.protocols import anthropic as proto
-from app.protocols.sse import iter_openai_frames
+from app.protocols.sse import OpenAIFrameStream
 from app.routes.chat import ERROR_TYPE_HEADER, execute_chat
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
@@ -75,7 +75,8 @@ async def anthropic_messages(
 ):
     try:
         areq = await parse_native_body(request, proto.AnthropicMessagesRequest)
-        openai_body = ChatCompletionRequest.model_validate(proto.to_openai_request(areq))
+        translated = proto.to_openai_request(areq)
+        openai_body = ChatCompletionRequest.model_validate(translated)
         inner = await execute_chat(openai_body, kc, db)
     except HTTPException as exc:
         # native_status: the engine relays its translated error type in a
@@ -95,7 +96,15 @@ async def anthropic_messages(
 
     if isinstance(inner, StreamingResponse):
         return StreamingResponse(
-            proto.stream_events(iter_openai_frames(inner.body_iterator)),
+            proto.stream_events(
+                OpenAIFrameStream(inner.body_iterator),
+                # The protocol reports the input count in message_start,
+                # which is emitted before the engine knows it (its usage
+                # frame lands at end-of-stream), so send the same estimate
+                # /v1/messages/count_tokens would return. The exact count
+                # follows in message_delta.usage.
+                input_tokens=_count_input_tokens(translated),
+            ),
             media_type="text/event-stream",
             headers={
                 "Cache-Control": "no-cache",

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -1,0 +1,145 @@
+"""POST /v1/messages — Anthropic Messages API ingress.
+
+Thin adapter over the shared chat engine: validate + translate the native
+request into the internal OpenAI format, run `execute_chat` (auth already
+happened in middleware; allowlist / auto-routing / prompt cache /
+RequestLog all live in the engine), then translate the result back.
+
+Anthropic-protocol specifics handled here rather than globally:
+  - request validation renders 400 `invalid_request_error` in the
+    Anthropic envelope (the app-wide handlers speak OpenAI's envelope
+    and use 422, which Anthropic clients don't expect)
+  - engine HTTPExceptions are re-rendered in the Anthropic envelope
+  - streaming re-frames the engine's `data:`-only SSE into Anthropic's
+    `event: <name>\\ndata: {json}` events (no [DONE] sentinel)
+"""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, Response, StreamingResponse
+from pydantic import BaseModel, ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db, get_key_context
+from app.protocols import anthropic as proto
+from app.protocols.sse import iter_openai_frames
+from app.routes.chat import execute_chat
+from app.schemas import ChatCompletionRequest
+from packages.auth.types import KeyContext
+
+logger = structlog.get_logger()
+router = APIRouter(tags=["Anthropic Messages"])
+
+_FORWARDED_HEADERS = (
+    "x-orca-cache",
+    "x-orca-resolved-model",
+    "x-orca-requested-model",
+    "x-orca-routing-strategy",
+)
+
+
+def forwarded_headers(inner: Response) -> dict[str, str]:
+    return {h: inner.headers[h] for h in _FORWARDED_HEADERS if h in inner.headers}
+
+
+def _validation_message(exc: ValidationError) -> str:
+    return "; ".join(
+        f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()
+    )
+
+
+async def parse_native_body(request: Request, model_cls: type[BaseModel]) -> BaseModel:
+    """Read + validate the native request body manually so validation
+    failures render in the native envelope instead of the app-wide 422."""
+    try:
+        raw = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Request body is not valid JSON") from None
+    if not isinstance(raw, dict):
+        raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+    try:
+        return model_cls.model_validate(raw)
+    except ValidationError as exc:
+        raise HTTPException(status_code=400, detail=_validation_message(exc)) from None
+
+
+@router.post("/v1/messages")
+async def anthropic_messages(
+    request: Request,
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+):
+    try:
+        areq = await parse_native_body(request, proto.AnthropicMessagesRequest)
+        openai_body = ChatCompletionRequest.model_validate(proto.to_openai_request(areq))
+        inner = await execute_chat(openai_body, kc, db)
+    except HTTPException as exc:
+        return proto.error_response(exc.status_code, str(exc.detail))
+    except ValidationError as exc:
+        return proto.error_response(400, _validation_message(exc))
+    except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+        logger.warning("anthropic_compat_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")
+
+    if isinstance(inner, StreamingResponse):
+        return StreamingResponse(
+            proto.stream_events(iter_openai_frames(inner.body_iterator)),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                **forwarded_headers(inner),
+            },
+        )
+
+    payload = json.loads(bytes(inner.body))
+    return JSONResponse(
+        proto.to_anthropic_response(payload),
+        headers=forwarded_headers(inner),
+    )
+
+
+@router.post("/v1/messages/count_tokens")
+async def anthropic_count_tokens(
+    request: Request,
+    kc: KeyContext = Depends(get_key_context),
+):
+    """Token estimate for the given request. Claude Code calls this for
+    context tracking; an estimate is enough (`litellm.token_counter` when
+    it knows the model, chars/4 otherwise)."""
+    try:
+        try:
+            raw = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body is not valid JSON") from None
+        if not isinstance(raw, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+        # Same schema as /v1/messages minus max_tokens/stream requirements.
+        raw = {**raw, "max_tokens": raw.get("max_tokens") or 1}
+        areq = proto.AnthropicMessagesRequest.model_validate(raw)
+        openai_body = proto.to_openai_request(areq)
+    except HTTPException as exc:
+        return proto.error_response(exc.status_code, str(exc.detail))
+    except ValidationError as exc:
+        return proto.error_response(400, _validation_message(exc))
+
+    return JSONResponse({"input_tokens": _count_input_tokens(openai_body)})
+
+
+def _count_input_tokens(openai_body: dict) -> int:
+    try:
+        import litellm
+
+        return int(litellm.token_counter(
+            model=openai_body["model"], messages=openai_body["messages"],
+        ))
+    except Exception:
+        total_chars = sum(
+            len(m["content"]) if isinstance(m.get("content"), str) else len(json.dumps(m.get("content") or ""))
+            for m in openai_body["messages"]
+        )
+        return max(1, total_chars // 4)

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -113,8 +113,9 @@ async def anthropic_messages(
         openai_body = ChatCompletionRequest.model_validate(translated)
         # log_status: the RequestLog row must record the status this
         # surface actually delivers (404 for model_not_found, 403 for the
-        # operator-side conditions), not the engine's generic 422.
-        inner = await execute_chat(openai_body, kc, db, log_status=proto.native_status)
+        # operator-side conditions, 500 for a generic upstream failure),
+        # not the engine's generic 422/503.
+        inner = await execute_chat(openai_body, kc, db, log_status=proto.delivered_status)
     except HTTPException as exc:
         # native_status: the engine relays its translated error type in a
         # header (e.g. model_not_found is 422 there, 404 not_found_error

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 
+import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, Response, StreamingResponse
@@ -26,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db, get_key_context
 from app.protocols import anthropic as proto
-from app.protocols.sse import OpenAIFrameStream
+from app.protocols.sse import OpenAIFrameStream, aclose_quietly
 from app.routes.chat import ERROR_TYPE_HEADER, execute_chat
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
@@ -50,6 +51,25 @@ def _validation_message(exc: ValidationError) -> str:
     return "; ".join(
         f"{'.'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()
     )
+
+
+async def guard_native_stream(gen, render_error, *, event: str):
+    """Wrap a native streaming body so a fault inside the adapter itself
+    still speaks the native protocol: the app-wide handlers render the
+    OpenAI envelope (or just reset the connection mid-stream), which the
+    Anthropic / google-genai SDKs cannot parse. An adapter exception is
+    logged and rendered as one in-stream native error frame; the response
+    is already 200 by the time the body runs, so that is the only channel.
+    Cancellation (client gone) passes straight through."""
+    try:
+        async for item in gen:
+            yield item
+    except Exception as exc:
+        logger.warning(event, error=str(exc))
+        yield render_error("Internal server error")
+    finally:
+        with anyio.CancelScope(shield=True):
+            await aclose_quietly(gen)
 
 
 async def parse_native_body(request: Request, model_cls: type[BaseModel]) -> BaseModel:
@@ -95,15 +115,18 @@ async def anthropic_messages(
         return proto.error_response(500, "Internal server error")
 
     if isinstance(inner, StreamingResponse):
+        events = proto.stream_events(
+            OpenAIFrameStream(inner.body_iterator),
+            # The protocol reports the input count in message_start,
+            # which is emitted before the engine knows it (its usage
+            # frame lands at end-of-stream), so send the same estimate
+            # /v1/messages/count_tokens would return. The exact count
+            # follows in message_delta.usage.
+            input_tokens=_count_input_tokens(translated),
+        )
         return StreamingResponse(
-            proto.stream_events(
-                OpenAIFrameStream(inner.body_iterator),
-                # The protocol reports the input count in message_start,
-                # which is emitted before the engine knows it (its usage
-                # frame lands at end-of-stream), so send the same estimate
-                # /v1/messages/count_tokens would return. The exact count
-                # follows in message_delta.usage.
-                input_tokens=_count_input_tokens(translated),
+            guard_native_stream(
+                events, proto.stream_error_event, event="anthropic_compat_stream_error",
             ),
             media_type="text/event-stream",
             headers={

--- a/app/routes/anthropic_compat.py
+++ b/app/routes/anthropic_compat.py
@@ -72,6 +72,20 @@ async def guard_native_stream(gen, render_error, *, event: str):
             await aclose_quietly(gen)
 
 
+def check_model_allowlist(model: str, kc: KeyContext) -> None:
+    """The same first check execute_chat applies to every completion: a key
+    with an allowlist may not touch models outside it. The count-token
+    endpoints never reach the engine, so they enforce it themselves —
+    otherwise a restricted key could probe denied models through them.
+    "auto" is exempt exactly as in the engine (it is never a literal in an
+    allowlist; the engine filters the resolved candidates instead)."""
+    if model != "auto" and kc.model_allowlist is not None and model not in kc.model_allowlist:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Model '{model}' is not allowed for this API key",
+        )
+
+
 async def parse_native_body(request: Request, model_cls: type[BaseModel]) -> BaseModel:
     """Read + validate the native request body manually so validation
     failures render in the native envelope instead of the app-wide 422."""
@@ -97,7 +111,10 @@ async def anthropic_messages(
         areq = await parse_native_body(request, proto.AnthropicMessagesRequest)
         translated = proto.to_openai_request(areq)
         openai_body = ChatCompletionRequest.model_validate(translated)
-        inner = await execute_chat(openai_body, kc, db)
+        # log_status: the RequestLog row must record the status this
+        # surface actually delivers (404 for model_not_found, 403 for the
+        # operator-side conditions), not the engine's generic 422.
+        inner = await execute_chat(openai_body, kc, db, log_status=proto.native_status)
     except HTTPException as exc:
         # native_status: the engine relays its translated error type in a
         # header (e.g. model_not_found is 422 there, 404 not_found_error
@@ -165,6 +182,7 @@ async def anthropic_count_tokens(
         # Same schema as /v1/messages minus max_tokens/stream requirements.
         raw = {**raw, "max_tokens": raw.get("max_tokens") or 1}
         areq = proto.AnthropicMessagesRequest.model_validate(raw)
+        check_model_allowlist(areq.model, kc)
         openai_body = proto.to_openai_request(areq)
         return JSONResponse({"input_tokens": _count_input_tokens(openai_body)})
     except HTTPException as exc:

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -44,6 +44,13 @@ router = APIRouter(prefix="/v1", tags=["Chat Completions"])
 # status/error taxonomy.
 ERROR_TYPE_HEADER = "x-orca-error-type"
 
+# Delays (seconds) between successive attempts to commit a streaming
+# RequestLog row; attempts = len + 1. That row is the only record of a
+# stream's tokens and cost, so a commit that fails outright is retried on
+# a fresh session before the row is given up on — bounded, because the
+# retries hold the (already [DONE]) stream open. Tests shrink this.
+_LOG_COMMIT_BACKOFF_S: tuple[float, ...] = (0.1, 0.4)
+
 
 def _chunk_to_dict(chunk) -> dict:
     """Normalize a litellm chunk (Pydantic model or dict) into a plain dict."""
@@ -391,6 +398,14 @@ async def execute_chat(
                     f"({sorted(needs) or 'none'}). Configure a provider that "
                     "supports them or pin a specific model."
                 ),
+                # Operator-side and permanent like its sibling above:
+                # providers ARE configured, but none of their deployable
+                # models has a capability the request needs (vision, tools,
+                # json_mode). The type lets the native surfaces render it
+                # as 403 permission_error / PERMISSION_DENIED — the same
+                # class as no_providers_configured — instead of collapsing
+                # the bare 422 to a client-blaming 400.
+                headers={ERROR_TYPE_HEADER: "no_capable_provider"},
             )
 
         resolved_model = candidates[0]
@@ -559,9 +574,26 @@ async def execute_chat(
                 synthetic = {
                     "model": agg_model or resolved_model,
                     "usage": agg_usage,
-                    "_orca_meta": {"provider": agg_provider, "latency_ms": agg_latency},
+                    "_orca_meta": {"provider": agg_provider},
                 }
-                log = await _build_log_row(
+                if agg_latency:
+                    # Real LiteLLM chunks carry no _orca_meta, so this is
+                    # normally absent — leaving the key out lets
+                    # _build_log_row fall back to the measured wall-clock
+                    # latency instead of persisting a constant 0.
+                    synthetic["_orca_meta"]["latency_ms"] = agg_latency
+                from sqlalchemy import select
+
+                from packages.db import session as session_mod
+
+                # The row's VALUES are computed exactly once — latency is
+                # measured here, before any commit attempt, so retry
+                # backoff never inflates it — and every attempt inserts a
+                # fresh ORM object carrying the same id/trace_id. (Fresh,
+                # because an object left over from a failed flush carries
+                # session state that makes a second session treat it as
+                # an UPDATE, not an INSERT.)
+                template = await _build_log_row(
                     body=body, kc=kc, response=synthetic,
                     status_code=status_code, error_type=error_type,
                     started_perf=started_perf,
@@ -569,42 +601,117 @@ async def execute_chat(
                     requested_model=requested_model,
                     actual_resolved=agg_model,
                 )
-                from packages.db import session as session_mod
+                row_values = {
+                    c.key: getattr(template, c.key)
+                    for c in RequestLog.__table__.columns
+                    if getattr(template, c.key) is not None
+                }
+                row_values.setdefault("id", str(uuid.uuid4()))
 
-                async def _commit_row() -> None:
-                    if session_mod._session_factory is not None:
-                        async with session_mod._session_factory() as s:
-                            s.add(log)
-                            await s.commit()
-                    else:
+                async def _already_persisted(s) -> bool:
+                    return (await s.scalar(
+                        select(RequestLog.id).where(RequestLog.trace_id == row_values["trace_id"])
+                    )) is not None
+
+                async def _commit_row(*, retry: bool) -> None:
+                    """INSERT + COMMIT the row on a session of its own.
+
+                    Only a failing `commit()` propagates; a failure while
+                    closing the session AFTER the commit returned is
+                    swallowed — the row is already in. A retry is
+                    idempotent: it first looks the trace_id up, so a COMMIT
+                    that landed but whose ack was lost on the wire
+                    (PostgreSQL, connection dropped mid-ack) is not
+                    inserted a second time — and the shared primary key
+                    would reject a duplicate anyway.
+                    """
+                    log = RequestLog(**row_values)
+                    if session_mod._session_factory is None:
+                        # Test-only fallback (the app always installs a
+                        # factory): the request-scoped session has to be
+                        # rolled back before a retry can reuse it.
+                        if retry and await _already_persisted(db):
+                            return
                         db.add(log)
-                        await db.commit()
-
-                # At-most-once: mark the attempt BEFORE it starts so the
-                # other _finalize call site never retries — a retry after an
-                # ambiguous failure (commit acked, teardown raised) would
-                # double-insert the row. Durability against a close/cancel
-                # landing mid-commit (e.g. a disconnect delivered during the
-                # protocol adapters' post-[DONE] drain) comes from running
-                # the commit in its own task: cancellation aimed at THIS
-                # task can't abort the INSERT.
-                log_written = True
-                commit_task = asyncio.ensure_future(_commit_row())
-                try:
-                    await asyncio.shield(commit_task)
-                except Exception as commit_err:
-                    logger.warning("request_log_commit_failed", error=str(commit_err))
-                except BaseException:
-                    # CancelledError/GeneratorExit aimed at us, not at the
-                    # commit — wait the commit out so the row isn't dropped,
-                    # then let the cancellation propagate.
+                        try:
+                            await db.commit()
+                        except Exception:
+                            try:
+                                await db.rollback()
+                            except Exception:
+                                pass
+                            raise
+                        return
+                    s = session_mod._session_factory()
                     try:
-                        await commit_task
+                        if retry and await _already_persisted(s):
+                            return
+                        s.add(log)
+                        await s.commit()
+                    finally:
+                        try:
+                            await s.close()
+                        except Exception as close_err:
+                            logger.debug(
+                                "request_log_session_close_failed", error=str(close_err),
+                            )
+
+                # At-most-once across the two call sites: mark BEFORE the
+                # first attempt so the other _finalize never re-runs this
+                # sequence. Retries live HERE, bounded by
+                # _LOG_COMMIT_BACKOFF_S and only for a commit that failed
+                # outright — this row is the only record of a stream's
+                # tokens and cost, so a transient DB hiccup at request end
+                # must not silently zero that spend. Durability against a
+                # close/cancel landing mid-commit (e.g. a disconnect
+                # delivered during the protocol adapters' post-[DONE]
+                # drain) comes from running each attempt in its own task:
+                # cancellation aimed at THIS task can't abort the INSERT.
+                log_written = True
+                attempts = len(_LOG_COMMIT_BACKOFF_S) + 1
+                for attempt in range(1, attempts + 1):
+                    commit_task = asyncio.ensure_future(_commit_row(retry=attempt > 1))
+                    try:
+                        await asyncio.shield(commit_task)
+                        return
                     except Exception as commit_err:
-                        logger.warning("request_log_commit_failed", error=str(commit_err))
+                        if attempt < attempts:
+                            logger.info(
+                                "request_log_commit_retry",
+                                error=str(commit_err), attempt=attempt,
+                            )
+                            try:
+                                await asyncio.sleep(_LOG_COMMIT_BACKOFF_S[attempt - 1])
+                            except BaseException:
+                                # Cancelled during the backoff: nothing is
+                                # in flight, the row is given up on — say
+                                # so, then propagate like the arm below.
+                                logger.warning(
+                                    "request_log_commit_failed",
+                                    error=str(commit_err), attempts=attempt,
+                                )
+                                raise
+                            continue
+                        logger.warning(
+                            "request_log_commit_failed",
+                            error=str(commit_err), attempts=attempt,
+                        )
                     except BaseException:
-                        pass
-                    raise
+                        # CancelledError aimed at us, not at the commit —
+                        # wait the in-flight attempt out so a row about to
+                        # land isn't dropped, then let the cancellation
+                        # propagate (no further attempts: we are being torn
+                        # down).
+                        try:
+                            await commit_task
+                        except Exception as commit_err:
+                            logger.warning(
+                                "request_log_commit_failed",
+                                error=str(commit_err), attempts=attempt,
+                            )
+                        except BaseException:
+                            pass
+                        raise
 
             try:
                 async for chunk in _aiter(stream_obj):

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -429,6 +429,8 @@ async def execute_chat(
             tool_choice=completion_kwargs.get("tool_choice"),
             top_p=completion_kwargs.get("top_p"),
             n=completion_kwargs.get("n"),
+            presence_penalty=completion_kwargs.get("presence_penalty"),
+            frequency_penalty=completion_kwargs.get("frequency_penalty"),
         )
         cached = await prompt_cache.get_backend().get(cache_lookup_key)
         if cached is not None:

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -279,9 +279,10 @@ async def execute_chat(
     `data: [DONE]` for streaming. Raises HTTPException on pre-stream errors.
 
     `log_status(engine_status, error_type)` lets a native-protocol caller
-    record in the RequestLog the status IT will deliver for a blocking
-    upstream failure (e.g. 404 for model_not_found where this engine says
-    422), so the persisted outcome matches what went over the wire.
+    record in the RequestLog the status IT will deliver for an upstream
+    failure (e.g. 404 for model_not_found where this engine says 422), on
+    both the blocking and the streaming path, so the persisted outcome
+    matches what went over the wire.
     """
     # Capture client intent before any mutation so the request log and the
     # `x-orca-requested-model` header always reflect what the user asked for,
@@ -600,9 +601,18 @@ async def execute_chat(
                 # because an object left over from a failed flush carries
                 # session state that makes a second session treat it as
                 # an UPDATE, not an INSERT.)
+                # Same correction the blocking path applies: on a native
+                # surface the delivered status differs from the engine's
+                # generic one (the Gemini aggregate stream renders a real
+                # 404/429/403 from the error chunk; the SSE surfaces report
+                # the same class in their in-band error frame), so the row
+                # must not say 503 for a response the client saw as 404.
+                row_status = status_code
+                if log_status is not None and error_type is not None:
+                    row_status = log_status(status_code, error_type)
                 template = await _build_log_row(
                     body=body, kc=kc, response=synthetic,
-                    status_code=status_code, error_type=error_type,
+                    status_code=row_status, error_type=error_type,
                     started_perf=started_perf,
                     strategy=strategy,
                     requested_model=requested_model,

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -38,6 +38,12 @@ from packages.litellm_adapter.types import UpstreamProviderError
 logger = structlog.get_logger()
 router = APIRouter(prefix="/v1", tags=["Chat Completions"])
 
+# Relays the engine's translated error type (rate_limit_error,
+# model_not_found, ...) on engine-raised HTTPExceptions so the
+# native-protocol routes can re-render the failure in their own
+# status/error taxonomy.
+ERROR_TYPE_HEADER = "x-orca-error-type"
+
 
 def _chunk_to_dict(chunk) -> dict:
     """Normalize a litellm chunk (Pydantic model or dict) into a plain dict."""
@@ -491,6 +497,10 @@ async def execute_chat(
             raise HTTPException(
                 status_code=exc.http_status,
                 detail=f"Upstream provider error: {exc}",
+                # The generic HTTP status alone loses the translated type
+                # (e.g. model_not_found is 422 here but 404 on the
+                # Anthropic/Gemini surfaces).
+                headers={ERROR_TYPE_HEADER: exc.error_type},
             ) from exc
         except Exception as exc:
             logger.warning("chat_completion_upstream_error", error=str(exc))
@@ -520,7 +530,6 @@ async def execute_chat(
                 nonlocal log_written, agg_provider
                 if log_written:
                     return
-                log_written = True
                 # Real LiteLLM stream chunks don't carry _orca_meta (the
                 # adapter only injects it on non-stream responses, since
                 # wrapping every chunk would be wasteful). Look up provider
@@ -550,19 +559,40 @@ async def execute_chat(
                 )
                 from packages.db import session as session_mod
 
-                if session_mod._session_factory is not None:
-                    try:
+                async def _commit_row() -> None:
+                    if session_mod._session_factory is not None:
                         async with session_mod._session_factory() as s:
                             s.add(log)
                             await s.commit()
-                    except Exception as commit_err:
-                        logger.warning("request_log_commit_failed", error=str(commit_err))
-                else:
-                    db.add(log)
-                    try:
+                    else:
+                        db.add(log)
                         await db.commit()
+
+                # At-most-once: mark the attempt BEFORE it starts so the
+                # other _finalize call site never retries — a retry after an
+                # ambiguous failure (commit acked, teardown raised) would
+                # double-insert the row. Durability against a close/cancel
+                # landing mid-commit (e.g. a disconnect delivered during the
+                # protocol adapters' post-[DONE] drain) comes from running
+                # the commit in its own task: cancellation aimed at THIS
+                # task can't abort the INSERT.
+                log_written = True
+                commit_task = asyncio.ensure_future(_commit_row())
+                try:
+                    await asyncio.shield(commit_task)
+                except Exception as commit_err:
+                    logger.warning("request_log_commit_failed", error=str(commit_err))
+                except BaseException:
+                    # CancelledError/GeneratorExit aimed at us, not at the
+                    # commit — wait the commit out so the row isn't dropped,
+                    # then let the cancellation propagate.
+                    try:
+                        await commit_task
                     except Exception as commit_err:
                         logger.warning("request_log_commit_failed", error=str(commit_err))
+                    except BaseException:
+                        pass
+                    raise
 
             try:
                 async for chunk in _aiter(stream_obj):
@@ -713,6 +743,9 @@ async def execute_chat(
         raise HTTPException(
             status_code=exc.http_status,
             detail=f"Upstream provider error: {exc}",
+            # See the streaming-path twin: lets the native routes map the
+            # translated type to their surface's status/error taxonomy.
+            headers={ERROR_TYPE_HEADER: exc.error_type},
         ) from exc
     except Exception as exc:
         status_code = 503

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -520,6 +520,32 @@ async def execute_chat(
         existing_so = completion_kwargs.get("stream_options") or {}
         if "include_usage" not in existing_so:
             completion_kwargs["stream_options"] = {**existing_so, "include_usage": True}
+
+        async def _log_pre_stream_failure(status: int, err_type: str | None) -> None:
+            """Persist a row for a stream that failed BEFORE its first chunk.
+
+            The mid-stream path logs from `_finalize` and the blocking path
+            from its `finally`, but this failure happens between them: the
+            client is rendered a real 404/429/403/503 and nothing recorded
+            it, so the same upstream failure was accounted for when
+            stream=false and vanished when stream=true.
+            """
+            if log_status is not None and err_type is not None:
+                status = log_status(status, err_type)
+            log = await _build_log_row(
+                body=body, kc=kc, response={},
+                status_code=status, error_type=err_type,
+                started_perf=started_perf,
+                strategy=strategy,
+                requested_model=requested_model,
+                actual_resolved=resolved_model,
+            )
+            db.add(log)
+            try:
+                await db.commit()
+            except Exception as commit_err:
+                logger.warning("request_log_commit_failed", error=str(commit_err))
+
         try:
             stream_obj = await client.acompletion(
                 **completion_kwargs,
@@ -530,6 +556,7 @@ async def execute_chat(
             raise
         except UpstreamProviderError as exc:
             logger.warning("chat_completion_upstream_error", error=str(exc))
+            await _log_pre_stream_failure(exc.http_status, exc.error_type)
             raise HTTPException(
                 status_code=exc.http_status,
                 detail=f"Upstream provider error: {exc}",
@@ -540,6 +567,7 @@ async def execute_chat(
             ) from exc
         except Exception as exc:
             logger.warning("chat_completion_upstream_error", error=str(exc))
+            await _log_pre_stream_failure(503, type(exc).__name__)
             raise HTTPException(status_code=503, detail=f"Upstream provider error: {exc}") from exc
 
         async def sse() -> AsyncGenerator[str, None]:

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -11,7 +11,7 @@ import asyncio
 import json
 import time
 import uuid
-from collections.abc import AsyncGenerator, AsyncIterable
+from collections.abc import AsyncGenerator, AsyncIterable, Callable
 
 import anyio
 import structlog
@@ -266,6 +266,8 @@ async def execute_chat(
     body: ChatCompletionRequest,
     kc: KeyContext,
     db: AsyncSession,
+    *,
+    log_status: Callable[[int, str | None], int] | None = None,
 ) -> JSONResponse | StreamingResponse:
     """Protocol-agnostic chat engine — the full pipeline behind
     POST /v1/chat/completions (allowlist → auto-resolution → prompt cache →
@@ -275,6 +277,11 @@ async def execute_chat(
     Returns OpenAI-wire-format results: JSONResponse for blocking requests,
     StreamingResponse emitting `data: {json}\\n\\n` frames with a terminal
     `data: [DONE]` for streaming. Raises HTTPException on pre-stream errors.
+
+    `log_status(engine_status, error_type)` lets a native-protocol caller
+    record in the RequestLog the status IT will deliver for a blocking
+    upstream failure (e.g. 404 for model_not_found where this engine says
+    422), so the persisted outcome matches what went over the wire.
     """
     # Capture client intent before any mutation so the request log and the
     # `x-orca-requested-model` header always reflect what the user asked for,
@@ -872,6 +879,8 @@ async def execute_chat(
         logger.warning("chat_completion_upstream_error", error=str(exc))
         raise HTTPException(status_code=503, detail=f"Upstream provider error: {exc}") from exc
     finally:
+        if log_status is not None and error_type is not None:
+            status_code = log_status(status_code, error_type)
         log = await _build_log_row(
             body=body, kc=kc, response=response if isinstance(response, dict) else {},
             status_code=status_code, error_type=error_type,

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -424,6 +424,11 @@ async def execute_chat(
             tools=completion_kwargs.get("tools"),
             response_format=completion_kwargs.get("response_format"),
             seed=completion_kwargs.get("seed"),
+            max_tokens=completion_kwargs.get("max_tokens"),
+            stop=completion_kwargs.get("stop"),
+            tool_choice=completion_kwargs.get("tool_choice"),
+            top_p=completion_kwargs.get("top_p"),
+            n=completion_kwargs.get("n"),
         )
         cached = await prompt_cache.get_backend().get(cache_lookup_key)
         if cached is not None:

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -28,6 +28,7 @@ from app.auto_routing import (
 )
 from app.config import get_settings
 from app.deps import get_db, get_key_context
+from app.protocols.sse import AdapterError
 from app.quality_scores import resolve_model_metrics
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
@@ -789,6 +790,25 @@ async def execute_chat(
                         pass
                 # Re-raise so asyncio/Starlette see proper cancel propagation.
                 raise
+            except AdapterError:
+                # The protocol adapter downstream of us failed and threw
+                # this in rather than closing us: our own fault, not the
+                # caller's. Without this branch the close would be
+                # indistinguishable from a disconnect and every adapter bug
+                # would be filed as 499/client_disconnect.
+                error_type = "adapter_error"
+                status_code = 500
+                logger.warning(
+                    "chat_completion_stream_adapter_error", served_model=agg_model,
+                )
+                aclose = getattr(stream_obj, "aclose", None)
+                with anyio.CancelScope(shield=True):
+                    if aclose is not None:
+                        try:
+                            await aclose()
+                        except Exception:
+                            pass
+                return
             except Exception as exc:
                 # Translate the underlying LiteLLM exception so the request
                 # log records the meaningful error_type (rate_limit_error,

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -246,6 +246,23 @@ async def chat_completions(
     kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ):
+    return await execute_chat(body, kc, db)
+
+
+async def execute_chat(
+    body: ChatCompletionRequest,
+    kc: KeyContext,
+    db: AsyncSession,
+) -> JSONResponse | StreamingResponse:
+    """Protocol-agnostic chat engine — the full pipeline behind
+    POST /v1/chat/completions (allowlist → auto-resolution → prompt cache →
+    LiteLLM Router → RequestLog writeback), reusable by native-protocol
+    adapters (Anthropic /v1/messages, Gemini /v1beta) with a translated body.
+
+    Returns OpenAI-wire-format results: JSONResponse for blocking requests,
+    StreamingResponse emitting `data: {json}\\n\\n` frames with a terminal
+    `data: [DONE]` for streaming. Raises HTTPException on pre-stream errors.
+    """
     # Capture client intent before any mutation so the request log and the
     # `x-orca-requested-model` header always reflect what the user asked for,
     # not the post-resolution primary.

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -315,6 +315,11 @@ async def execute_chat(
                     "model='auto' requires at least one provider with a "
                     "configured key. No deployable provider found."
                 ),
+                # Same operator-side, permanent condition the pinned-model
+                # path reports as no_providers_configured. Without the
+                # type the native surfaces would collapse this 422 to a
+                # client-blaming 400 while the pinned path renders 403.
+                headers={ERROR_TYPE_HEADER: "no_providers_configured"},
             )
         # `quality`, `balanced`, `fastest` all want AA-derived metrics.
         # `resolve_model_metrics` does the AA fetch + merges manual

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -7,9 +7,12 @@ Endpoints:
   GET  /v1beta/models            (catalog, Gemini list shape)
   GET  /v1beta/models/{model}
 
-FastAPI path templates can't express the `:action` suffix, so a single
-`{model_and_action}` segment is split on the last ':'. The `model` half
-supports "auto" like every other ingress.
+FastAPI path templates can't express the `:action` suffix, so a `:path`
+`{model_and_action}` parameter is split on the last ':'. `:path` (rather
+than a single segment) lets provider-qualified model ids containing '/'
+(e.g. "orcarouter/free") route here instead of falling through to the
+app-wide OpenAI-shaped 404. The `model` half supports "auto" like every
+other ingress.
 """
 
 from __future__ import annotations
@@ -30,7 +33,7 @@ from app.routes.anthropic_compat import (
     forwarded_headers,
     parse_native_body,
 )
-from app.routes.chat import execute_chat
+from app.routes.chat import ERROR_TYPE_HEADER, execute_chat
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
@@ -55,15 +58,19 @@ async def gemini_list_models(_kc: KeyContext = Depends(get_key_context)):
     return {"models": [_model_entry(m) for m in CATALOG]}
 
 
-@router.get("/v1beta/models/{model_id}")
+@router.get("/v1beta/models/{model_id:path}")
 async def gemini_get_model(model_id: str, _kc: KeyContext = Depends(get_key_context)):
-    m = CATALOG_BY_ID.get(model_id)
+    # The list endpoint presents Google resource names ("models/{id}");
+    # accept that form here too (`:path` so the embedded slash still
+    # routes), falling back to the bare id.
+    bare = model_id.removeprefix("models/")
+    m = CATALOG_BY_ID.get(bare)
     if m is None:
-        return proto.error_response(404, f"models/{model_id} is not found")
+        return proto.error_response(404, f"models/{bare} is not found")
     return _model_entry(m)
 
 
-@router.post("/v1beta/models/{model_and_action}")
+@router.post("/v1beta/models/{model_and_action:path}")
 async def gemini_generate(
     model_and_action: str,
     request: Request,
@@ -89,7 +96,14 @@ async def gemini_generate(
         )
         inner = await execute_chat(openai_body, kc, db)
     except HTTPException as exc:
-        return proto.error_response(exc.status_code, str(exc.detail))
+        # native_status: the engine relays its translated error type in a
+        # header (e.g. model_not_found is 422 there, 404 NOT_FOUND here).
+        return proto.error_response(
+            proto.native_status(
+                exc.status_code, (exc.headers or {}).get(ERROR_TYPE_HEADER)
+            ),
+            str(exc.detail),
+        )
     except ValidationError as exc:
         return proto.error_response(400, _validation_message(exc))
     except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
@@ -97,10 +111,14 @@ async def gemini_generate(
         return proto.error_response(500, "Internal server error")
 
     if not stream:
-        payload = json.loads(bytes(inner.body))
-        return JSONResponse(
-            proto.to_gemini_response(payload), headers=forwarded_headers(inner)
-        )
+        try:
+            payload = json.loads(bytes(inner.body))
+            return JSONResponse(
+                proto.to_gemini_response(payload), headers=forwarded_headers(inner)
+            )
+        except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+            logger.warning("gemini_compat_error", error=str(exc))
+            return proto.error_response(500, "Internal server error")
 
     chunks = proto.stream_chunks(iter_openai_frames(inner.body_iterator))
     if alt_sse:
@@ -122,7 +140,14 @@ async def gemini_generate(
         )
 
     # No alt=sse: the REST default is a JSON array of chunks — aggregate.
-    collected = [chunk async for chunk in chunks]
+    # Nothing has been sent yet, so a raw failure here (as opposed to the
+    # engine's in-band error frame, handled below) must still render the
+    # native envelope, not FastAPI's OpenAI-shaped 500.
+    try:
+        collected = [chunk async for chunk in chunks]
+    except Exception as exc:
+        logger.warning("gemini_compat_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")
     for chunk in collected:
         err = chunk.get("error") if isinstance(chunk, dict) else None
         if err:

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -123,4 +123,14 @@ async def gemini_generate(
 
     # No alt=sse: the REST default is a JSON array of chunks — aggregate.
     collected = [chunk async for chunk in chunks]
+    for chunk in collected:
+        err = chunk.get("error") if isinstance(chunk, dict) else None
+        if err:
+            # A mid-stream engine failure surfaces as an error chunk.
+            # Nothing has been sent yet, so render the native non-200
+            # envelope instead of burying the error in a 200 array.
+            return proto.error_response(
+                err.get("code") or 500,
+                err.get("message") or "Upstream provider error",
+            )
     return JSONResponse(collected, headers=forwarded_headers(inner))

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -33,6 +33,7 @@ from app.protocols.sse import OpenAIFrameStream, aclose_quietly
 from app.routes.anthropic_compat import (
     _count_input_tokens,
     _validation_message,
+    check_model_allowlist,
     forwarded_headers,
     guard_native_stream,
     parse_native_body,
@@ -100,14 +101,16 @@ async def gemini_generate(
     alt_sse = request.query_params.get("alt", "").lower() == "sse"
 
     if action == "countTokens":
-        return await _count_tokens(model, request)
+        return await _count_tokens(model, request, kc)
 
     try:
         greq = await parse_native_body(request, proto.GeminiGenerateRequest)
         openai_body = ChatCompletionRequest.model_validate(
             proto.to_openai_request(greq, model=model, stream=stream)
         )
-        inner = await execute_chat(openai_body, kc, db)
+        # log_status: RequestLog records the status this surface delivers
+        # (404 NOT_FOUND / 403 PERMISSION_DENIED), not the engine's 422.
+        inner = await execute_chat(openai_body, kc, db, log_status=proto.native_status)
     except HTTPException as exc:
         # native_status: the engine relays its translated error type in a
         # header (e.g. model_not_found is 422 there, 404 NOT_FOUND here).
@@ -178,7 +181,7 @@ async def gemini_generate(
     return JSONResponse(collected, headers=forwarded_headers(inner))
 
 
-async def _count_tokens(model: str, request: Request) -> JSONResponse:
+async def _count_tokens(model: str, request: Request, kc: KeyContext) -> JSONResponse:
     """POST /v1beta/models/{model}:countTokens — the google-genai SDK calls
     this for context tracking in agentic loops (client.models.count_tokens),
     exactly as Claude Code calls /v1/messages/count_tokens. The body is
@@ -186,6 +189,7 @@ async def _count_tokens(model: str, request: Request) -> JSONResponse:
     {...}} form; an estimate is enough (same counter as the Anthropic
     sibling)."""
     try:
+        check_model_allowlist(model, kc)
         try:
             raw = await request.json()
         except Exception:

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -109,8 +109,10 @@ async def gemini_generate(
             proto.to_openai_request(greq, model=model, stream=stream)
         )
         # log_status: RequestLog records the status this surface delivers
-        # (404 NOT_FOUND / 403 PERMISSION_DENIED), not the engine's 422.
-        inner = await execute_chat(openai_body, kc, db, log_status=proto.native_status)
+        # (404 NOT_FOUND / 403 PERMISSION_DENIED), not the engine's 422 —
+        # on the aggregate streaming path that mapping is what the client
+        # actually receives, since nothing has been sent when it fails.
+        inner = await execute_chat(openai_body, kc, db, log_status=proto.delivered_status)
     except HTTPException as exc:
         # native_status: the engine relays its translated error type in a
         # header (e.g. model_not_found is 422 there, 404 NOT_FOUND here).

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -27,7 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.deps import get_db, get_key_context
 from app.protocols import gemini as proto
-from app.protocols.sse import aclose_quietly, iter_openai_frames
+from app.protocols.sse import OpenAIFrameStream, aclose_quietly
 from app.routes.anthropic_compat import (
     _validation_message,
     forwarded_headers,
@@ -126,7 +126,7 @@ async def gemini_generate(
             logger.warning("gemini_compat_error", error=str(exc))
             return proto.error_response(500, "Internal server error")
 
-    chunks = proto.stream_chunks(iter_openai_frames(inner.body_iterator))
+    chunks = proto.stream_chunks(OpenAIFrameStream(inner.body_iterator))
     if alt_sse:
         async def sse():
             try:

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -4,6 +4,7 @@ Endpoints:
   POST /v1beta/models/{model}:generateContent
   POST /v1beta/models/{model}:streamGenerateContent   (?alt=sse → SSE,
         otherwise the chunks are aggregated into one JSON array)
+  POST /v1beta/models/{model}:countTokens             (estimate)
   GET  /v1beta/models            (catalog, Gemini list shape)
   GET  /v1beta/models/{model}
 
@@ -19,6 +20,7 @@ from __future__ import annotations
 
 import json
 
+import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -29,8 +31,10 @@ from app.deps import get_db, get_key_context
 from app.protocols import gemini as proto
 from app.protocols.sse import OpenAIFrameStream, aclose_quietly
 from app.routes.anthropic_compat import (
+    _count_input_tokens,
     _validation_message,
     forwarded_headers,
+    guard_native_stream,
     parse_native_body,
 )
 from app.routes.chat import ERROR_TYPE_HEADER, execute_chat
@@ -41,7 +45,7 @@ from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
 logger = structlog.get_logger()
 router = APIRouter(tags=["Gemini"])
 
-_ACTIONS = ("generateContent", "streamGenerateContent")
+_ACTIONS = ("generateContent", "streamGenerateContent", "countTokens")
 
 
 def _model_entry(m) -> dict:
@@ -95,6 +99,9 @@ async def gemini_generate(
     stream = action == "streamGenerateContent"
     alt_sse = request.query_params.get("alt", "").lower() == "sse"
 
+    if action == "countTokens":
+        return await _count_tokens(model, request)
+
     try:
         greq = await parse_native_body(request, proto.GeminiGenerateRequest)
         openai_body = ChatCompletionRequest.model_validate(
@@ -126,14 +133,18 @@ async def gemini_generate(
             logger.warning("gemini_compat_error", error=str(exc))
             return proto.error_response(500, "Internal server error")
 
-    chunks = proto.stream_chunks(OpenAIFrameStream(inner.body_iterator))
+    chunks = guard_native_stream(
+        proto.stream_chunks(OpenAIFrameStream(inner.body_iterator)),
+        proto.stream_error_chunk, event="gemini_compat_stream_error",
+    )
     if alt_sse:
         async def sse():
             try:
                 async for chunk in chunks:
                     yield f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n"
             finally:
-                await aclose_quietly(chunks)
+                with anyio.CancelScope(shield=True):
+                    await aclose_quietly(chunks)
 
         return StreamingResponse(
             sse(),
@@ -165,3 +176,35 @@ async def gemini_generate(
                 err.get("message") or "Upstream provider error",
             )
     return JSONResponse(collected, headers=forwarded_headers(inner))
+
+
+async def _count_tokens(model: str, request: Request) -> JSONResponse:
+    """POST /v1beta/models/{model}:countTokens — the google-genai SDK calls
+    this for context tracking in agentic loops (client.models.count_tokens),
+    exactly as Claude Code calls /v1/messages/count_tokens. The body is
+    either {"contents": ...} or the wrapped {"generateContentRequest":
+    {...}} form; an estimate is enough (same counter as the Anthropic
+    sibling)."""
+    try:
+        try:
+            raw = await request.json()
+        except Exception:
+            raise HTTPException(status_code=400, detail="Request body is not valid JSON") from None
+        if not isinstance(raw, dict):
+            raise HTTPException(status_code=400, detail="Request body must be a JSON object")
+        wrapped = raw.get("generateContentRequest") or raw.get("generate_content_request")
+        if isinstance(wrapped, dict):
+            raw = {**wrapped, **{k: v for k, v in raw.items()
+                                 if k not in ("generateContentRequest", "generate_content_request")}}
+        if "contents" not in raw:
+            raise HTTPException(status_code=400, detail="countTokens requires 'contents'")
+        greq = proto.GeminiGenerateRequest.model_validate(raw)
+        openai_body = proto.to_openai_request(greq, model=model, stream=False)
+        return JSONResponse({"totalTokens": _count_input_tokens(openai_body)})
+    except HTTPException as exc:
+        return proto.error_response(exc.status_code, str(exc.detail))
+    except ValidationError as exc:
+        return proto.error_response(400, _validation_message(exc))
+    except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+        logger.warning("gemini_count_tokens_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -1,0 +1,126 @@
+"""/v1beta — Gemini (Google AI Studio style) API ingress.
+
+Endpoints:
+  POST /v1beta/models/{model}:generateContent
+  POST /v1beta/models/{model}:streamGenerateContent   (?alt=sse → SSE,
+        otherwise the chunks are aggregated into one JSON array)
+  GET  /v1beta/models            (catalog, Gemini list shape)
+  GET  /v1beta/models/{model}
+
+FastAPI path templates can't express the `:action` suffix, so a single
+`{model_and_action}` segment is split on the last ':'. The `model` half
+supports "auto" like every other ingress.
+"""
+
+from __future__ import annotations
+
+import json
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.deps import get_db, get_key_context
+from app.protocols import gemini as proto
+from app.protocols.sse import aclose_quietly, iter_openai_frames
+from app.routes.anthropic_compat import (
+    _validation_message,
+    forwarded_headers,
+    parse_native_body,
+)
+from app.routes.chat import execute_chat
+from app.schemas import ChatCompletionRequest
+from packages.auth.types import KeyContext
+from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
+
+logger = structlog.get_logger()
+router = APIRouter(tags=["Gemini"])
+
+_ACTIONS = ("generateContent", "streamGenerateContent")
+
+
+def _model_entry(m) -> dict:
+    return {
+        "name": f"models/{m.id}",
+        "displayName": m.id,
+        "description": f"{m.provider} model served via OrcaRouter Lite",
+        "supportedGenerationMethods": list(_ACTIONS),
+    }
+
+
+@router.get("/v1beta/models")
+async def gemini_list_models(_kc: KeyContext = Depends(get_key_context)):
+    return {"models": [_model_entry(m) for m in CATALOG]}
+
+
+@router.get("/v1beta/models/{model_id}")
+async def gemini_get_model(model_id: str, _kc: KeyContext = Depends(get_key_context)):
+    m = CATALOG_BY_ID.get(model_id)
+    if m is None:
+        return proto.error_response(404, f"models/{model_id} is not found")
+    return _model_entry(m)
+
+
+@router.post("/v1beta/models/{model_and_action}")
+async def gemini_generate(
+    model_and_action: str,
+    request: Request,
+    kc: KeyContext = Depends(get_key_context),
+    db: AsyncSession = Depends(get_db),
+):
+    if ":" not in model_and_action:
+        return proto.error_response(
+            404, f"POST is not supported for models/{model_and_action}"
+        )
+    model, action = model_and_action.rsplit(":", 1)
+    if action not in _ACTIONS:
+        return proto.error_response(
+            404, f"Unknown method '{action}' for models/{model}"
+        )
+    stream = action == "streamGenerateContent"
+    alt_sse = request.query_params.get("alt", "").lower() == "sse"
+
+    try:
+        greq = await parse_native_body(request, proto.GeminiGenerateRequest)
+        openai_body = ChatCompletionRequest.model_validate(
+            proto.to_openai_request(greq, model=model, stream=stream)
+        )
+        inner = await execute_chat(openai_body, kc, db)
+    except HTTPException as exc:
+        return proto.error_response(exc.status_code, str(exc.detail))
+    except ValidationError as exc:
+        return proto.error_response(400, _validation_message(exc))
+    except Exception as exc:  # defense-in-depth: never leak the OpenAI envelope
+        logger.warning("gemini_compat_error", error=str(exc))
+        return proto.error_response(500, "Internal server error")
+
+    if not stream:
+        payload = json.loads(bytes(inner.body))
+        return JSONResponse(
+            proto.to_gemini_response(payload), headers=forwarded_headers(inner)
+        )
+
+    chunks = proto.stream_chunks(iter_openai_frames(inner.body_iterator))
+    if alt_sse:
+        async def sse():
+            try:
+                async for chunk in chunks:
+                    yield f"data: {json.dumps(chunk, separators=(',', ':'))}\n\n"
+            finally:
+                await aclose_quietly(chunks)
+
+        return StreamingResponse(
+            sse(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+                **forwarded_headers(inner),
+            },
+        )
+
+    # No alt=sse: the REST default is a JSON array of chunks — aggregate.
+    collected = [chunk async for chunk in chunks]
+    return JSONResponse(collected, headers=forwarded_headers(inner))

--- a/app/routes/gemini_compat.py
+++ b/app/routes/gemini_compat.py
@@ -77,6 +77,12 @@ async def gemini_generate(
     kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ):
+    # The list endpoint presents Google resource names ("models/{id}"), so
+    # a caller following its own naming POSTs
+    # /v1beta/models/models/{id}:generateContent — accept that form here
+    # exactly as gemini_get_model does, or the model half would reach the
+    # engine as "models/{id}" and fail as model_not_found.
+    model_and_action = model_and_action.removeprefix("models/")
     if ":" not in model_and_action:
         return proto.error_response(
             404, f"POST is not supported for models/{model_and_action}"

--- a/app/routes/models.py
+++ b/app/routes/models.py
@@ -1,10 +1,18 @@
-"""GET /v1/models — OpenAI-compatible model listing."""
+"""GET /v1/models — model listing.
+
+One path, two protocols. The OpenAI envelope is the default; a request
+carrying `anthropic-version` (which the official Anthropic SDK and Claude
+Code always send, and no OpenAI client sends) gets the Anthropic envelope
+instead, so `client.models.list()` works against the same base URL the
+native /v1/messages surface lives on. The Gemini surface has its own
+listing at GET /v1beta/models.
+"""
 
 from __future__ import annotations
 
 import time
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
 
 from app.deps import get_key_context
 from packages.auth.types import KeyContext
@@ -12,9 +20,39 @@ from packages.litellm_adapter.catalog import CATALOG
 
 router = APIRouter(prefix="/v1", tags=["models"])
 
+# Anthropic's ModelInfo.created_at is an RFC 3339 release date. We don't
+# track release dates, and the API documents the epoch as the value to
+# use when the date is unknown.
+_UNKNOWN_RELEASE = "1970-01-01T00:00:00Z"
+
+
+def _anthropic_listing() -> dict:
+    data = [
+        {
+            "type": "model",
+            "id": m.id,
+            "display_name": m.id,
+            "created_at": _UNKNOWN_RELEASE,
+        }
+        for m in CATALOG
+    ]
+    return {
+        "data": data,
+        # The whole catalog is returned in one page, so pagination is a
+        # constant: nothing follows this page.
+        "has_more": False,
+        "first_id": data[0]["id"] if data else None,
+        "last_id": data[-1]["id"] if data else None,
+    }
+
 
 @router.get("/models")
-async def list_models(_kc: KeyContext = Depends(get_key_context)) -> dict:
+async def list_models(
+    request: Request, _kc: KeyContext = Depends(get_key_context),
+) -> dict:
+    if "anthropic-version" in request.headers:
+        return _anthropic_listing()
+
     now = int(time.time())
     return {
         "object": "list",

--- a/integrations/claude-code.md
+++ b/integrations/claude-code.md
@@ -1,0 +1,48 @@
+# Claude Code → OrcaRouter Lite
+
+Lite serves the Anthropic Messages API natively (`POST /v1/messages`), so
+Claude Code and the official `anthropic` SDKs connect without changes.
+
+## Claude Code
+
+```bash
+export ANTHROPIC_BASE_URL=http://localhost:8000    # no /v1 suffix
+export ANTHROPIC_API_KEY=sk-orca-...               # your Lite key
+# optional: pin the model (any catalog model, or "auto")
+# export ANTHROPIC_MODEL=claude-3-5-sonnet-latest
+
+claude
+```
+
+Requests route through Lite's normal pipeline: `model="auto"` works, the
+prompt cache works, and every request lands in the local dashboard.
+
+## Anthropic Python SDK
+
+```python
+from anthropic import Anthropic
+
+client = Anthropic(
+    base_url="http://localhost:8000",   # SDK appends /v1/messages itself
+    api_key="sk-orca-...",
+)
+message = client.messages.create(
+    model="auto",                        # or any catalog model
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello!"}],
+)
+print(message.content[0].text)
+```
+
+Streaming (`client.messages.stream(...)`) and tool use work as usual.
+
+## Known limitations (v1)
+
+- `thinking` (extended thinking) is accepted but **dropped** — the request
+  still works, without a thinking budget. A `structlog` warning is emitted.
+- `top_k` is dropped; `temperature` / `top_p` pass through.
+- Server-side tools (web search, computer use), PDF `document` blocks, and
+  the Files API return 400. Custom function tools are fully supported.
+- `POST /v1/messages/count_tokens` returns an estimate
+  (`litellm.token_counter`, chars/4 fallback), good enough for Claude
+  Code's context tracking.

--- a/integrations/claude-code.md
+++ b/integrations/claude-code.md
@@ -41,6 +41,8 @@ Streaming (`client.messages.stream(...)`) and tool use work as usual.
 - `thinking` (extended thinking) is accepted but **dropped** — the request
   still works, without a thinking budget. A `structlog` warning is emitted.
 - `top_k` is dropped; `temperature` / `top_p` pass through.
+- `stop_sequences` beyond the OpenAI wire cap of 4 are truncated to the
+  first 4 (a `structlog` warning is emitted).
 - Server-side tools (web search, computer use), PDF `document` blocks, and
   the Files API return 400. Custom function tools are fully supported.
 - `POST /v1/messages/count_tokens` returns an estimate

--- a/integrations/claude-code.md
+++ b/integrations/claude-code.md
@@ -40,9 +40,19 @@ Streaming (`client.messages.stream(...)`) and tool use work as usual.
 
 - `thinking` (extended thinking) is accepted but **dropped** — the request
   still works, without a thinking budget. A `structlog` warning is emitted.
-- `top_k` is dropped; `temperature` / `top_p` pass through.
+- `top_k` is dropped; `temperature` / `top_p` pass through, and values
+  outside the API's own 0–1 range are rejected with a 400 rather than
+  forwarded (an upstream rejection would reach you as a retryable 500).
+  `max_tokens` must be >= 1, likewise.
 - `stop_sequences` beyond the OpenAI wire cap of 4 are truncated to the
   first 4 (a `structlog` warning is emitted).
+- Images inside a `tool_result` are forwarded as a user message following
+  the tool result, since the internal format's tool messages are
+  text-only. Non-text blocks in `system` (which the API itself does not
+  allow) are dropped with a warning.
+- Streaming `message_start.usage.input_tokens` is the same estimate
+  `/v1/messages/count_tokens` returns — the upstream only reports the
+  exact count at end-of-stream, where it is sent in `message_delta`.
 - Server-side tools (web search, computer use), PDF `document` blocks, and
   the Files API return 400. Custom function tools are fully supported.
 - `POST /v1/messages/count_tokens` returns an estimate

--- a/integrations/gemini-sdk.md
+++ b/integrations/gemini-sdk.md
@@ -57,6 +57,12 @@ logs; the header form doesn't.
   `thoughtSignature` parts in history are dropped the same way.
 - `stopSequences` beyond the OpenAI wire cap of 4 are truncated to the
   first 4 (a `structlog` warning is emitted).
+- `temperature` (0–2), `topP` (0–1) and `maxOutputTokens` (>= 1) are
+  range-checked and rejected with a 400 INVALID_ARGUMENT rather than
+  forwarded — an upstream rejection would reach you as a retryable 500.
+- `functionCallingConfig.mode: ANY` with several `allowedFunctionNames`
+  restricts the tools sent upstream to that subset, so the model cannot
+  call a function you excluded.
 - `responseMimeType: "application/json"` maps to JSON mode;
   `responseSchema` itself is not yet enforced.
 - `streamGenerateContent` without `?alt=sse` returns the full JSON array

--- a/integrations/gemini-sdk.md
+++ b/integrations/gemini-sdk.md
@@ -53,7 +53,10 @@ logs; the header form doesn't.
   server-side tools (`googleSearch`, `codeExecution`, `urlContext`)
   return 400. Function declarations are fully supported (uppercase proto
   type enums are normalized automatically).
-- `safetySettings`, `thinkingConfig`, and `topK` are dropped.
+- `safetySettings`, `thinkingConfig`, and `topK` are dropped; `thought` /
+  `thoughtSignature` parts in history are dropped the same way.
+- `stopSequences` beyond the OpenAI wire cap of 4 are truncated to the
+  first 4 (a `structlog` warning is emitted).
 - `responseMimeType: "application/json"` maps to JSON mode;
   `responseSchema` itself is not yet enforced.
 - `streamGenerateContent` without `?alt=sse` returns the full JSON array

--- a/integrations/gemini-sdk.md
+++ b/integrations/gemini-sdk.md
@@ -57,6 +57,11 @@ logs; the header form doesn't.
   `thoughtSignature` parts in history are dropped the same way.
 - `stopSequences` beyond the OpenAI wire cap of 4 are truncated to the
   first 4 (a `structlog` warning is emitted).
+- Streaming keeps text and `functionCall` parts in the model's order
+  across chunks, but within ONE upstream chunk that carries both, the
+  text part is always emitted first: the internal OpenAI delta has no
+  ordering between `content` and `tool_calls`, so a call that preceded
+  text in the same chunk cannot be told apart from one that followed it.
 - `temperature` (0–2), `topP` (0–1) and `maxOutputTokens` (>= 1) are
   range-checked and rejected with a 400 INVALID_ARGUMENT rather than
   forwarded — an upstream rejection would reach you as a retryable 500.

--- a/integrations/gemini-sdk.md
+++ b/integrations/gemini-sdk.md
@@ -1,0 +1,60 @@
+# Google Gemini SDK → OrcaRouter Lite
+
+Lite serves the Gemini API natively (AI Studio style, `/v1beta`), so the
+official `google-genai` SDK connects without changes.
+
+## google-genai (Python)
+
+```python
+from google import genai
+from google.genai.types import HttpOptions
+
+client = genai.Client(
+    api_key="sk-orca-...",                                  # your Lite key
+    http_options=HttpOptions(base_url="http://localhost:8000"),
+)
+
+resp = client.models.generate_content(
+    model="auto",                       # or any catalog model
+    contents="Hello!",
+)
+print(resp.text)
+
+# streaming
+for chunk in client.models.generate_content_stream(
+    model="gemini-1.5-flash", contents="Tell me a story",
+):
+    print(chunk.text, end="")
+```
+
+## curl
+
+```bash
+# blocking
+curl "http://localhost:8000/v1beta/models/auto:generateContent" \
+  -H "x-goog-api-key: sk-orca-..." \
+  -H "content-type: application/json" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"Hello!"}]}]}'
+
+# streaming (SSE)
+curl -N "http://localhost:8000/v1beta/models/auto:streamGenerateContent?alt=sse" \
+  -H "x-goog-api-key: sk-orca-..." \
+  -H "content-type: application/json" \
+  -d '{"contents":[{"role":"user","parts":[{"text":"Hello!"}]}]}'
+```
+
+Auth is accepted as `x-goog-api-key` (preferred) or `?key=` — note the
+query-param form puts the key in URLs, which typically end up in access
+logs; the header form doesn't.
+
+## Known limitations (v1)
+
+- `candidateCount > 1`, `cachedContent`, Files API (`fileData`), and
+  server-side tools (`googleSearch`, `codeExecution`, `urlContext`)
+  return 400. Function declarations are fully supported (uppercase proto
+  type enums are normalized automatically).
+- `safetySettings`, `thinkingConfig`, and `topK` are dropped.
+- `responseMimeType: "application/json"` maps to JSON mode;
+  `responseSchema` itself is not yet enforced.
+- `streamGenerateContent` without `?alt=sse` returns the full JSON array
+  in one response (the SDKs all use `alt=sse`).

--- a/packages/litellm_adapter/client.py
+++ b/packages/litellm_adapter/client.py
@@ -124,6 +124,11 @@ class OrcaLiteLLMClient:
             if d.tpm:
                 params["tpm"] = d.tpm
             entry: dict = {"model_name": d.model_name, "litellm_params": params}
+            if d.deployment_id:
+                # Pins the Router's deployment id so aliases of one upstream
+                # share cooldown / allowed-fails state instead of each
+                # spelling failing its own way into a cooldown.
+                entry["model_info"] = {"id": d.deployment_id}
             model_list.append(entry)
 
         if not model_list:

--- a/packages/litellm_adapter/hosted_catalog.py
+++ b/packages/litellm_adapter/hosted_catalog.py
@@ -151,6 +151,16 @@ HOSTED_MODEL_ALIASES: frozenset[str] = frozenset({
 # robotics-er, grok-imagine-*) are deployable via explicit pin but skipped
 # by auto-routing (no cost metadata → eligibility filter drops them).
 HOSTED_CATALOG_SUPPLEMENT: tuple[tuple, ...] = (
+    # Zero-credit models, listed under the provider-qualified wire IDs O2's
+    # own /v1/models uses (each has a matching deployment via
+    # HOSTED_MODEL_ALIASES). 0.0/0.0 is the true zero-credit price; note
+    # that choose_auto_model deliberately excludes zero-blended-cost
+    # entries from auto-routing, so these are discoverable + pinnable but
+    # never auto-selected.
+    ('deepseek/deepseek-v4-flash-free', 'deepseek', 'deepseek/', True, False, True, 0.0, 0.0),
+    ('deepseek/deepseek-v4-pro-free'  ,  'deepseek', 'deepseek/', True, False, True, 0.0, 0.0),
+    ('orcarouter/free'           , 'orcarouter',   'openai/', True, False, True, 0.0, 0.0),
+    ('qwen/qwen3.8-27b-free'     ,      'qwen',   'openai/', True, False, True, 0.0, 0.0),
     ('claude-haiku-4.5'          , 'anthropic', 'anthropic/', True, True, True, 1.00e-06, 5.00e-06),
     ('claude-opus-4'             , 'anthropic', 'anthropic/', True, True, True, 1.50e-05, 7.50e-05),
     ('claude-opus-4.1'           , 'anthropic', 'anthropic/', True, True, True, 1.50e-05, 7.50e-05),

--- a/packages/litellm_adapter/hosted_catalog.py
+++ b/packages/litellm_adapter/hosted_catalog.py
@@ -40,7 +40,9 @@ HOSTED_MODELS: tuple[tuple[str, str], ...] = (
     ('deepseek', 'deepseek-chat'),
     ('deepseek', 'deepseek-reasoner'),
     ('deepseek', 'deepseek-v4-flash'),
+    ('deepseek', 'deepseek-v4-flash-free'),
     ('deepseek', 'deepseek-v4-pro'),
+    ('deepseek', 'deepseek-v4-pro-free'),
     ('google', 'gemini-2.5-flash-image'),
     ('google', 'gemini-2.5-pro'),
     ('google', 'gemini-3-flash-preview'),
@@ -111,6 +113,7 @@ HOSTED_MODELS: tuple[tuple[str, str], ...] = (
     ('openai', 'gpt-5.5-2026-04-23'),
     ('openai', 'gpt-5.5-pro'),
     ('openai', 'gpt-5.5-pro-2026-04-23'),
+    ('orcarouter', 'free'),
     ('qwen', 'qwen3-max'),
     ('qwen', 'qwen3-max-preview'),
     ('qwen', 'qwen3-vl-235b-a22b-instruct'),
@@ -128,7 +131,19 @@ HOSTED_MODELS: tuple[tuple[str, str], ...] = (
     ('qwen', 'qwen3.6-flash-2026-04-16'),
     ('qwen', 'qwen3.6-plus'),
     ('qwen', 'qwen3.6-plus-2026-04-02'),
+    ('qwen', 'qwen3.8-27b-free'),
 )
+
+# O2's public API uses provider-qualified IDs for its zero-credit models.
+# Keep the normal bare model group for compatibility, and additionally expose
+# these exact wire IDs so OpenAI-compatible clients can copy an ID directly
+# from api.orcarouter.ai/v1/models into their local Lite request unchanged.
+HOSTED_MODEL_ALIASES: frozenset[str] = frozenset({
+    'deepseek/deepseek-v4-flash-free',
+    'deepseek/deepseek-v4-pro-free',
+    'orcarouter/free',
+    'qwen/qwen3.8-27b-free',
+})
 
 # Supplemental catalog metadata for O2 models absent from LiteLLM's model_cost.
 # Subset of HOSTED_MODELS — only entries whose bare_id LiteLLM doesn't ship.

--- a/packages/litellm_adapter/types.py
+++ b/packages/litellm_adapter/types.py
@@ -62,3 +62,8 @@ class ProviderDeployment:
     tpm: int | None = None
     custom_llm_provider: str | None = None
     extra_headers: dict | None = None
+    # LiteLLM Router keys cooldown/health state by deployment id, which it
+    # derives from the entry (model_name included). Two entries that are
+    # really the SAME upstream under two names (the hosted wire-id aliases)
+    # must share one id, or each name probes a dead upstream separately.
+    deployment_id: str | None = None

--- a/scripts/smoke_native.py
+++ b/scripts/smoke_native.py
@@ -1,0 +1,250 @@
+"""Smoke test for the native Anthropic + Gemini protocol endpoints.
+
+Runs against a LIVE OrcaRouter Lite server with at least one real provider
+key configured (real completions are made — a few cents of spend). Wire-level
+checks use httpx (always available); when the official `anthropic` /
+`google-genai` SDKs are installed, true SDK-compatibility checks run too.
+
+Usage:
+    # server side: docker compose up   (with a provider key in .env)
+    ORCA_API_KEY=sk-orca-... PYTHONPATH=. python scripts/smoke_native.py
+
+    # optional:
+    ORCA_BASE_URL=http://localhost:8000   (default)
+    ORCA_SMOKE_MODEL=auto                 (default; any catalog model works)
+
+Exit code 0 = every check passed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import httpx
+
+BASE_URL = os.environ.get("ORCA_BASE_URL", "http://localhost:8000").rstrip("/")
+API_KEY = os.environ.get("ORCA_API_KEY", "")
+MODEL = os.environ.get("ORCA_SMOKE_MODEL", "auto")
+
+RESULTS: list[tuple[str, bool, str]] = []
+
+
+def check(name: str):
+    def wrap(fn):
+        def run():
+            try:
+                detail = fn() or ""
+                RESULTS.append((name, True, detail))
+                print(f"  ✓ {name}" + (f" — {detail}" if detail else ""))
+            except Exception as exc:  # noqa: BLE001 - report, don't crash the suite
+                RESULTS.append((name, False, str(exc)))
+                print(f"  ✗ {name} — {exc}")
+        return run
+    return wrap
+
+
+# ── wire-level: Anthropic /v1/messages ──────────────────────────────────
+
+@check("anthropic blocking (httpx)")
+def anthropic_blocking():
+    r = httpx.post(
+        f"{BASE_URL}/v1/messages",
+        headers={"x-api-key": API_KEY},
+        json={
+            "model": MODEL,
+            "max_tokens": 64,
+            "messages": [{"role": "user", "content": "Reply with exactly: pong"}],
+        },
+        timeout=120,
+    )
+    assert r.status_code == 200, f"HTTP {r.status_code}: {r.text[:200]}"
+    body = r.json()
+    assert body["type"] == "message" and body["role"] == "assistant", body
+    assert body["content"] and body["content"][0]["type"] == "text", body
+    assert body["usage"]["output_tokens"] > 0, body["usage"]
+    return f"model={r.headers.get('x-orca-resolved-model')}"
+
+
+@check("anthropic streaming (httpx)")
+def anthropic_streaming():
+    events: list[str] = []
+    with httpx.stream(
+        "POST", f"{BASE_URL}/v1/messages",
+        headers={"x-api-key": API_KEY},
+        json={
+            "model": MODEL, "max_tokens": 64, "stream": True,
+            "messages": [{"role": "user", "content": "Count to three."}],
+        },
+        timeout=120,
+    ) as r:
+        assert r.status_code == 200, f"HTTP {r.status_code}"
+        assert r.headers["content-type"].startswith("text/event-stream")
+        for line in r.iter_lines():
+            if line.startswith("event: "):
+                events.append(line[len("event: "):])
+    assert events[0] == "message_start", events[:3]
+    assert events[-1] == "message_stop", events[-3:]
+    assert "content_block_delta" in events, events
+    return f"{len(events)} events"
+
+
+@check("anthropic tool use (httpx)")
+def anthropic_tool_use():
+    r = httpx.post(
+        f"{BASE_URL}/v1/messages",
+        headers={"x-api-key": API_KEY},
+        json={
+            "model": MODEL,
+            "max_tokens": 128,
+            "messages": [{"role": "user", "content": "What's the weather in Paris?"}],
+            "tools": [{
+                "name": "get_weather",
+                "description": "Get current weather for a city",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }],
+            "tool_choice": {"type": "any"},
+        },
+        timeout=120,
+    )
+    assert r.status_code == 200, f"HTTP {r.status_code}: {r.text[:200]}"
+    body = r.json()
+    tool_blocks = [b for b in body["content"] if b["type"] == "tool_use"]
+    assert tool_blocks, f"no tool_use block; stop_reason={body['stop_reason']}"
+    assert tool_blocks[0]["name"] == "get_weather", tool_blocks[0]
+    assert isinstance(tool_blocks[0]["input"], dict), tool_blocks[0]
+    return f"stop_reason={body['stop_reason']}"
+
+
+@check("anthropic count_tokens (httpx)")
+def anthropic_count_tokens():
+    r = httpx.post(
+        f"{BASE_URL}/v1/messages/count_tokens",
+        headers={"x-api-key": API_KEY},
+        json={"model": MODEL,
+              "messages": [{"role": "user", "content": "hello there"}]},
+        timeout=30,
+    )
+    assert r.status_code == 200, f"HTTP {r.status_code}: {r.text[:200]}"
+    tokens = r.json()["input_tokens"]
+    assert isinstance(tokens, int) and tokens > 0, tokens
+    return f"input_tokens={tokens}"
+
+
+# ── wire-level: Gemini /v1beta ──────────────────────────────────────────
+
+@check("gemini blocking (httpx)")
+def gemini_blocking():
+    r = httpx.post(
+        f"{BASE_URL}/v1beta/models/{MODEL}:generateContent",
+        headers={"x-goog-api-key": API_KEY},
+        json={"contents": [{"role": "user",
+                            "parts": [{"text": "Reply with exactly: pong"}]}]},
+        timeout=120,
+    )
+    assert r.status_code == 200, f"HTTP {r.status_code}: {r.text[:200]}"
+    body = r.json()
+    cand = body["candidates"][0]
+    assert cand["content"]["parts"][0]["text"], body
+    assert body["usageMetadata"]["candidatesTokenCount"] > 0, body["usageMetadata"]
+    return f"finishReason={cand['finishReason']}"
+
+
+@check("gemini streaming alt=sse (httpx)")
+def gemini_streaming():
+    frames: list[dict] = []
+    with httpx.stream(
+        "POST", f"{BASE_URL}/v1beta/models/{MODEL}:streamGenerateContent?alt=sse",
+        headers={"x-goog-api-key": API_KEY},
+        json={"contents": [{"role": "user", "parts": [{"text": "Count to three."}]}]},
+        timeout=120,
+    ) as r:
+        assert r.status_code == 200, f"HTTP {r.status_code}"
+        for line in r.iter_lines():
+            if line.startswith("data: "):
+                frames.append(json.loads(line[len("data: "):]))
+    assert frames, "no SSE frames"
+    assert frames[-1]["candidates"][0].get("finishReason"), frames[-1]
+    assert "usageMetadata" in frames[-1], frames[-1]
+    return f"{len(frames)} frames"
+
+
+@check("gemini model listing (httpx)")
+def gemini_models():
+    r = httpx.get(f"{BASE_URL}/v1beta/models",
+                  headers={"x-goog-api-key": API_KEY}, timeout=30)
+    assert r.status_code == 200, f"HTTP {r.status_code}"
+    models = r.json()["models"]
+    assert models and models[0]["name"].startswith("models/"), models[:1]
+    return f"{len(models)} models"
+
+
+# ── SDK-level (run when installed) ──────────────────────────────────────
+
+@check("anthropic SDK blocking + stream")
+def anthropic_sdk():
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return "SKIPPED (pip install anthropic)"
+    client = Anthropic(base_url=BASE_URL, api_key=API_KEY)
+    msg = client.messages.create(
+        model=MODEL, max_tokens=64,
+        messages=[{"role": "user", "content": "Reply with exactly: pong"}],
+    )
+    assert msg.content[0].text, msg
+    chunks = []
+    with client.messages.stream(
+        model=MODEL, max_tokens=64,
+        messages=[{"role": "user", "content": "Count to three."}],
+    ) as stream:
+        for text in stream.text_stream:
+            chunks.append(text)
+    assert "".join(chunks), "empty stream"
+    return f"blocking + {len(chunks)} stream chunks"
+
+
+@check("google-genai SDK blocking + stream")
+def gemini_sdk():
+    try:
+        from google import genai
+        from google.genai.types import HttpOptions
+    except ImportError:
+        return "SKIPPED (pip install google-genai)"
+    client = genai.Client(api_key=API_KEY,
+                          http_options=HttpOptions(base_url=BASE_URL))
+    resp = client.models.generate_content(
+        model=MODEL, contents="Reply with exactly: pong",
+    )
+    assert resp.text, resp
+    chunks = [c for c in client.models.generate_content_stream(
+        model=MODEL, contents="Count to three.",
+    )]
+    assert chunks, "empty stream"
+    return f"blocking + {len(chunks)} stream chunks"
+
+
+def main() -> int:
+    if not API_KEY:
+        print("ORCA_API_KEY is required (the sk-orca-* key printed at server startup).")
+        return 2
+    print(f"Native-protocol smoke against {BASE_URL} (model={MODEL})\n")
+    for fn in (
+        anthropic_blocking, anthropic_streaming, anthropic_tool_use,
+        anthropic_count_tokens, gemini_blocking, gemini_streaming,
+        gemini_models, anthropic_sdk, gemini_sdk,
+    ):
+        fn()
+    failed = [name for name, ok, _ in RESULTS if not ok]
+    print(f"\n{len(RESULTS) - len(failed)}/{len(RESULTS)} checks passed"
+          + (f" — FAILED: {', '.join(failed)}" if failed else ""))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/integration/test_adapter_failure_attribution.py
+++ b/tests/integration/test_adapter_failure_attribution.py
@@ -1,0 +1,131 @@
+# ruff: noqa: F811  (fixtures imported from sibling modules are re-bound as parameters)
+"""An adapter fault mid-stream is OUR failure, not a client disconnect.
+
+The adapter generator IS the response body, so when it raises, its cleanup
+closes the engine's SSE generator — indistinguishable at the engine's
+suspended yield from Starlette closing it because the client went away. The
+row then said 499/client_disconnect while the client was told "Internal
+server error", hiding every adapter regression in the analytics. The
+transformers now ABORT the frame source (AdapterError) when they unwind on
+their own exception, and the engine records that as 500/adapter_error.
+
+The fault is induced the way it would really happen: a chunk the
+transformer cannot handle (`choices` is a string, so `choices[0].get(...)`
+raises inside it), not a wrapper around it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from unittest.mock import AsyncMock
+
+from sqlalchemy import select
+
+from tests.integration.test_anthropic_messages import (  # noqa: F401 (fixture)
+    _messages_payload,
+    native_client,
+)
+
+_GEMINI_PAYLOAD = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+
+
+async def _log_rows() -> list[tuple[int, str | None, bool]]:
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    return [(r.status_code, r.error_type, r.is_streaming) for r in rows]
+
+
+def _malformed_chunk_router(fake) -> None:
+    """Engine emits a chunk whose `choices` is a string — well-formed SSE,
+    but the transformers index into it and raise."""
+    async def _stream():
+        yield {"id": "chatcmpl-1", "model": "gpt-4o-mini", "choices": "boom"}
+
+    async def _acompletion(**kwargs):
+        assert kwargs.get("stream")
+        return _stream()
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+
+async def test_anthropic_adapter_fault_is_logged_as_adapter_error(native_client):
+    client, fake, key = native_client
+    _malformed_chunk_router(fake)
+
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    # the client still gets a parseable native error event
+    assert '"type":"api_error"' in r.text.replace(" ", "")
+    await asyncio.sleep(0.1)
+    # ...and the row blames us, not the caller
+    assert await _log_rows() == [(500, "adapter_error", True)]
+
+
+async def test_gemini_adapter_fault_is_logged_as_adapter_error(native_client):
+    client, fake, key = native_client
+    _malformed_chunk_router(fake)
+
+    r = await client.post(
+        "/v1beta/models/gpt-4o-mini:streamGenerateContent?alt=sse",
+        json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    frames = [json.loads(line[len("data: "):]) for line in r.text.splitlines()
+              if line.startswith("data: ")]
+    assert frames[-1]["error"]["status"] == "INTERNAL"
+    await asyncio.sleep(0.1)
+    assert await _log_rows() == [(500, "adapter_error", True)]
+
+
+async def test_a_real_client_disconnect_is_still_499(native_client):
+    """The new abort path must not swallow the genuine disconnect case."""
+    client, fake, key = native_client
+
+    class _CancellingStream:
+        def __init__(self):
+            self.closed = False
+            self._yielded = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                return {
+                    "id": "chatcmpl-1", "object": "chat.completion.chunk",
+                    "model": "gpt-4o-mini", "created": int(time.time()),
+                    "choices": [{"index": 0, "delta": {"content": "Hi"},
+                                 "finish_reason": None}],
+                }
+            raise asyncio.CancelledError()
+
+        async def aclose(self):
+            self.closed = True
+
+    slow = _CancellingStream()
+
+    async def _stream_router(**kwargs):
+        assert kwargs.get("stream")
+        return slow
+
+    fake.acompletion = AsyncMock(side_effect=_stream_router)
+
+    try:
+        async with client.stream("POST", "/v1/messages",
+                                 json=_messages_payload(stream=True),
+                                 headers={"x-api-key": key}) as response:
+            async for _ in response.aiter_lines():
+                pass
+    except Exception:
+        pass
+    await asyncio.sleep(0.2)
+
+    assert slow.closed is True
+    assert await _log_rows() == [(499, "client_disconnect", True)]

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -484,3 +484,20 @@ async def test_count_tokens_requires_auth(native_client):
     })
     assert r.status_code == 401
     assert r.json()["type"] == "error"
+
+
+async def test_count_tokens_unexpected_error_stays_in_anthropic_envelope(native_client):
+    """Defense-in-depth: a schema-valid but malformed body that explodes
+    inside the translator (non-dict image source → AttributeError) must
+    render the Anthropic error envelope, not FastAPI's default 500 body."""
+    client, _, key = native_client
+    r = await client.post("/v1/messages/count_tokens", json={
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": [
+            {"type": "image", "source": "not-a-dict"},
+        ]}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 500
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "api_error"

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -705,3 +705,40 @@ async def test_auto_capability_mismatch_matches_the_pinned_403(native_client):
     assert r.status_code == 422, r.text
     assert "vision" in r.text
     fake.acompletion.assert_not_awaited()
+
+
+async def test_adapter_failure_mid_stream_renders_a_native_error_event(native_client, monkeypatch):
+    """A fault inside the streaming adapter itself must not fall through to
+    the app-wide OpenAI-envelope handler (or a bare connection reset): the
+    client gets one Anthropic `error` event it can parse."""
+    client, fake, key = native_client
+    from app.protocols import anthropic as proto
+    from app.routes import anthropic_compat
+
+    real = proto.stream_events
+
+    async def exploding(frames, **kw):
+        gen = real(frames, **kw)
+        async for ev in gen:
+            yield ev
+            raise RuntimeError("adapter bug")
+
+    monkeypatch.setattr(anthropic_compat.proto, "stream_events", exploding)
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    events = _parse_anthropic_sse(r.text)
+    assert events[0][0] == "message_start"
+    assert events[-1][0] == "error"
+    assert events[-1][1] == {
+        "type": "error",
+        "error": {"type": "api_error", "message": "Internal server error"},
+    }
+
+
+async def test_models_list_auth_failure_speaks_anthropic_envelope(native_client):
+    client, _fake, _key = native_client
+    r = await client.get("/v1/models", headers={"anthropic-version": "2023-06-01"})
+    assert r.status_code == 401
+    assert r.json()["type"] == "error"
+    assert r.json()["error"]["type"] == "authentication_error"

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -1,0 +1,486 @@
+"""POST /v1/messages — Anthropic Messages API ingress (slices S3-S5).
+
+Real app + mocked LiteLLM router (same pattern as test_streaming.py).
+Covers: x-api-key / Bearer auth, native error envelopes (never the OpenAI
+one), blocking + streaming translation, tool round-trips, RequestLog
+writeback, cross-protocol prompt-cache sharing, and count_tokens.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _openai_response(**kwargs) -> dict:
+    return {
+        "id": "chatcmpl-1",
+        "model": kwargs.get("model", "gpt-4o-mini"),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "choices": [{
+            "index": 0,
+            "message": kwargs.get(
+                "message", {"role": "assistant", "content": "Hello world"}
+            ),
+            "finish_reason": kwargs.get("finish_reason", "stop"),
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        "_orca_meta": {"provider": "openai", "latency_ms": 12},
+    }
+
+
+def _stream_chunks() -> list[dict]:
+    now = int(time.time())
+    return [
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": now,
+            "choices": [{"index": 0,
+                         "delta": {"role": "assistant", "content": "Hello"},
+                         "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": now,
+            "choices": [{"index": 0, "delta": {"content": " world"},
+                         "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": now,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+            "_orca_meta": {"provider": "openai", "latency_ms": 12},
+        },
+    ]
+
+
+@pytest.fixture
+async def native_client(tmp_sqlite_url, monkeypatch):
+    """App + mocked router. NO default auth header — credential-location
+    variants are part of what these tests exercise. Yields
+    (httpx client, fake router mock, seeded api key)."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    async def _stream_iter(chunks):
+        for c in chunks:
+            yield c
+
+    fake = AsyncMock()
+
+    async def _acompletion(**kwargs):
+        if kwargs.get("stream"):
+            return _stream_iter(_stream_chunks())
+        return _openai_response(model=kwargs.get("model", "gpt-4o-mini"))
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    from app.main import create_app
+    app = create_app()
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        yield c, fake, seed.api_key
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
+def _messages_payload(**overrides) -> dict:
+    base = {
+        "model": "gpt-4o-mini",
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return base
+
+
+def _parse_anthropic_sse(text: str) -> list[tuple[str, dict]]:
+    events = []
+    for frame in text.split("\n\n"):
+        if not frame.strip():
+            continue
+        lines = frame.splitlines()
+        assert lines[0].startswith("event: "), f"frame missing event line: {frame!r}"
+        assert lines[1].startswith("data: ")
+        events.append((lines[0][len("event: "):],
+                       json.loads(lines[1][len("data: "):])))
+    return events
+
+
+# ── auth ──
+
+
+async def test_x_api_key_authenticates(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+
+
+async def test_bearer_also_authenticates(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+
+
+async def test_missing_key_renders_anthropic_envelope(native_client):
+    client, _, _ = native_client
+    r = await client.post("/v1/messages", json=_messages_payload())
+    assert r.status_code == 401
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "authentication_error"
+
+
+async def test_invalid_key_renders_anthropic_envelope(native_client):
+    client, _, _ = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"x-api-key": "sk-orca-bogus"})
+    assert r.status_code == 401
+    assert r.json()["type"] == "error"
+
+
+# ── blocking ──
+
+
+async def test_blocking_response_shape_and_orca_headers(native_client):
+    client, fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    body = r.json()
+    assert body["type"] == "message"
+    assert body["role"] == "assistant"
+    assert body["content"] == [{"type": "text", "text": "Hello world"}]
+    assert body["stop_reason"] == "end_turn"
+    assert body["usage"] == {"input_tokens": 4, "output_tokens": 2}
+    assert r.headers["x-orca-resolved-model"] == "gpt-4o-mini"
+    assert r.headers["x-orca-requested-model"] == "gpt-4o-mini"
+
+    # engine received the translated OpenAI body
+    kwargs = fake.acompletion.call_args.kwargs
+    assert kwargs["messages"] == [{"role": "user", "content": "hi"}]
+    assert kwargs["max_tokens"] == 128
+
+
+async def test_missing_max_tokens_is_400_invalid_request_not_422(native_client):
+    client, _, key = native_client
+    payload = _messages_payload()
+    del payload["max_tokens"]
+    r = await client.post("/v1/messages", json=payload, headers={"x-api-key": key})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "max_tokens" in body["error"]["message"]
+
+
+async def test_malformed_json_body_returns_native_400(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", content=b"{not json",
+                          headers={"x-api-key": key,
+                                   "content-type": "application/json"})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "invalid_request_error"
+
+
+async def test_non_object_body_returns_native_400(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json=[1, 2],
+                          headers={"x-api-key": key})
+    assert r.status_code == 400
+    assert r.json()["error"]["type"] == "invalid_request_error"
+
+
+async def test_upstream_error_renders_native_envelope(native_client):
+    client, fake, key = native_client
+    fake.acompletion = AsyncMock(side_effect=RuntimeError("provider exploded"))
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"x-api-key": key})
+    assert r.status_code == 500  # engine's 503 collapses to Anthropic api_error/500
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "api_error"
+
+
+async def test_tools_round_trip_through_the_wire(native_client):
+    client, fake, key = native_client
+
+    async def _tool_response(**kwargs):
+        return _openai_response(
+            message={
+                "role": "assistant", "content": None,
+                "tool_calls": [{
+                    "id": "call_1", "type": "function",
+                    "function": {"name": "get_weather",
+                                 "arguments": '{"city": "SF"}'},
+                }],
+            },
+            finish_reason="tool_calls",
+        )
+
+    fake.acompletion = AsyncMock(side_effect=_tool_response)
+    r = await client.post("/v1/messages", json=_messages_payload(
+        tools=[{"name": "get_weather", "description": "d",
+                "input_schema": {"type": "object",
+                                 "properties": {"city": {"type": "string"}}}}],
+        tool_choice={"type": "auto"},
+    ), headers={"x-api-key": key})
+    assert r.status_code == 200
+
+    kwargs = fake.acompletion.call_args.kwargs
+    assert kwargs["tools"][0]["type"] == "function"
+    assert kwargs["tools"][0]["function"]["name"] == "get_weather"
+    assert kwargs["tool_choice"] == "auto"
+
+    body = r.json()
+    assert body["stop_reason"] == "tool_use"
+    (block,) = body["content"]
+    assert block["type"] == "tool_use"
+    assert block["input"] == {"city": "SF"}
+
+
+async def test_tool_result_history_reaches_engine_as_tool_message(native_client):
+    client, fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(messages=[
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+             "input": {"city": "SF"}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "72F"},
+        ]},
+    ]), headers={"x-api-key": key})
+    assert r.status_code == 200
+    messages = fake.acompletion.call_args.kwargs["messages"]
+    tool_msgs = [m for m in messages if m.get("role") == "tool"]
+    assert tool_msgs == [{"role": "tool", "tool_call_id": "toolu_1", "content": "72F"}]
+
+
+# ── streaming ──
+
+
+async def test_streaming_event_sequence_and_request_log(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+
+    events = _parse_anthropic_sse(r.text)
+    names = [n for n, _ in events]
+    assert names == [
+        "message_start", "content_block_start", "content_block_delta",
+        "content_block_delta", "content_block_stop", "message_delta",
+        "message_stop",
+    ]
+    assert "[DONE]" not in r.text
+
+    deltas = [d["delta"]["text"] for n, d in events if n == "content_block_delta"]
+    assert "".join(deltas) == "Hello world"
+    msg_delta = [d for n, d in events if n == "message_delta"][0]
+    assert msg_delta["usage"]["output_tokens"] == 2
+
+    # the engine wrote the RequestLog row with streamed usage
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].is_streaming is True
+    assert rows[0].input_tokens == 4
+    assert rows[0].output_tokens == 2
+    assert rows[0].status_code == 200
+
+
+async def test_streaming_client_disconnect_closes_upstream_and_logs_499(native_client):
+    """Client bails mid-stream. The cancellation must propagate through the
+    adapter's generator chain (transformer → iter_openai_frames → engine)
+    so the engine's disconnect handling still runs: upstream aclose() gets
+    called (stop burning tokens) and the RequestLog row records
+    499/client_disconnect. Mirrors test_streaming.py's disconnect test."""
+    import asyncio
+
+    client, fake, key = native_client
+
+    class _CancellingStream:
+        def __init__(self):
+            self.closed = False
+            self._yielded = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._yielded:
+                self._yielded = True
+                return {
+                    "id": "chatcmpl-1", "object": "chat.completion.chunk",
+                    "model": "gpt-4o-mini", "created": int(time.time()),
+                    "choices": [{"index": 0, "delta": {"content": "Hi"},
+                                 "finish_reason": None}],
+                }
+            raise asyncio.CancelledError()
+
+        async def aclose(self):
+            self.closed = True
+
+    slow = _CancellingStream()
+
+    async def _stream_router(**kwargs):
+        assert kwargs.get("stream")
+        return slow
+
+    fake.acompletion = AsyncMock(side_effect=_stream_router)
+
+    try:
+        async with client.stream(
+            "POST", "/v1/messages",
+            json=_messages_payload(stream=True),
+            headers={"x-api-key": key},
+        ) as response:
+            assert response.status_code == 200
+            async for _ in response.aiter_lines():
+                pass
+    except Exception:
+        # The cancel may surface as a transport error to httpx — we only
+        # care about server-side state below.
+        pass
+
+    await asyncio.sleep(0.2)
+
+    assert slow.closed is True, (
+        "upstream aclose() must be called when the client disconnects, even "
+        "through the protocol-adapter generator chain"
+    )
+
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].status_code == 499
+    assert rows[0].error_type == "client_disconnect"
+    assert rows[0].is_streaming is True
+
+
+# ── pipeline reuse ──
+
+
+async def test_prompt_cache_is_shared_across_protocols(native_client):
+    """The cache key is computed on the TRANSLATED body, so the same
+    semantic request via /v1/chat/completions then /v1/messages must hit
+    the same cache entry."""
+    client, fake, key = native_client
+    openai_payload = {
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+        "max_tokens": 128,
+    }
+    r1 = await client.post("/v1/chat/completions", json=openai_payload,
+                           headers={"Authorization": f"Bearer {key}"})
+    assert r1.status_code == 200
+    assert r1.headers["x-orca-cache"] == "MISS"
+
+    r2 = await client.post("/v1/messages", json=_messages_payload(),
+                           headers={"x-api-key": key})
+    assert r2.status_code == 200
+    assert r2.headers["x-orca-cache"] == "HIT"
+    assert r2.json()["content"] == [{"type": "text", "text": "Hello world"}]
+    # only the first request reached the (mock) upstream
+    assert fake.acompletion.call_count == 1
+
+
+async def test_model_auto_resolves_through_anthropic_ingress(native_client):
+    client, fake, key = native_client
+
+    from packages.litellm_adapter.catalog import models_for_provider
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    fake._deployments = [
+        ProviderDeployment(
+            model_name=m.id, litellm_model=f"{m.litellm_prefix}{m.id}",
+            api_key="sk-test", provider="openai",
+        )
+        for m in models_for_provider("openai")
+    ]
+    r = await client.post("/v1/messages", json=_messages_payload(model="auto"),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    assert r.headers["x-orca-requested-model"] == "auto"
+    resolved = r.headers["x-orca-resolved-model"]
+    assert resolved != "auto"
+    assert fake.acompletion.call_args.kwargs["model"] == resolved
+
+
+# ── count_tokens ──
+
+
+async def test_count_tokens_returns_positive_estimate(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages/count_tokens", json={
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hello there, how are you?"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 200
+    tokens = r.json()["input_tokens"]
+    assert isinstance(tokens, int)
+    assert tokens > 0
+
+
+async def test_count_tokens_requires_auth(native_client):
+    client, _, _ = native_client
+    r = await client.post("/v1/messages/count_tokens", json={
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+    })
+    assert r.status_code == 401
+    assert r.json()["type"] == "error"

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -420,17 +420,20 @@ async def test_prompt_cache_is_shared_across_protocols(native_client):
     semantic request via /v1/chat/completions then /v1/messages must hit
     the same cache entry."""
     client, fake, key = native_client
+    # temperature 0 on both sides: only a deterministic request is cached
+    # at all (an omitted temperature means the upstream default of 1.0).
     openai_payload = {
         "model": "gpt-4o-mini",
         "messages": [{"role": "user", "content": "hi"}],
         "max_tokens": 128,
+        "temperature": 0,
     }
     r1 = await client.post("/v1/chat/completions", json=openai_payload,
                            headers={"Authorization": f"Bearer {key}"})
     assert r1.status_code == 200
     assert r1.headers["x-orca-cache"] == "MISS"
 
-    r2 = await client.post("/v1/messages", json=_messages_payload(),
+    r2 = await client.post("/v1/messages", json=_messages_payload(temperature=0),
                            headers={"x-api-key": key})
     assert r2.status_code == 200
     assert r2.headers["x-orca-cache"] == "HIT"
@@ -556,7 +559,7 @@ async def test_cache_is_not_shared_across_different_max_tokens(native_client):
     client, fake, key = native_client
 
     body = {
-        "model": "gpt-4o-mini", "max_tokens": 16,
+        "model": "gpt-4o-mini", "max_tokens": 16, "temperature": 0,
         "messages": [{"role": "user", "content": "cache probe"}],
     }
     first = await client.post("/v1/messages", json=body, headers={"x-api-key": key})
@@ -572,6 +575,25 @@ async def test_cache_is_not_shared_across_different_max_tokens(native_client):
         "/v1/messages", json={**body, "max_tokens": 4096}, headers={"x-api-key": key},
     )
     assert other.headers["x-orca-cache"] == "MISS"
+
+
+async def test_request_without_temperature_bypasses_the_cache(native_client):
+    """Regression: the native translators only forward a temperature the
+    client sent, and Claude Code never sends one — so the upstream samples
+    at its 1.0 default. Caching that would replay one arbitrary sample to
+    every later identical request (an agent's retries would get the same
+    stale answer)."""
+    client, fake, key = native_client
+
+    body = {
+        "model": "gpt-4o-mini", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "no temperature here"}],
+    }
+    first = await client.post("/v1/messages", json=body, headers={"x-api-key": key})
+    second = await client.post("/v1/messages", json=body, headers={"x-api-key": key})
+    assert first.headers["x-orca-cache"] == "BYPASS"
+    assert second.headers["x-orca-cache"] == "BYPASS"
+    assert fake.acompletion.call_count == 2, "both must reach the upstream"
 
 
 async def test_streaming_message_start_carries_an_input_token_estimate(native_client):

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -506,6 +506,42 @@ async def test_blocking_model_not_found_renders_404_not_found(native_client):
     assert body["error"]["type"] == "not_found_error"
 
 
+async def test_blocking_upstream_auth_error_is_non_retryable(native_client):
+    """OUR provider credential failing is permanent until the operator
+    fixes it. The engine reports it as a retryable 503; this surface must
+    render a non-retryable 403 permission_error (matching the Gemini
+    surface), NOT 500 api_error which SDKs retry with backoff — and not
+    401, since the caller's own key is fine."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "provider rejected the key", http_status=503,
+        error_type="upstream_auth_error",
+    ))
+    r = await client.post("/v1/messages", json={
+        "model": "gpt-4o-mini", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 403
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "permission_error"
+
+
+async def test_max_tokens_zero_is_native_400(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json={
+        "model": "gpt-4o-mini", "max_tokens": 0,
+        "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 400
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "invalid_request_error"
+    assert "max_tokens" in body["error"]["message"]
+
+
 async def test_count_tokens_unexpected_error_stays_in_anthropic_envelope(native_client):
     """Defense-in-depth: a schema-valid but malformed body that explodes
     inside the translator (non-dict image source → AttributeError) must

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -661,3 +661,47 @@ async def test_count_tokens_unexpected_error_stays_in_anthropic_envelope(native_
     body = r.json()
     assert body["type"] == "error"
     assert body["error"]["type"] == "api_error"
+
+
+async def test_auto_capability_mismatch_matches_the_pinned_403(native_client):
+    """Providers ARE configured, but no deployable model supports what the
+    request needs (an image with only a text-only model deployed). Same
+    operator-side, permanent class as no_providers_configured: the native
+    surface must render 403 permission_error, not collapse the engine's
+    bare 422 into a client-blaming 400 — while the OpenAI surface keeps
+    its 422 (x-orca-error-type is an in-process relay to the native
+    routes; the app-wide handler does not put it on the wire)."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.catalog import CATALOG
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    text_only = next(m for m in CATALOG if not m.supports_vision)
+    fake._deployments = [ProviderDeployment(
+        model_name=text_only.id,
+        litellm_model=f"{text_only.litellm_prefix}{text_only.id}",
+        api_key="sk-test", provider=text_only.provider,
+    )]
+    image_message = {"role": "user", "content": [
+        {"type": "text", "text": "describe"},
+        {"type": "image", "source": {
+            "type": "base64", "media_type": "image/png", "data": "AAAA",
+        }},
+    ]}
+
+    r = await client.post("/v1/messages", json=_messages_payload(
+        model="auto", messages=[image_message],
+    ), headers={"x-api-key": key})
+    assert r.status_code == 403, r.text
+    assert r.json()["error"]["type"] == "permission_error"
+    assert "vision" in r.json()["error"]["message"]
+
+    r = await client.post("/v1/chat/completions", json={
+        "model": "auto",
+        "messages": [{"role": "user", "content": [
+            {"type": "text", "text": "describe"},
+            {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+        ]}],
+    }, headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 422, r.text
+    assert "vision" in r.text
+    fake.acompletion.assert_not_awaited()

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -340,7 +340,7 @@ async def test_streaming_event_sequence_and_request_log(native_client):
 
 async def test_streaming_client_disconnect_closes_upstream_and_logs_499(native_client):
     """Client bails mid-stream. The cancellation must propagate through the
-    adapter's generator chain (transformer → iter_openai_frames → engine)
+    adapter's generator chain (transformer → OpenAIFrameStream → engine)
     so the engine's disconnect handling still runs: upstream aclose() gets
     called (stop burning tokens) and the RequestLog row records
     499/client_disconnect. Mirrors test_streaming.py's disconnect test."""
@@ -527,6 +527,72 @@ async def test_blocking_upstream_auth_error_is_non_retryable(native_client):
     body = r.json()
     assert body["type"] == "error"
     assert body["error"]["type"] == "permission_error"
+
+
+async def test_no_providers_configured_is_non_retryable(native_client):
+    """A fresh install with no provider key is permanent until the
+    operator adds one — it must not render as a retryable 500 api_error
+    the SDK keeps backing off against."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "No provider keys configured.", http_status=503,
+        error_type="no_providers_configured",
+    ))
+    r = await client.post("/v1/messages", json={
+        "model": "gpt-4o-mini", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 403
+    assert r.json()["error"]["type"] == "permission_error"
+
+
+async def test_cache_is_not_shared_across_different_max_tokens(native_client):
+    """Regression: the prompt-cache key omitted max_tokens, so a second
+    request differing only in its budget was served the first response
+    (x-orca-cache: HIT). The Anthropic surface sends max_tokens on every
+    request, so the collision was reachable in normal use."""
+    client, fake, key = native_client
+
+    body = {
+        "model": "gpt-4o-mini", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "cache probe"}],
+    }
+    first = await client.post("/v1/messages", json=body, headers={"x-api-key": key})
+    assert first.status_code == 200
+    assert first.headers["x-orca-cache"] == "MISS"
+
+    # identical request → served from cache
+    again = await client.post("/v1/messages", json=body, headers={"x-api-key": key})
+    assert again.headers["x-orca-cache"] == "HIT"
+
+    # same prompt, different budget → must NOT reuse the entry
+    other = await client.post(
+        "/v1/messages", json={**body, "max_tokens": 4096}, headers={"x-api-key": key},
+    )
+    assert other.headers["x-orca-cache"] == "MISS"
+
+
+async def test_streaming_message_start_carries_an_input_token_estimate(native_client):
+    """The protocol reports the input count in message_start; 0 there made
+    every streaming response understate usage to the SDK."""
+    client, _, key = native_client
+    r = await client.post("/v1/messages", json={
+        "model": "gpt-4o-mini", "max_tokens": 16, "stream": True,
+        "messages": [{"role": "user", "content": "hello there, how are you?"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 200
+
+    start = None
+    for line in r.text.splitlines():
+        if line.startswith("data: "):
+            payload = json.loads(line[len("data: "):])
+            if payload.get("type") == "message_start":
+                start = payload
+                break
+    assert start is not None
+    assert start["message"]["usage"]["input_tokens"] > 0
 
 
 async def test_max_tokens_zero_is_native_400(native_client):

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -486,6 +486,26 @@ async def test_count_tokens_requires_auth(native_client):
     assert r.json()["type"] == "error"
 
 
+async def test_blocking_model_not_found_renders_404_not_found(native_client):
+    """The engine reports model_not_found as HTTP 422; on this surface it
+    must render 404 not_found_error (Anthropic's contract), matching the
+    streaming error map — not collapse to 400 invalid_request_error."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "model does not exist", http_status=422, error_type="model_not_found",
+    ))
+    r = await client.post("/v1/messages", json={
+        "model": "gpt-4o-mini", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 404
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "not_found_error"
+
+
 async def test_count_tokens_unexpected_error_stays_in_anthropic_envelope(native_client):
     """Defense-in-depth: a schema-valid but malformed body that explodes
     inside the translator (non-dict image source → AttributeError) must

--- a/tests/integration/test_anthropic_messages.py
+++ b/tests/integration/test_anthropic_messages.py
@@ -551,6 +551,22 @@ async def test_no_providers_configured_is_non_retryable(native_client):
     assert r.json()["error"]["type"] == "permission_error"
 
 
+async def test_auto_without_providers_matches_the_pinned_403(native_client):
+    """The same permanent operator-side condition must classify the same
+    way whether the model is pinned or auto-resolved: auto used to render
+    a client-blaming 400 invalid_request_error while a pinned model gave
+    403 permission_error."""
+    client, fake, key = native_client
+    fake._deployments = []  # no provider key configured anywhere
+
+    r = await client.post("/v1/messages", json={
+        "model": "auto", "max_tokens": 16,
+        "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"x-api-key": key})
+    assert r.status_code == 403
+    assert r.json()["error"]["type"] == "permission_error"
+
+
 async def test_cache_is_not_shared_across_different_max_tokens(native_client):
     """Regression: the prompt-cache key omitted max_tokens, so a second
     request differing only in its budget was served the first response

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -152,6 +152,48 @@ async def test_query_param_key_only_works_under_v1beta(app_with_auth, db_session
     assert allowed.status_code == 404  # passed auth, no such route
 
 
+async def test_empty_bearer_falls_through_to_x_api_key(app_with_auth, db_session):
+    """An empty `Authorization: Bearer ` (e.g. blanked by a proxy) must not
+    short-circuit the documented fallback chain — a valid key in x-api-key
+    still authenticates."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.seed import seed_initial_state
+
+    seed = await seed_initial_state(db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get(
+            "/v1/protected",
+            headers={"Authorization": "Bearer ", "x-api-key": seed.api_key},
+        )
+    assert r.status_code == 200
+
+
+def test_extract_credential_empty_bearer_falls_through_each_location():
+    """Scope-level check of the precedence chain with an empty Bearer token
+    (immune to any client/transport header normalization)."""
+    from app.middleware.auth import _extract_credential
+
+    def scope(headers: dict[str, str], path="/v1/x", query=""):
+        return {
+            "headers": [(k.encode(), v.encode()) for k, v in headers.items()],
+            "path": path,
+            "query_string": query.encode(),
+        }
+
+    assert _extract_credential(
+        scope({"authorization": "Bearer ", "x-api-key": "sk-orca-a"})
+    ) == "sk-orca-a"
+    assert _extract_credential(
+        scope({"authorization": "Bearer ", "x-goog-api-key": "sk-orca-b"})
+    ) == "sk-orca-b"
+    assert _extract_credential(
+        scope({"authorization": "Bearer "}, path="/v1beta/models", query="key=sk-orca-c")
+    ) == "sk-orca-c"
+    assert _extract_credential(scope({"authorization": "Bearer "})) is None
+
+
 async def test_v1_messages_401_uses_anthropic_envelope(app_with_auth):
     """Auth failures on the Anthropic surface render the Anthropic error
     envelope, not the OpenAI one."""

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -90,3 +90,76 @@ async def test_protected_with_valid_key_returns_200(app_with_auth, db_session):
         r = await c.get("/v1/protected", headers={"Authorization": f"Bearer {seed.api_key}"})
     assert r.status_code == 200
     assert r.json() == {"workspace_id": "default"}
+
+
+# ── native-protocol credential locations + /v1beta guard (slice S1) ──
+
+
+async def test_v1beta_is_guarded_not_waved_through_as_static(app_with_auth):
+    """Regression: `_is_static` used to match only the "/v1/" prefix, so
+    "/v1beta/..." bypassed auth entirely. It must 401 (in the Google
+    envelope), not fall through to the app unauthenticated."""
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get("/v1beta/models")
+    assert r.status_code == 401
+    err = r.json()["error"]
+    assert err["code"] == 401
+    assert err["status"] == "UNAUTHENTICATED"
+
+
+async def test_x_api_key_header_authenticates(app_with_auth, db_session):
+    """Anthropic SDK / Claude Code style credential location."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.seed import seed_initial_state
+
+    seed = await seed_initial_state(db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get("/v1/protected", headers={"x-api-key": seed.api_key})
+    assert r.status_code == 200
+
+
+async def test_x_goog_api_key_header_authenticates(app_with_auth, db_session):
+    """google-genai SDK style credential location."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.seed import seed_initial_state
+
+    seed = await seed_initial_state(db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get("/v1/protected", headers={"x-goog-api-key": seed.api_key})
+    assert r.status_code == 200
+
+
+async def test_query_param_key_only_works_under_v1beta(app_with_auth, db_session):
+    """?key= must NOT authenticate /v1/* paths (credential-in-URL is scoped
+    to the Gemini surface); under /v1beta a valid ?key= passes the
+    middleware (the test app then 404s — anything but 401 proves it)."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.seed import seed_initial_state
+
+    seed = await seed_initial_state(db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        denied = await c.get(f"/v1/protected?key={seed.api_key}")
+        allowed = await c.get(f"/v1beta/anything?key={seed.api_key}")
+    assert denied.status_code == 401
+    assert allowed.status_code == 404  # passed auth, no such route
+
+
+async def test_v1_messages_401_uses_anthropic_envelope(app_with_auth):
+    """Auth failures on the Anthropic surface render the Anthropic error
+    envelope, not the OpenAI one."""
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.post("/v1/messages", json={})
+    assert r.status_code == 401
+    body = r.json()
+    assert body["type"] == "error"
+    assert body["error"]["type"] == "authentication_error"

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -255,3 +255,28 @@ async def test_v1_messages_401_uses_anthropic_envelope(app_with_auth):
     body = r.json()
     assert body["type"] == "error"
     assert body["error"]["type"] == "authentication_error"
+
+
+async def test_anthropic_client_gets_anthropic_envelope_on_any_v1_path(app_with_auth):
+    """GET /v1/models serves the Anthropic listing to callers sending
+    `anthropic-version`, so their auth failures on that path must speak the
+    Anthropic envelope too — `auth_error` is not a type the SDK knows."""
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get("/v1/protected", headers={"anthropic-version": "2023-06-01"})
+        assert r.status_code == 401
+        assert r.json() == {
+            "type": "error",
+            "error": {"type": "authentication_error", "message": r.json()["error"]["message"]},
+        }
+
+        r = await c.get("/v1/protected", headers={
+            "anthropic-version": "2023-06-01", "x-api-key": "sk-orca-bogus",
+        })
+        assert r.status_code == 401
+        assert r.json()["error"]["type"] == "authentication_error"
+
+        # no header → the OpenAI envelope, unchanged
+        r = await c.get("/v1/protected")
+        assert r.json()["error"]["type"] == "auth_error"

--- a/tests/integration/test_auth_middleware.py
+++ b/tests/integration/test_auth_middleware.py
@@ -152,6 +152,45 @@ async def test_query_param_key_only_works_under_v1beta(app_with_auth, db_session
     assert allowed.status_code == 404  # passed auth, no such route
 
 
+async def test_foreign_bearer_token_falls_through_to_x_api_key(app_with_auth, db_session):
+    """Regression: a reverse proxy / SSO gateway that injects its own
+    non-empty Bearer token must not mask the caller's valid key in
+    x-api-key — the rejected candidate falls through to the next one."""
+    from httpx import ASGITransport, AsyncClient
+
+    from app.seed import seed_initial_state
+
+    seed = await seed_initial_state(db_session)
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get(
+            "/v1/protected",
+            headers={
+                "Authorization": "Bearer gateway-injected-token",
+                "x-api-key": seed.api_key,
+            },
+        )
+    assert r.status_code == 200
+    assert r.json() == {"workspace_id": "default"}
+
+
+async def test_all_invalid_candidates_still_401(app_with_auth):
+    """Falling through the chain must not become fail-open: when every
+    candidate is rejected the request is still 401."""
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(transport=ASGITransport(app=app_with_auth), base_url="http://t") as c:
+        r = await c.get(
+            "/v1/protected",
+            headers={
+                "Authorization": "Bearer sk-orca-bogus-1",
+                "x-api-key": "sk-orca-bogus-2",
+                "x-goog-api-key": "sk-orca-bogus-3",
+            },
+        )
+    assert r.status_code == 401
+
+
 async def test_empty_bearer_falls_through_to_x_api_key(app_with_auth, db_session):
     """An empty `Authorization: Bearer ` (e.g. blanked by a proxy) must not
     short-circuit the documented fallback chain — a valid key in x-api-key
@@ -170,10 +209,12 @@ async def test_empty_bearer_falls_through_to_x_api_key(app_with_auth, db_session
     assert r.status_code == 200
 
 
-def test_extract_credential_empty_bearer_falls_through_each_location():
-    """Scope-level check of the precedence chain with an empty Bearer token
-    (immune to any client/transport header normalization)."""
-    from app.middleware.auth import _extract_credential
+def test_extract_credentials_collects_every_location_in_order():
+    """Scope-level check of the candidate chain (immune to any
+    client/transport header normalization). Every location contributes a
+    candidate — an empty or foreign Bearer must not hide the others — and
+    duplicates collapse so the same key isn't validated twice."""
+    from app.middleware.auth import _extract_credentials
 
     def scope(headers: dict[str, str], path="/v1/x", query=""):
         return {
@@ -182,16 +223,25 @@ def test_extract_credential_empty_bearer_falls_through_each_location():
             "query_string": query.encode(),
         }
 
-    assert _extract_credential(
+    assert _extract_credentials(
         scope({"authorization": "Bearer ", "x-api-key": "sk-orca-a"})
-    ) == "sk-orca-a"
-    assert _extract_credential(
+    ) == ["sk-orca-a"]
+    assert _extract_credentials(
         scope({"authorization": "Bearer ", "x-goog-api-key": "sk-orca-b"})
-    ) == "sk-orca-b"
-    assert _extract_credential(
+    ) == ["sk-orca-b"]
+    assert _extract_credentials(
         scope({"authorization": "Bearer "}, path="/v1beta/models", query="key=sk-orca-c")
-    ) == "sk-orca-c"
-    assert _extract_credential(scope({"authorization": "Bearer "})) is None
+    ) == ["sk-orca-c"]
+    assert _extract_credentials(scope({"authorization": "Bearer "})) == []
+
+    # A proxy's own Bearer keeps precedence but no longer excludes the rest.
+    assert _extract_credentials(
+        scope({"authorization": "Bearer proxy-token", "x-api-key": "sk-orca-a"})
+    ) == ["proxy-token", "sk-orca-a"]
+    # Same key in two locations (Claude Code sends both) → one candidate.
+    assert _extract_credentials(
+        scope({"authorization": "Bearer sk-orca-a", "x-api-key": "sk-orca-a"})
+    ) == ["sk-orca-a"]
 
 
 async def test_v1_messages_401_uses_anthropic_envelope(app_with_auth):

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -1,0 +1,371 @@
+"""/v1beta Gemini ingress — generateContent / streamGenerateContent (S7-S9).
+
+Real app + mocked LiteLLM router. Covers: x-goog-api-key and ?key= auth
+(and ?key= being scoped to /v1beta only), native error envelopes, blocking
++ streaming translation (alt=sse and JSON-array aggregation), schema-enum
+normalization reaching the engine, model listing, and auto routing.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+def _openai_response(**kwargs) -> dict:
+    return {
+        "id": "chatcmpl-1",
+        "model": kwargs.get("model", "gemini-1.5-flash"),
+        "object": "chat.completion",
+        "created": int(time.time()),
+        "choices": [{
+            "index": 0,
+            "message": kwargs.get(
+                "message", {"role": "assistant", "content": "Hello world"}
+            ),
+            "finish_reason": kwargs.get("finish_reason", "stop"),
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        "_orca_meta": {"provider": "google", "latency_ms": 9},
+    }
+
+
+def _stream_chunks() -> list[dict]:
+    now = int(time.time())
+    return [
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gemini-1.5-flash", "created": now,
+            "choices": [{"index": 0,
+                         "delta": {"role": "assistant", "content": "Hello"},
+                         "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gemini-1.5-flash", "created": now,
+            "choices": [{"index": 0, "delta": {"content": " world"},
+                         "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gemini-1.5-flash", "created": now,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+            "_orca_meta": {"provider": "google", "latency_ms": 9},
+        },
+    ]
+
+
+@pytest.fixture
+async def native_client(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    async def _stream_iter(chunks):
+        for c in chunks:
+            yield c
+
+    fake = AsyncMock()
+
+    async def _acompletion(**kwargs):
+        if kwargs.get("stream"):
+            return _stream_iter(_stream_chunks())
+        return _openai_response(model=kwargs.get("model", "gemini-1.5-flash"))
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    from app.main import create_app
+    app = create_app()
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+    ) as c:
+        yield c, fake, seed.api_key
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
+_PAYLOAD = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+
+
+def _sse_frames(text: str) -> list[dict]:
+    out = []
+    for line in text.splitlines():
+        if line.startswith("data: "):
+            out.append(json.loads(line[len("data: "):]))
+    return out
+
+
+# ── auth ──
+
+
+async def test_x_goog_api_key_authenticates(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1beta/models/gemini-1.5-flash:generateContent",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+
+
+async def test_query_param_key_authenticates_on_v1beta(native_client):
+    client, _, key = native_client
+    r = await client.post(
+        f"/v1beta/models/gemini-1.5-flash:generateContent?key={key}",
+        json=_PAYLOAD,
+    )
+    assert r.status_code == 200
+
+
+async def test_query_param_key_is_rejected_outside_v1beta(native_client):
+    """?key= is scoped to /v1beta — it must NOT authenticate OpenAI paths."""
+    client, _, key = native_client
+    r = await client.get(f"/v1/models?key={key}")
+    assert r.status_code == 401
+    assert r.json()["error"]["type"] == "auth_error"  # OpenAI envelope there
+
+
+async def test_missing_key_renders_google_envelope(native_client):
+    client, _, _ = native_client
+    r = await client.post("/v1beta/models/gemini-1.5-flash:generateContent",
+                          json=_PAYLOAD)
+    assert r.status_code == 401
+    err = r.json()["error"]
+    assert err["code"] == 401
+    assert err["status"] == "UNAUTHENTICATED"
+
+
+# ── blocking ──
+
+
+async def test_generate_content_shape_and_engine_body(native_client):
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json={
+            **_PAYLOAD,
+            "systemInstruction": {"parts": [{"text": "be brief"}]},
+            "generationConfig": {"temperature": 0.5, "maxOutputTokens": 99},
+        },
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    (cand,) = body["candidates"]
+    assert cand["content"] == {"role": "model", "parts": [{"text": "Hello world"}]}
+    assert cand["finishReason"] == "STOP"
+    assert body["usageMetadata"]["promptTokenCount"] == 4
+    assert body["usageMetadata"]["candidatesTokenCount"] == 2
+    assert body["modelVersion"] == "gemini-1.5-flash"
+
+    kwargs = fake.acompletion.call_args.kwargs
+    assert kwargs["model"] == "gemini-1.5-flash"
+    assert kwargs["messages"][0] == {"role": "system", "content": "be brief"}
+    assert kwargs["temperature"] == 0.5
+    assert kwargs["max_tokens"] == 99
+
+
+async def test_function_declaration_enums_normalized_before_engine(native_client):
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json={
+            **_PAYLOAD,
+            "tools": [{"functionDeclarations": [{
+                "name": "get_weather",
+                "parameters": {"type": "OBJECT",
+                               "properties": {"city": {"type": "STRING"}}},
+            }]}],
+        },
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    params = fake.acompletion.call_args.kwargs["tools"][0]["function"]["parameters"]
+    assert params["type"] == "object"
+    assert params["properties"]["city"]["type"] == "string"
+
+
+async def test_tool_call_response_becomes_function_call_part(native_client):
+    client, fake, key = native_client
+
+    async def _tool_response(**kwargs):
+        return _openai_response(
+            message={
+                "role": "assistant", "content": None,
+                "tool_calls": [{
+                    "id": "call_1", "type": "function",
+                    "function": {"name": "get_weather",
+                                 "arguments": '{"city": "SF"}'},
+                }],
+            },
+            finish_reason="tool_calls",
+        )
+
+    fake.acompletion = AsyncMock(side_effect=_tool_response)
+    r = await client.post("/v1beta/models/gemini-1.5-flash:generateContent",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    parts = r.json()["candidates"][0]["content"]["parts"]
+    assert parts == [{"functionCall": {"name": "get_weather",
+                                       "args": {"city": "SF"}}}]
+
+
+async def test_invalid_request_renders_google_envelope(native_client):
+    client, _, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json={**_PAYLOAD, "generationConfig": {"candidateCount": 3}},
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 400
+    err = r.json()["error"]
+    assert err["status"] == "INVALID_ARGUMENT"
+    assert "candidateCount" in err["message"]
+
+
+async def test_post_without_action_colon_is_native_404(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1beta/models/gemini-1.5-flash",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 404
+    assert r.json()["error"]["status"] == "NOT_FOUND"
+
+
+async def test_unknown_action_is_native_404(native_client):
+    client, _, key = native_client
+    r = await client.post("/v1beta/models/gemini-1.5-flash:embedContent",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 404
+    assert r.json()["error"]["status"] == "NOT_FOUND"
+
+
+# ── streaming ──
+
+
+async def test_stream_alt_sse_frames_and_request_log(native_client):
+    client, _, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("text/event-stream")
+    assert "[DONE]" not in r.text
+    assert "event:" not in r.text  # Gemini SSE is data-only frames
+
+    frames = _sse_frames(r.text)
+    texts = [
+        f["candidates"][0]["content"]["parts"][0]["text"]
+        for f in frames
+        if f["candidates"][0]["content"]["parts"]
+    ]
+    assert "".join(texts) == "Hello world"
+    final = frames[-1]
+    assert final["candidates"][0]["finishReason"] == "STOP"
+    assert final["usageMetadata"]["totalTokenCount"] == 6
+
+    from sqlalchemy import select
+
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].is_streaming is True
+    assert rows[0].output_tokens == 2
+    assert rows[0].status_code == 200
+
+
+async def test_stream_without_alt_sse_aggregates_json_array(native_client):
+    client, _, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:streamGenerateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/json")
+    chunks = r.json()
+    assert isinstance(chunks, list)
+    assert chunks[-1]["candidates"][0]["finishReason"] == "STOP"
+    assert "usageMetadata" in chunks[-1]
+
+
+# ── model listing + auto ──
+
+
+async def test_list_models_gemini_shape(native_client):
+    client, _, key = native_client
+    r = await client.get("/v1beta/models", headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    models = r.json()["models"]
+    assert len(models) > 0
+    assert all(m["name"].startswith("models/") for m in models)
+    assert "generateContent" in models[0]["supportedGenerationMethods"]
+
+
+async def test_get_single_model_and_native_404(native_client):
+    client, _, key = native_client
+    from packages.litellm_adapter.catalog import CATALOG
+
+    known = CATALOG[0].id
+    r = await client.get(f"/v1beta/models/{known}", headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    assert r.json()["name"] == f"models/{known}"
+
+    r = await client.get("/v1beta/models/not-a-model-xyz",
+                         headers={"x-goog-api-key": key})
+    assert r.status_code == 404
+    assert r.json()["error"]["status"] == "NOT_FOUND"
+
+
+async def test_model_auto_resolves_through_gemini_ingress(native_client):
+    client, fake, key = native_client
+
+    from packages.litellm_adapter.catalog import models_for_provider
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    fake._deployments = [
+        ProviderDeployment(
+            model_name=m.id, litellm_model=f"{m.litellm_prefix}{m.id}",
+            api_key="sk-test", provider="openai",
+        )
+        for m in models_for_provider("openai")
+    ]
+    r = await client.post("/v1beta/models/auto:generateContent",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    assert r.headers["x-orca-requested-model"] == "auto"
+    assert r.headers["x-orca-resolved-model"] != "auto"

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -379,6 +379,77 @@ async def test_get_single_model_and_native_404(native_client):
     assert r.json()["error"]["status"] == "NOT_FOUND"
 
 
+async def test_get_single_model_accepts_resource_name_form(native_client):
+    """The list endpoint presents "models/{id}" resource names; following
+    one (GET /v1beta/models/models/{id}) must resolve, not 404."""
+    client, _, key = native_client
+    from packages.litellm_adapter.catalog import CATALOG
+
+    known = CATALOG[0].id
+    r = await client.get(f"/v1beta/models/models/{known}",
+                         headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    assert r.json()["name"] == f"models/{known}"
+
+
+async def test_slashed_model_id_routes_to_generate(native_client):
+    """Provider-qualified ids with '/' (the zero-credit models, e.g.
+    "orcarouter/free") must reach the generate route — a single-segment
+    path param would fall through to the app-wide OpenAI-shaped 404."""
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/orcarouter/free:generateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    assert r.json()["candidates"][0]["content"]["parts"][0]["text"] == "Hello world"
+    assert fake.acompletion.call_args.kwargs["model"] == "orcarouter/free"
+
+
+async def test_blocking_model_not_found_renders_404_not_found(native_client):
+    """The engine reports model_not_found as HTTP 422; on this surface it
+    must render 404 NOT_FOUND (Google's contract), matching the streaming
+    error map — not collapse to 400 INVALID_ARGUMENT."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "model does not exist", http_status=422, error_type="model_not_found",
+    ))
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 404
+    err = r.json()["error"]
+    assert err["code"] == 404
+    assert err["status"] == "NOT_FOUND"
+
+
+async def test_stream_aggregate_unexpected_error_renders_google_envelope(
+    native_client, monkeypatch,
+):
+    """Defense-in-depth: a RAW exception out of the chunk source (not the
+    engine's in-band error frame) during aggregation must render the Google
+    envelope, not FastAPI's OpenAI-shaped 500."""
+    client, _, key = native_client
+    from app.routes import gemini_compat as gc
+
+    async def _boom(_frames):
+        raise RuntimeError("adapter exploded")
+        yield  # pragma: no cover — makes this an async generator
+
+    monkeypatch.setattr(gc.proto, "stream_chunks", _boom)
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:streamGenerateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 500
+    err = r.json()["error"]
+    assert err["code"] == 500
+    assert err["status"] == "INTERNAL"
+
+
 async def test_model_auto_resolves_through_gemini_ingress(native_client):
     client, fake, key = native_client
 

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -530,3 +530,64 @@ async def test_auto_capability_mismatch_matches_the_pinned_403(native_client):
     assert r.status_code == 403, r.text
     assert r.json()["error"]["status"] == "PERMISSION_DENIED"
     fake.acompletion.assert_not_awaited()
+
+
+async def test_count_tokens_endpoint(native_client):
+    """client.models.count_tokens → POST :countTokens, routinely called in
+    agentic loops; both the bare and the generateContentRequest-wrapped
+    body shapes are accepted."""
+    client, fake, key = native_client
+    r = await client.post("/v1beta/models/gemini-1.5-flash:countTokens",
+                          json={"contents": [{"role": "user", "parts": [{"text": "hello there"}]}]},
+                          headers={"x-goog-api-key": key})
+    assert r.status_code == 200, r.text
+    assert r.json()["totalTokens"] > 0
+
+    r = await client.post("/v1beta/models/gemini-1.5-flash:countTokens",
+                          json={"generateContentRequest": {
+                              "model": "models/gemini-1.5-flash",
+                              "contents": [{"role": "user", "parts": [{"text": "hello there"}]}],
+                          }},
+                          headers={"x-goog-api-key": key})
+    assert r.status_code == 200, r.text
+    assert r.json()["totalTokens"] > 0
+
+    r = await client.post("/v1beta/models/gemini-1.5-flash:countTokens",
+                          json={}, headers={"x-goog-api-key": key})
+    assert r.status_code == 400
+    assert r.json()["error"]["status"] == "INVALID_ARGUMENT"
+    fake.acompletion.assert_not_awaited()
+
+    r = await client.get("/v1beta/models", headers={"x-goog-api-key": key})
+    assert "countTokens" in r.json()["models"][0]["supportedGenerationMethods"]
+
+
+async def test_adapter_failure_mid_stream_renders_a_native_error(native_client, monkeypatch):
+    """A fault inside the streaming adapter must render the Google envelope
+    on both stream shapes: an in-stream error chunk for alt=sse, a non-200
+    error response for the aggregated JSON array."""
+    client, fake, key = native_client
+    from app.protocols import gemini as proto
+    from app.routes import gemini_compat
+
+    real = proto.stream_chunks
+
+    async def exploding(frames):
+        gen = real(frames)
+        async for chunk in gen:
+            yield chunk
+            raise RuntimeError("adapter bug")
+
+    monkeypatch.setattr(gemini_compat.proto, "stream_chunks", exploding)
+
+    r = await client.post("/v1beta/models/gemini-1.5-flash:streamGenerateContent?alt=sse",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+    frames = [json.loads(line[len("data: "):]) for line in r.text.splitlines()
+              if line.startswith("data: ")]
+    assert frames[-1] == {"error": {"code": 500, "message": "Internal server error", "status": "INTERNAL"}}
+
+    r = await client.post("/v1beta/models/gemini-1.5-flash:streamGenerateContent",
+                          json=_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 500
+    assert r.json()["error"]["status"] == "INTERNAL"

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -421,6 +421,25 @@ async def test_slashed_model_id_routes_to_generate(native_client):
     assert fake.acompletion.call_args.kwargs["model"] == "orcarouter/free"
 
 
+async def test_no_providers_configured_is_non_retryable(native_client):
+    """A fresh install with no provider key is permanent until the
+    operator adds one — it must not render as a retryable 503 UNAVAILABLE
+    the SDK keeps backing off against."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "No provider keys configured.", http_status=503,
+        error_type="no_providers_configured",
+    ))
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 403
+    assert r.json()["error"]["status"] == "PERMISSION_DENIED"
+
+
 async def test_blocking_model_not_found_renders_404_not_found(native_client):
     """The engine reports model_not_found as HTTP 422; on this surface it
     must render 404 NOT_FOUND (Google's contract), matching the streaming

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -392,6 +392,21 @@ async def test_get_single_model_accepts_resource_name_form(native_client):
     assert r.json()["name"] == f"models/{known}"
 
 
+async def test_generate_accepts_resource_name_form(native_client):
+    """Regression: the list endpoint presents "models/{id}", so a caller
+    following its own naming POSTs /v1beta/models/models/{id}:generate...
+    — the model half must be normalized to the bare id the engine knows,
+    matching GET /v1beta/models/{id}."""
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/models/gemini-1.5-flash:generateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    assert r.json()["candidates"][0]["content"]["parts"][0]["text"] == "Hello world"
+    assert fake.acompletion.call_args.kwargs["model"] == "gemini-1.5-flash"
+
+
 async def test_slashed_model_id_routes_to_generate(native_client):
     """Provider-qualified ids with '/' (the zero-credit models, e.g.
     "orcarouter/free") must reach the generate route — a single-segment

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -502,3 +502,31 @@ async def test_model_auto_resolves_through_gemini_ingress(native_client):
     assert r.status_code == 200
     assert r.headers["x-orca-requested-model"] == "auto"
     assert r.headers["x-orca-resolved-model"] != "auto"
+
+
+async def test_auto_capability_mismatch_matches_the_pinned_403(native_client):
+    """Same class as no_providers_configured (operator-side, permanent):
+    providers exist but none of their deployable models supports what the
+    request needs. Must render 403 PERMISSION_DENIED, not a client-blaming
+    400 INVALID_ARGUMENT."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.catalog import CATALOG
+    from packages.litellm_adapter.types import ProviderDeployment
+
+    text_only = next(m for m in CATALOG if not m.supports_vision)
+    fake._deployments = [ProviderDeployment(
+        model_name=text_only.id,
+        litellm_model=f"{text_only.litellm_prefix}{text_only.id}",
+        api_key="sk-test", provider=text_only.provider,
+    )]
+    r = await client.post(
+        "/v1beta/models/auto:generateContent",
+        json={"contents": [{"role": "user", "parts": [
+            {"text": "describe"},
+            {"inlineData": {"mimeType": "image/png", "data": "AAAA"}},
+        ]}]},
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 403, r.text
+    assert r.json()["error"]["status"] == "PERMISSION_DENIED"
+    fake.acompletion.assert_not_awaited()

--- a/tests/integration/test_gemini_generate.py
+++ b/tests/integration/test_gemini_generate.py
@@ -323,6 +323,34 @@ async def test_stream_without_alt_sse_aggregates_json_array(native_client):
     assert "usageMetadata" in chunks[-1]
 
 
+async def test_stream_aggregate_mid_stream_error_returns_non_200(native_client):
+    """Regression: without ?alt=sse the whole stream is aggregated before
+    anything is sent, so a mid-stream engine failure must render the native
+    non-200 Google envelope — not HTTP 200 with an error object buried in
+    the JSON array."""
+    client, fake, key = native_client
+
+    async def _broken_stream():
+        yield _stream_chunks()[0]
+        raise RuntimeError("provider exploded")
+
+    async def _acompletion(**kwargs):
+        return _broken_stream()
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:streamGenerateContent",
+        json=_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    # a plain RuntimeError translates to upstream_error → 503 UNAVAILABLE
+    assert r.status_code == 503
+    body = r.json()
+    assert isinstance(body, dict)
+    assert body["error"]["code"] == 503
+    assert body["error"]["status"] == "UNAVAILABLE"
+
+
 # ── model listing + auto ──
 
 

--- a/tests/integration/test_misc_routes.py
+++ b/tests/integration/test_misc_routes.py
@@ -60,6 +60,34 @@ async def test_models_returns_openai_format_listing(lite_client):
     assert "owned_by" in sample
 
 
+async def test_models_returns_anthropic_format_for_anthropic_clients(lite_client):
+    """The native /v1/messages surface lives on the same base URL, so
+    `client.models.list()` from the Anthropic SDK hits this path too. It
+    always sends `anthropic-version` (no OpenAI client does), which is
+    what selects the Anthropic envelope."""
+    client, _ = lite_client
+    r = await client.get("/v1/models", headers={"anthropic-version": "2023-06-01"})
+    assert r.status_code == 200
+    body = r.json()
+    assert "object" not in body  # not the OpenAI envelope
+    assert body["has_more"] is False
+    assert body["first_id"] == body["data"][0]["id"]
+    assert body["last_id"] == body["data"][-1]["id"]
+    sample = body["data"][0]
+    assert sample["type"] == "model"
+    assert sample["id"] and sample["display_name"]
+    # RFC 3339, per ModelInfo.created_at
+    assert sample["created_at"].endswith("Z")
+
+
+async def test_models_without_anthropic_header_stays_openai_shaped(lite_client):
+    """Regression guard: adding the Anthropic envelope must not change the
+    default shape every OpenAI client depends on."""
+    client, _ = lite_client
+    r = await client.get("/v1/models", headers={"user-agent": "openai-python/1.0"})
+    assert r.json()["object"] == "list"
+
+
 # ── /v1/keys ──────────────────────────────────────────────────────────
 
 async def test_list_keys_shows_seeded_key(lite_client):

--- a/tests/integration/test_native_log_status.py
+++ b/tests/integration/test_native_log_status.py
@@ -1,0 +1,200 @@
+# ruff: noqa: F811  (fixtures imported from sibling modules are re-bound as parameters)
+"""RequestLog status == delivered status on the native surfaces (PR #64
+round 12), including the streaming paths, plus the empty-turn rule.
+
+`execute_chat(log_status=...)` corrects the engine's generic status to the
+one the surface actually puts on the wire. Round 11 wired it into the
+blocking path only, and it used `native_status`, which leaves a generic
+upstream 5xx at 503 even though the Anthropic envelope delivers 500.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from tests.integration.test_anthropic_messages import (  # noqa: F401 (fixture)
+    _messages_payload,
+    native_client,
+)
+
+_GEMINI_PAYLOAD = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+
+
+async def _log_rows() -> list[tuple[int, str | None]]:
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    return [(r.status_code, r.error_type) for r in rows]
+
+
+def _erroring_stream(error_type: str):
+    """A stream that yields one chunk and then raises the LiteLLM exception
+    the engine translates into `error_type` — the engine runs the failure
+    through `_translate_error`, so a real provider exception is what
+    produces the in-band error frame under test."""
+    import litellm
+
+    exceptions = {
+        "model_not_found": lambda: litellm.NotFoundError(
+            message="boom", model="m", llm_provider="openai"),
+        "rate_limit_error": lambda: litellm.RateLimitError(
+            message="boom", model="m", llm_provider="openai"),
+    }
+
+    async def _stream():
+        yield {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": int(time.time()),
+            "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": None}],
+        }
+        raise exceptions[error_type]()
+
+    return _stream()
+
+
+# ── streaming: the status the client saw is the status we persist ──
+
+
+async def test_gemini_aggregate_stream_logs_the_delivered_status(native_client):
+    """Without alt=sse nothing has been sent when the stream fails, so the
+    route renders a genuine 404 — the row must not say 503."""
+    client, fake, key = native_client
+    fake.acompletion = AsyncMock(side_effect=lambda **kw: _erroring_stream("model_not_found"))
+
+    r = await client.post(
+        "/v1beta/models/nope-1:streamGenerateContent",
+        json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 404, r.text
+    assert r.json()["error"]["status"] == "NOT_FOUND"
+    assert await _log_rows() == [(404, "model_not_found")]
+
+
+async def test_gemini_sse_stream_logs_the_surface_status(native_client):
+    """alt=sse delivers the same failure class as an in-band error chunk;
+    the row records that class (429), not the engine's generic 503."""
+    client, fake, key = native_client
+    fake.acompletion = AsyncMock(side_effect=lambda **kw: _erroring_stream("rate_limit_error"))
+
+    r = await client.post(
+        "/v1beta/models/gpt-4o-mini:streamGenerateContent?alt=sse",
+        json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 200
+    frames = [json.loads(line[len("data: "):]) for line in r.text.splitlines()
+              if line.startswith("data: ")]
+    assert frames[-1]["error"]["code"] == 429
+    assert await _log_rows() == [(429, "rate_limit_error")]
+
+
+async def test_anthropic_stream_logs_the_surface_status(native_client):
+    client, fake, key = native_client
+    fake.acompletion = AsyncMock(side_effect=lambda **kw: _erroring_stream("model_not_found"))
+
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    assert "not_found_error" in r.text
+    assert await _log_rows() == [(404, "model_not_found")]
+
+
+async def test_openai_streaming_surface_still_logs_503(native_client):
+    """No log_status on that surface — its row keeps the engine status."""
+    client, fake, key = native_client
+    fake.acompletion = AsyncMock(side_effect=lambda **kw: _erroring_stream("model_not_found"))
+
+    r = await client.post("/v1/chat/completions", json={
+        "model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }, headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 200
+    assert await _log_rows() == [(503, "model_not_found")]
+
+
+# ── blocking: a generic upstream 5xx is delivered as 500, not 503 ──
+
+
+async def test_anthropic_blocking_generic_upstream_error_logs_500(native_client):
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "provider exploded", http_status=503, error_type="upstream_error",
+    ))
+    r = await client.post("/v1/messages", json=_messages_payload(),
+                          headers={"x-api-key": key})
+    assert r.status_code == 500
+    assert r.json()["error"]["type"] == "api_error"
+    assert await _log_rows() == [(500, "upstream_error")]
+
+
+async def test_gemini_blocking_generic_upstream_error_logs_503(native_client):
+    """Google's envelope carries 503 as-is (UNAVAILABLE), so the row does too."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "provider exploded", http_status=503, error_type="upstream_error",
+    ))
+    r = await client.post("/v1beta/models/gpt-4o-mini:generateContent",
+                          json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 503
+    assert r.json()["error"]["status"] == "UNAVAILABLE"
+    assert await _log_rows() == [(503, "upstream_error")]
+
+
+# ── empty user turns are rejected, never silently dropped ──
+
+
+@pytest.mark.parametrize("messages", [
+    [{"role": "user", "content": []}],
+    [{"role": "user", "content": "hi"},
+     {"role": "assistant", "content": "ok"},
+     {"role": "user", "content": []}],
+    [{"role": "user", "content": [{"type": "thinking", "thinking": "hmm"}]}],
+])
+async def test_anthropic_empty_user_turn_is_native_400(native_client, messages):
+    client, fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(messages=messages),
+                          headers={"x-api-key": key})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["type"] == "invalid_request_error"
+    fake.acompletion.assert_not_awaited()
+
+
+async def test_gemini_empty_user_turn_is_native_400(native_client):
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/gpt-4o-mini:generateContent",
+        json={"contents": [
+            {"role": "user", "parts": [{"text": "hi"}]},
+            {"role": "user", "parts": []},
+        ]},
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["status"] == "INVALID_ARGUMENT"
+    fake.acompletion.assert_not_awaited()
+
+
+async def test_well_formed_turns_still_reach_the_engine(native_client):
+    """The rejection must not catch a user turn that carries only tool
+    results (it translates to role:"tool" messages, not a user message)."""
+    client, fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(messages=[
+        {"role": "user", "content": "what is the weather"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "get_weather", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "sunny"}]},
+    ]), headers={"x-api-key": key})
+    assert r.status_code == 200, r.text
+    sent = fake.acompletion.call_args.kwargs["messages"]
+    assert [m["role"] for m in sent] == ["user", "assistant", "tool"]

--- a/tests/integration/test_native_surface_hardening.py
+++ b/tests/integration/test_native_surface_hardening.py
@@ -1,0 +1,218 @@
+"""Native-surface hardening (PR #64 round 11): allowlist on the count-token
+endpoints, native envelopes from the app-wide handlers, RequestLog status
+matching the delivered native status, and lenient credential-header
+decoding. Reuses the mocked-router app fixtures of the sibling test modules.
+"""
+
+# ruff: noqa: F811  (fixtures imported from sibling modules are re-bound as parameters)
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from sqlalchemy import select
+
+from tests.integration.test_anthropic_messages import (  # noqa: F401 (fixture)
+    _messages_payload,
+    native_client,
+)
+from tests.integration.test_auth_middleware import app_with_auth  # noqa: F401 (fixture)
+
+_GEMINI_PAYLOAD = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+
+
+async def _restrict_seeded_key(allowlist: list[str]) -> None:
+    from packages.db import session as session_mod
+    from packages.db.models.api_key import ApiKey
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(ApiKey))).scalars().all()
+        rows[0].model_allowlist = allowlist
+        await s.commit()
+
+
+async def _log_rows() -> list[tuple[int, str | None]]:
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    return [(r.status_code, r.error_type) for r in rows]
+
+
+# ── allowlist on count-token endpoints ──
+
+
+async def test_anthropic_count_tokens_enforces_the_model_allowlist(native_client):
+    """The count-token endpoints never reach the engine, so they must apply
+    the allowlist themselves — a restricted key must not probe denied models."""
+    client, _fake, key = native_client
+    await _restrict_seeded_key(["gpt-4o"])
+
+    def body(model):
+        return {"model": model, "messages": [{"role": "user", "content": "hi"}]}
+
+    r = await client.post("/v1/messages/count_tokens", json=body("claude-opus-4"),
+                          headers={"x-api-key": key})
+    assert r.status_code == 403, r.text
+    assert r.json()["error"]["type"] == "permission_error"
+    r = await client.post("/v1/messages/count_tokens", json=body("gpt-4o"),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    # auto is exempt, exactly as in the engine
+    r = await client.post("/v1/messages/count_tokens", json=body("auto"),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+
+
+async def test_gemini_count_tokens_enforces_the_model_allowlist(native_client):
+    client, _fake, key = native_client
+    await _restrict_seeded_key(["gpt-4o"])
+    r = await client.post("/v1beta/models/gemini-1.5-flash:countTokens",
+                          json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 403, r.text
+    assert r.json()["error"]["status"] == "PERMISSION_DENIED"
+    r = await client.post("/v1beta/models/gpt-4o:countTokens",
+                          json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 200
+
+
+# ── malformed tool blocks / turns ──
+
+
+async def test_tool_result_without_tool_use_id_is_native_400_not_retryable_503(native_client):
+    client, fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(messages=[
+        {"role": "user", "content": [{"type": "tool_result", "content": "x"}]},
+    ]), headers={"x-api-key": key})
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["type"] == "invalid_request_error"
+    assert "tool_use_id" in r.json()["error"]["message"]
+    fake.acompletion.assert_not_awaited()
+
+
+async def test_user_turn_carrying_function_call_parts_is_rejected(native_client):
+    """A functionCall in a user turn used to translate to [] — the turn
+    vanished from the upstream conversation with no error and no log."""
+    client, fake, key = native_client
+    r = await client.post(
+        "/v1beta/models/gemini-1.5-flash:generateContent",
+        json={"contents": [
+            {"role": "user", "parts": [{"functionCall": {"name": "f", "args": {}}}]},
+            {"role": "user", "parts": [{"text": "hi"}]},
+        ]},
+        headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["error"]["status"] == "INVALID_ARGUMENT"
+    fake.acompletion.assert_not_awaited()
+
+
+# ── app-wide handlers speak the native envelope ──
+
+
+async def test_routing_level_failures_speak_the_anthropic_envelope(native_client):
+    """404/405 never reach a route body; the app-wide handlers must still
+    render the caller's envelope on the native surface."""
+    client, _fake, key = native_client
+    r = await client.get("/v1/messages", headers={"x-api-key": key})
+    assert r.status_code == 405
+    assert r.json()["type"] == "error"
+    assert set(r.json()["error"]) == {"type", "message"}
+
+    r = await client.post("/v1/messages/unknown", json={}, headers={"x-api-key": key})
+    assert r.status_code == 404
+    assert r.json()["error"]["type"] == "not_found_error"
+
+    # an Anthropic SDK caller on any other path gets it too
+    r = await client.get("/v1/nope", headers={"x-api-key": key, "anthropic-version": "2023-06-01"})
+    assert r.status_code == 404
+    assert r.json()["error"]["type"] == "not_found_error"
+
+    # and the OpenAI surface is unchanged
+    r = await client.get("/v1/nope", headers={"Authorization": f"Bearer {key}"})
+    assert r.json()["error"]["type"] == "not_found"
+
+
+async def test_routing_level_failures_speak_the_google_envelope(native_client):
+    client, _fake, key = native_client
+    r = await client.post("/v1beta/models", json={}, headers={"x-goog-api-key": key})
+    assert r.status_code == 405
+    assert r.json()["error"]["code"] == 405
+    assert set(r.json()["error"]) == {"code", "message", "status"}
+
+    r = await client.get("/v1beta/anything", headers={"x-goog-api-key": key})
+    assert r.status_code == 404
+    assert r.json()["error"]["status"] == "NOT_FOUND"
+
+
+# ── RequestLog status == delivered status ──
+
+
+async def test_request_log_records_the_delivered_anthropic_status(native_client):
+    """The engine says 422 for model_not_found; this surface delivers 404.
+    The persisted row must show what went over the wire."""
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "model does not exist", http_status=422, error_type="model_not_found",
+    ))
+    r = await client.post("/v1/messages", json=_messages_payload(model="nope-1"),
+                          headers={"x-api-key": key})
+    assert r.status_code == 404
+    assert await _log_rows() == [(404, "model_not_found")]
+
+
+async def test_request_log_records_the_delivered_google_status(native_client):
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "no key", http_status=503, error_type="no_providers_configured",
+    ))
+    r = await client.post("/v1beta/models/gpt-4o-mini:generateContent",
+                          json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key})
+    assert r.status_code == 403
+    assert await _log_rows() == [(403, "no_providers_configured")]
+
+
+async def test_openai_surface_log_status_is_unchanged(native_client):
+    client, fake, key = native_client
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "model does not exist", http_status=422, error_type="model_not_found",
+    ))
+    r = await client.post("/v1/chat/completions", json={
+        "model": "nope-1", "messages": [{"role": "user", "content": "hi"}],
+    }, headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 422
+    assert await _log_rows() == [(422, "model_not_found")]
+
+
+# ── credential headers with non-UTF-8 bytes ──
+
+
+async def test_non_utf8_credential_header_is_a_clean_401(app_with_auth):
+    """A raw non-UTF-8 byte in x-api-key is an unauthenticated, remotely
+    reachable input; it must end as 401, not an unhandled UnicodeDecodeError."""
+    sent: list[dict] = []
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    async def send(message):
+        sent.append(message)
+
+    bad = bytes([0xFF, 0xFE])
+    scope = {
+        "type": "http", "asgi": {"version": "3.0"}, "http_version": "1.1",
+        "method": "GET", "scheme": "http", "path": "/v1/protected",
+        "raw_path": b"/v1/protected", "query_string": b"", "root_path": "",
+        "headers": [(b"host", b"t"), (b"x-api-key", b"sk-orca-" + bad),
+                    (b"anthropic-version", bad)],
+        "client": ("127.0.0.1", 1), "server": ("t", 80),
+    }
+    await app_with_auth(scope, receive, send)
+    start = next(m for m in sent if m["type"] == "http.response.start")
+    assert start["status"] == 401

--- a/tests/integration/test_pre_stream_failure_log.py
+++ b/tests/integration/test_pre_stream_failure_log.py
@@ -1,0 +1,96 @@
+# ruff: noqa: F811  (fixtures imported from sibling modules are re-bound as parameters)
+"""A streaming request that fails BEFORE its first chunk must still be
+logged (PR #64 round 4).
+
+The blocking path logs from its `finally` and a mid-stream failure logs
+from `_finalize`, but a failure at `client.acompletion(stream=True)` sat
+between the two: the client was rendered a real 404/429/403 and the
+RequestLog had no entry at all — the same upstream failure accounted for
+when stream=false and vanishing when stream=true.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from tests.integration.test_anthropic_messages import (  # noqa: F401 (fixture)
+    _messages_payload,
+    native_client,
+)
+
+_GEMINI_PAYLOAD = {"contents": [{"role": "user", "parts": [{"text": "hi"}]}]}
+
+
+async def _log_rows() -> list[tuple[int, str | None, bool]]:
+    from packages.db import session as session_mod
+    from packages.db.models.request_log import RequestLog
+
+    async with session_mod._session_factory() as s:
+        rows = (await s.execute(select(RequestLog))).scalars().all()
+    return [(r.status_code, r.error_type, r.is_streaming) for r in rows]
+
+
+def _failing_router(fake, *, error_type: str, http_status: int = 422) -> None:
+    from packages.litellm_adapter.types import UpstreamProviderError
+
+    fake.acompletion = AsyncMock(side_effect=UpstreamProviderError(
+        "boom", http_status=http_status, error_type=error_type,
+    ))
+
+
+@pytest.mark.parametrize("error_type,expected_status", [
+    ("model_not_found", 404),
+    ("rate_limit_error", 429),
+    ("no_providers_configured", 403),
+])
+async def test_anthropic_pre_stream_failure_is_logged(
+    native_client, error_type, expected_status,
+):
+    client, fake, key = native_client
+    _failing_router(fake, error_type=error_type)
+
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == expected_status, r.text
+    # the row records the status the client actually received
+    assert await _log_rows() == [(expected_status, error_type, True)]
+
+
+async def test_gemini_pre_stream_failure_is_logged(native_client):
+    client, fake, key = native_client
+    _failing_router(fake, error_type="model_not_found")
+
+    r = await client.post(
+        "/v1beta/models/nope-1:streamGenerateContent?alt=sse",
+        json=_GEMINI_PAYLOAD, headers={"x-goog-api-key": key},
+    )
+    assert r.status_code == 404, r.text
+    assert await _log_rows() == [(404, "model_not_found", True)]
+
+
+async def test_openai_pre_stream_failure_is_logged_with_the_engine_status(native_client):
+    """No log_status on that surface, so the row keeps the engine's own
+    status — but a row must exist there too."""
+    client, fake, key = native_client
+    _failing_router(fake, error_type="model_not_found")
+
+    r = await client.post("/v1/chat/completions", json={
+        "model": "nope-1", "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    }, headers={"Authorization": f"Bearer {key}"})
+    assert r.status_code == 422
+    assert await _log_rows() == [(422, "model_not_found", True)]
+
+
+async def test_successful_stream_still_logs_exactly_one_row(native_client):
+    """The new pre-stream row must not duplicate the end-of-stream one."""
+    client, _fake, key = native_client
+    r = await client.post("/v1/messages", json=_messages_payload(stream=True),
+                          headers={"x-api-key": key})
+    assert r.status_code == 200
+    rows = await _log_rows()
+    assert len(rows) == 1
+    assert rows[0][:2] == (200, None)

--- a/tests/integration/test_request_log_commit_retry.py
+++ b/tests/integration/test_request_log_commit_retry.py
@@ -1,0 +1,285 @@
+"""Streaming RequestLog durability — the commit-retry policy in `_finalize`.
+
+The streaming row is the only record of a stream's tokens and cost (the
+engine persists them nowhere else), so a commit that fails outright must
+be retried on a fresh session rather than dropped; a failure AFTER the
+commit returned (session close) must NOT be retried, or the row would be
+inserted twice. Real app + mocked router + a real SQLite DB whose session
+class is rigged to fail on demand.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from sqlalchemy.exc import OperationalError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from packages.db.models.request_log import RequestLog
+
+
+class _RiggedSession(AsyncSession):
+    """AsyncSession whose commit()/close() fail on demand — but only for a
+    session that is persisting a RequestLog, so the auth middleware and
+    seeding (which share the factory) are never disturbed."""
+
+    commit_failures_left = 0
+    close_failures_left = 0
+    lost_acks_left = 0  # COMMIT lands, but the call raises as if the connection dropped
+    commits_attempted = 0
+
+    def _adding_request_log(self) -> bool:
+        return any(isinstance(o, RequestLog) for o in self.sync_session.new)
+
+    async def commit(self):
+        if self._adding_request_log():
+            type(self).commits_attempted += 1
+            if type(self).commit_failures_left > 0:
+                type(self).commit_failures_left -= 1
+                raise OperationalError("COMMIT", {}, Exception("database is locked"))
+            if type(self).lost_acks_left > 0:
+                type(self).lost_acks_left -= 1
+                await super().commit()
+                raise OperationalError("COMMIT", {}, Exception("connection reset before ack"))
+            self._committed_log = True
+        return await super().commit()
+
+    async def close(self):
+        await super().close()
+        if getattr(self, "_committed_log", False) and type(self).close_failures_left > 0:
+            type(self).close_failures_left -= 1
+            raise RuntimeError("connection reset during session close")
+
+
+def _chunks() -> list[dict]:
+    now = int(time.time())
+    return [
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": now,
+            "choices": [{"index": 0, "delta": {"content": "Hello"},
+                         "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "object": "chat.completion.chunk",
+            "model": "gpt-4o-mini", "created": now,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+        },
+    ]
+
+
+async def _stream_iter():
+    for c in _chunks():
+        yield c
+
+
+@pytest.fixture
+async def rigged_client(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from app import config as cfg
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, class_=_RiggedSession, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    from app.seed import seed_initial_state
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+
+    from app import router_cache
+    router_cache.invalidate_router()
+
+    fake = AsyncMock()
+
+    async def _acompletion(**kwargs):
+        assert kwargs.get("stream")
+        return _stream_iter()
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    # No real backoff in tests — the policy, not the wall-clock, is under test.
+    from app.routes import chat as chat_mod
+    monkeypatch.setattr(chat_mod, "_LOG_COMMIT_BACKOFF_S", (0.0, 0.0))
+
+    _RiggedSession.commit_failures_left = 0
+    _RiggedSession.close_failures_left = 0
+    _RiggedSession.lost_acks_left = 0
+    _RiggedSession.commits_attempted = 0
+
+    from app.main import create_app
+    app = create_app()
+
+    from httpx import ASGITransport, AsyncClient
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://t",
+        headers={"Authorization": f"Bearer {seed.api_key}"},
+    ) as c:
+        yield c, factory
+
+    await engine.dispose()
+    session_mod._session_factory = None
+
+
+async def _rows(factory) -> list[RequestLog]:
+    from sqlalchemy import select
+
+    async with factory() as s:
+        return list((await s.execute(select(RequestLog))).scalars().all())
+
+
+async def _stream(client) -> str:
+    r = await client.post("/v1/chat/completions", json={
+        "model": "gpt-4o-mini",
+        "messages": [{"role": "user", "content": "hi"}],
+        "stream": True,
+    })
+    assert r.status_code == 200
+    return r.text
+
+
+async def test_transient_commit_failure_is_retried_and_the_row_lands_once(rigged_client):
+    """A commit that fails outright persisted nothing, so it is retried on a
+    fresh session — and the row lands exactly once, with the stream's real
+    token counts."""
+    client, factory = rigged_client
+    _RiggedSession.commit_failures_left = 1
+
+    body = await _stream(client)
+    assert "data: [DONE]" in body
+
+    rows = await _rows(factory)
+    assert len(rows) == 1
+    assert (rows[0].status_code, rows[0].input_tokens, rows[0].output_tokens) == (200, 4, 2)
+    assert rows[0].is_streaming is True
+    assert _RiggedSession.commits_attempted == 2
+
+
+async def test_persistent_commit_failure_gives_up_after_bounded_attempts(rigged_client):
+    """The retries are bounded (they hold the already-[DONE] stream open)
+    and the failure is reported; the client-visible stream is unaffected."""
+    from structlog.testing import capture_logs
+
+    client, factory = rigged_client
+    _RiggedSession.commit_failures_left = 99
+
+    with capture_logs() as logs:
+        body = await _stream(client)
+    assert "data: [DONE]" in body
+
+    assert await _rows(factory) == []
+    assert _RiggedSession.commits_attempted == 3  # len(_LOG_COMMIT_BACKOFF_S) + 1
+    failed = [e for e in logs if e["event"] == "request_log_commit_failed"]
+    assert [e["attempts"] for e in failed] == [3]
+
+
+async def test_failure_after_a_successful_commit_is_not_retried(rigged_client):
+    """The session-close failure arrives AFTER the commit returned: the row
+    is already persisted, so a retry would insert it twice."""
+    client, factory = rigged_client
+    _RiggedSession.close_failures_left = 1
+
+    body = await _stream(client)
+    assert "data: [DONE]" in body
+
+    assert len(await _rows(factory)) == 1
+    assert _RiggedSession.commits_attempted == 1
+
+
+async def test_lost_commit_ack_does_not_double_insert(rigged_client):
+    """PostgreSQL-style lost ack: the COMMIT landed but the call raised. The
+    retry must find the row by trace_id and insert nothing — one row, one
+    trace_id, not two rows with different ids."""
+    client, factory = rigged_client
+    _RiggedSession.lost_acks_left = 1
+
+    body = await _stream(client)
+    assert "data: [DONE]" in body
+
+    rows = await _rows(factory)
+    assert len(rows) == 1
+    assert rows[0].status_code == 200
+
+
+async def test_retry_backoff_does_not_inflate_latency(rigged_client, monkeypatch):
+    """latency_ms is measured once, before the first attempt: a failed
+    commit plus 0.3 s of backoff must not show up as model latency."""
+    from app.routes import chat as chat_mod
+    monkeypatch.setattr(chat_mod, "_LOG_COMMIT_BACKOFF_S", (0.3,))
+    client, factory = rigged_client
+    _RiggedSession.commit_failures_left = 1
+
+    await _stream(client)
+
+    rows = await _rows(factory)
+    assert len(rows) == 1
+    assert rows[0].latency_ms < 250, rows[0].latency_ms
+
+
+async def test_fallback_session_is_rolled_back_before_a_retry(monkeypatch):
+    """Without a session factory (unit-style callers) the request-scoped
+    session is reused: a failed commit leaves it in a failed transaction,
+    so the retry must roll it back first — and add a FRESH row object, not
+    re-add the one whose flush failed."""
+    from app import router_cache
+    from app.routes import chat as chat_mod
+    from app.schemas import ChatCompletionRequest
+    from packages.auth.types import KeyContext
+    from packages.db import session as session_mod
+
+    monkeypatch.setattr(session_mod, "_session_factory", None)
+    monkeypatch.setattr(chat_mod, "_LOG_COMMIT_BACKOFF_S", (0.0,))
+
+    fake = AsyncMock()
+
+    async def _acompletion(**kwargs):
+        return _stream_iter()
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    db = AsyncMock()
+    db.add = MagicMock()
+    db.commit = AsyncMock(side_effect=[RuntimeError("database is locked"), None])
+    db.scalar = AsyncMock(return_value=None)  # trace_id lookup on retry: not there
+
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}], stream=True,
+    )
+    kc = KeyContext(key_id="k", workspace_id="default", name="t", key_type="standard")
+    response = await chat_mod.execute_chat(body, kc, db)
+    frames = [f async for f in response.body_iterator]
+    assert frames[-1] == "data: [DONE]\n\n"
+
+    assert db.commit.await_count == 2
+    db.rollback.assert_awaited_once()
+    assert db.add.call_count == 2
+    first, second = (c.args[0] for c in db.add.call_args_list)
+    assert first is not second
+    assert (first.id, first.trace_id) == (second.id, second.trace_id)
+    assert (second.input_tokens, second.output_tokens) == (4, 2)
+    db.scalar.assert_awaited_once()

--- a/tests/integration/test_stream_error_disconnect_window.py
+++ b/tests/integration/test_stream_error_disconnect_window.py
@@ -1,0 +1,130 @@
+"""Disconnect in the window between the engine's mid-stream error frame and
+the native adapter's error event/chunk.
+
+The adapter is suspended at that yield while the event is in flight; if the
+client goes away right then, the adapter is closed at the yield. Whatever
+path that takes into the engine, the RequestLog row must record the real
+upstream failure (503 + translated error type) — never a 499
+client_disconnect, which would erase the true cause from analytics. Real
+engine, real SQLite writeback, mocked upstream stream.
+
+This is an end-to-end INVARIANT check, not a regression test: the engine's
+error-path yields live inside its `except Exception` handler, so even a
+forwarded close there reaches its `finally` with the 503 state intact. What
+the pre-yield drain changes — the engine completing naturally instead of
+being closed — is pinned down by the unit tests
+`test_close_at_the_error_event_still_drains_the_engine_source` (Anthropic)
+and `test_close_at_the_error_chunk_still_drains_the_engine_source` (Gemini),
+which fail on the old ordering.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from sqlalchemy import select
+
+from packages.db.models.request_log import RequestLog
+
+
+class _UpstreamExploded(Exception):
+    pass
+
+
+async def _failing_stream():
+    yield {
+        "id": "chatcmpl-1", "model": "gpt-4o-mini",
+        "choices": [{"index": 0, "delta": {"content": "Hi"}, "finish_reason": None}],
+    }
+    raise _UpstreamExploded("upstream exploded mid-stream")
+
+
+@pytest.fixture
+async def engine_with_failing_upstream(tmp_sqlite_url, monkeypatch):
+    """(execute_chat args, session factory) with a router whose stream
+    raises after one chunk, and a real DB the engine's writeback lands in."""
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    monkeypatch.setattr(session_mod, "_session_factory", factory)
+
+    from app import router_cache
+
+    fake = AsyncMock()
+
+    async def _acompletion(**kwargs):
+        assert kwargs.get("stream")
+        return _failing_stream()
+
+    fake.acompletion = AsyncMock(side_effect=_acompletion)
+
+    async def _fake_get_router(_session):
+        return fake
+
+    monkeypatch.setattr(router_cache, "get_router", _fake_get_router)
+
+    from app.schemas import ChatCompletionRequest
+    from packages.auth.types import KeyContext
+
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}], stream=True,
+    )
+    kc = KeyContext(key_id="k", workspace_id="default", name="t", key_type="standard")
+    yield (body, kc), factory
+
+    await engine.dispose()
+
+
+async def _rows(factory) -> list[RequestLog]:
+    async with factory() as s:
+        return list((await s.execute(select(RequestLog))).scalars().all())
+
+
+async def test_anthropic_close_at_error_event_logs_the_upstream_error(engine_with_failing_upstream):
+    (body, kc), factory = engine_with_failing_upstream
+    from app.protocols.anthropic import stream_events
+    from app.protocols.sse import OpenAIFrameStream
+    from app.routes.chat import execute_chat
+
+    inner = await execute_chat(body, kc, AsyncMock())
+    events = stream_events(OpenAIFrameStream(inner.body_iterator))
+    names = []
+    async for ev in events:
+        names.append(ev.splitlines()[0][len("event: "):])
+        if names[-1] == "error":
+            break
+    await events.aclose()  # client gone while the error event was in flight
+
+    assert names[:2] == ["message_start", "content_block_start"]
+    rows = await _rows(factory)
+    assert len(rows) == 1
+    assert (rows[0].status_code, rows[0].error_type) == (503, "upstream_error")
+    assert rows[0].is_streaming is True
+
+
+async def test_gemini_close_at_error_chunk_logs_the_upstream_error(engine_with_failing_upstream):
+    (body, kc), factory = engine_with_failing_upstream
+    from app.protocols.gemini import stream_chunks
+    from app.protocols.sse import OpenAIFrameStream
+    from app.routes.chat import execute_chat
+
+    inner = await execute_chat(body, kc, AsyncMock())
+    chunks = stream_chunks(OpenAIFrameStream(inner.body_iterator))
+    async for chunk in chunks:
+        if "error" in chunk:
+            assert chunk["error"]["status"] == "UNAVAILABLE"
+            break
+    await chunks.aclose()  # client gone while the error chunk was in flight
+
+    rows = await _rows(factory)
+    assert len(rows) == 1
+    assert (rows[0].status_code, rows[0].error_type) == (503, "upstream_error")

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 
+import anyio
 import pytest
 
 from app.protocols.anthropic import stream_events
@@ -526,6 +527,55 @@ async def test_text_between_argument_fragments_of_one_call_does_not_split_it():
     partial = [d["delta"]["partial_json"] for n, d in events
                if n == "content_block_delta" and d["delta"]["type"] == "input_json_delta"]
     assert partial == ['{"city": "SF"}']
+
+
+async def test_first_fragment_with_empty_arguments_is_not_flushed_by_following_text():
+    """The standard first fragment carries only id + name with
+    arguments "" — it must not count as a complete call when text follows,
+    or the client gets an empty tool_use plus a nameless second block."""
+    frames = [
+        _tool_fragment(0, "", call_id="call_1", name="get_weather"),
+        _text_chunk("thinking..."),
+        _tool_fragment(0, '{"city": "SF"}'),
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    starts = [(d["content_block"]["type"], d["content_block"].get("name"))
+              for n, d in events if n == "content_block_start"]
+    assert starts == [("text", None), ("tool_use", "get_weather")]
+    partial = [d["delta"]["partial_json"] for n, d in events
+               if n == "content_block_delta" and d["delta"]["type"] == "input_json_delta"]
+    assert partial == ['{"city": "SF"}']
+
+
+async def test_client_cancel_during_the_final_drain_still_lets_the_engine_finish():
+    """This generator is the response body: a client disconnect lands as
+    task cancellation. The forwarding in `finally` must be shielded so the
+    engine is still driven to completion (its RequestLog writeback runs)
+    instead of being abandoned to GC finalization."""
+    drain_started = asyncio.Event()
+    order: list[str] = []
+
+    async def engine_sse():
+        yield 'data: {"id":"c1","model":"m","choices":[{"index":0,' \
+              '"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+        drain_started.set()
+        await asyncio.sleep(0.05)  # the engine's writeback, in progress
+        order.append("engine_writeback")
+
+    async def consume():
+        async for _ in stream_events(OpenAIFrameStream(engine_sse())):
+            pass
+
+    # Starlette cancels the response task through an anyio task group —
+    # the cancellation shape the shield is there to absorb.
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(consume)
+        await drain_started.wait()
+        tg.cancel_scope.cancel()
+    assert order == ["engine_writeback"]
 
 
 async def test_delta_carrying_both_text_and_a_tool_fragment_emits_text_first():

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -1,8 +1,8 @@
 """Anthropic streaming transformer — pure-transformer unit tests (slice S4).
 
-Feeds synthetic OpenAI chunk dicts (what `iter_openai_frames` yields after
+Feeds synthetic OpenAI chunk dicts (what `OpenAIFrameStream` yields after
 parsing the engine's SSE) and asserts the exact Anthropic event sequence.
-Also covers `iter_openai_frames` itself.
+Also covers `OpenAIFrameStream` itself.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ import json
 import pytest
 
 from app.protocols.anthropic import stream_events
-from app.protocols.sse import iter_openai_frames
+from app.protocols.sse import OpenAIFrameStream
 
 
 async def _agen(items):
@@ -89,6 +89,20 @@ async def test_text_stream_event_sequence():
     assert msg_delta["delta"]["stop_reason"] == "end_turn"
     assert msg_delta["usage"]["output_tokens"] == 2
     assert msg_delta["usage"]["input_tokens"] == 4
+
+
+async def test_message_start_reports_the_supplied_input_token_estimate():
+    """The protocol puts the input count in message_start (SDKs read it
+    there), but the engine only knows the true value at end-of-stream, so
+    the route passes its own estimate in and the exact count follows in
+    message_delta."""
+    raw = [f async for f in stream_events(
+        _agen([_text_chunk("hi"), _FINISH_CHUNK, _USAGE_CHUNK]), input_tokens=37,
+    )]
+    events = _parse_events(raw)
+    assert events[0][1]["message"]["usage"] == {"input_tokens": 37, "output_tokens": 0}
+    # exact count from the engine's usage frame still lands in message_delta
+    assert events[-2][1]["usage"]["input_tokens"] == 4
 
 
 async def test_usage_frame_missing_still_terminates_with_zero_usage():
@@ -291,11 +305,33 @@ async def test_error_frame_drains_engine_source_instead_of_closing_it():
             state["exit"] = "generator_exit"
             raise
 
-    raw = [f async for f in stream_events(iter_openai_frames(engine_sse()))]
+    raw = [f async for f in stream_events(OpenAIFrameStream(engine_sse()))]
     events = _parse_events(raw)
     assert events[-1][0] == "error"
     assert events[-1][1]["error"]["type"] == "rate_limit_error"
     assert state["exit"] == "completed"
+
+
+async def test_terminal_events_reach_the_client_before_the_engine_writeback():
+    """Ordering regression: resuming the engine past [DONE] runs its
+    `finally` — the RequestLog DB commit. That write must not sit between
+    the last content the client sees and message_stop, or a slow/wedged DB
+    leaves the SDK waiting for a stream that has no terminal event."""
+    order: list[str] = []
+
+    async def engine_sse():
+        yield 'data: {"id":"c1","model":"m","choices":[{"index":0,' \
+              '"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+        # Whoever resumes the engine past [DONE] awaits this.
+        order.append("engine_writeback")
+
+    async for raw in stream_events(OpenAIFrameStream(engine_sse())):
+        order.append(raw.splitlines()[0][len("event: "):])
+
+    assert "engine_writeback" in order, "the engine must still be drained"
+    assert order.index("message_stop") < order.index("engine_writeback")
+    assert order[-1] == "engine_writeback"
 
 
 async def test_empty_stream_still_emits_valid_skeleton():
@@ -304,30 +340,54 @@ async def test_empty_stream_still_emits_valid_skeleton():
     assert names == ["message_start", "message_delta", "message_stop"]
 
 
-# ── iter_openai_frames ──
+# ── OpenAIFrameStream ──
 
 
-async def test_iter_openai_frames_parses_and_stops_at_done():
+async def test_frame_stream_parses_stops_at_done_then_drains_on_finish():
+    """Iteration stops at [DONE] leaving the engine suspended; finish()
+    is what resumes it to natural completion."""
+    resumed = {"value": False}
+
     async def producer():
         yield 'data: {"a": 1}\n\n'
         yield 'data: {"b": 2}\n\n'
         yield "data: [DONE]\n\n"
-        yield 'data: {"never": true}\n\n'
+        resumed["value"] = True
 
-    frames = [f async for f in iter_openai_frames(producer())]
+    stream = OpenAIFrameStream(producer())
+    frames = [f async for f in stream]
     assert frames == [{"a": 1}, {"b": 2}]
+    assert resumed["value"] is False, "the engine must not be resumed by iteration"
+    await stream.finish()
+    assert resumed["value"] is True
 
 
-async def test_iter_openai_frames_handles_split_and_bytes_frames():
+async def test_frame_stream_handles_split_and_bytes_frames():
     async def producer():
         yield b'data: {"a"'
         yield b': 1}\n\ndata: [DONE]\n\n'
 
-    frames = [f async for f in iter_openai_frames(producer())]
-    assert frames == [{"a": 1}]
+    stream = OpenAIFrameStream(producer())
+    assert [f async for f in stream] == [{"a": 1}]
 
 
-async def test_iter_openai_frames_forwards_close_to_source():
+async def test_frame_stream_finish_is_idempotent():
+    drains = {"count": 0}
+
+    async def producer():
+        yield 'data: {"a": 1}\n\ndata: [DONE]\n\n'
+        drains["count"] += 1
+
+    stream = OpenAIFrameStream(producer())
+    assert [f async for f in stream] == [{"a": 1}]
+    await stream.finish()
+    await stream.finish()
+    assert drains["count"] == 1
+
+
+async def test_frame_stream_finish_forwards_close_when_done_not_reached():
+    """No [DONE] seen (client disconnected mid-stream) → forward the close
+    so the engine's own disconnect handling runs."""
     closed = {"value": False}
 
     class _Source:
@@ -340,9 +400,9 @@ async def test_iter_openai_frames_forwards_close_to_source():
         async def aclose(self):
             closed["value"] = True
 
-    gen = iter_openai_frames(_Source())
-    assert (await gen.__anext__()) == {"a": 1}
-    await gen.aclose()
+    stream = OpenAIFrameStream(_Source())
+    assert (await stream.__aiter__().__anext__()) == {"a": 1}
+    await stream.finish()
     assert closed["value"] is True
 
 
@@ -371,9 +431,9 @@ async def test_close_during_post_done_drain_still_forwards_close_to_source():
         async def aclose(self):
             closed["value"] = True
 
-    gen = iter_openai_frames(_Source())
-    assert (await gen.__anext__()) == {"a": 1}
-    task = asyncio.create_task(gen.__anext__())
+    stream = OpenAIFrameStream(_Source())
+    assert [f async for f in stream] == [{"a": 1}]
+    task = asyncio.create_task(stream.finish())
     await drain_entered.wait()
     task.cancel()
     with pytest.raises(asyncio.CancelledError):

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -439,3 +439,135 @@ async def test_close_during_post_done_drain_still_forwards_close_to_source():
     with pytest.raises(asyncio.CancelledError):
         await task
     assert closed["value"] is True
+
+
+# ── block ordering: text ↔ tool calls ──
+
+
+def _block_sequence(events) -> list[tuple[str, int, str | None]]:
+    """(event, index, block type for starts) for every content_block_* event."""
+    out = []
+    for name, data in events:
+        if name.startswith("content_block_"):
+            btype = data["content_block"]["type"] if name == "content_block_start" else None
+            out.append((name, data["index"], btype))
+    return out
+
+
+async def test_text_after_a_tool_call_is_delivered_after_the_tool_use_block():
+    """Regression: tool fragments were held to end-of-stream while text
+    streamed through immediately, so text the model wrote AFTER a tool
+    call reached the client BEFORE it. SDKs process blocks strictly in
+    order, so an agent misread which text preceded the call."""
+    frames = [
+        _tool_fragment(0, '{"city": "SF"}', call_id="call_1", name="get_weather"),
+        _text_chunk("Checking the weather."),
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    assert _block_sequence(events) == [
+        ("content_block_start", 0, "tool_use"),
+        ("content_block_delta", 0, None),
+        ("content_block_stop", 0, None),
+        ("content_block_start", 1, "text"),
+        ("content_block_delta", 1, None),
+        ("content_block_stop", 1, None),
+    ]
+    tool_start = events[1][1]["content_block"]
+    assert (tool_start["id"], tool_start["name"]) == ("call_1", "get_weather")
+    assert events[-2][1]["delta"]["stop_reason"] == "end_turn"
+
+
+async def test_tool_call_between_two_text_runs_keeps_the_model_order():
+    """text → tool call → text must come out as three blocks in that
+    order, never as one merged text block followed by the tool block —
+    and the split call's fragments must still reassemble into one block."""
+    frames = [
+        _text_chunk("A"),
+        _tool_fragment(0, '{"ci', call_id="call_1", name="f"),
+        _tool_fragment(0, 'ty": "SF"}'),
+        _text_chunk("B"),
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    starts = [(d["index"], d["content_block"]["type"])
+              for n, d in events if n == "content_block_start"]
+    assert starts == [(0, "text"), (1, "tool_use"), (2, "text")]
+    texts = {d["index"]: d["delta"]["text"] for n, d in events
+             if n == "content_block_delta" and d["delta"]["type"] == "text_delta"}
+    assert texts == {0: "A", 2: "B"}
+    partial = [d["delta"]["partial_json"] for n, d in events
+               if n == "content_block_delta" and d["delta"]["type"] == "input_json_delta"]
+    assert partial == ['{"city": "SF"}']
+    # each block is start → delta → stop before the next one opens
+    assert [e for e, _, _ in _block_sequence(events)] == [
+        "content_block_start", "content_block_delta", "content_block_stop",
+    ] * 3
+
+
+async def test_text_between_argument_fragments_of_one_call_does_not_split_it():
+    """A text delta landing BETWEEN two argument fragments of the SAME call
+    must not flush the half-built call: it stays buffered (to
+    end-of-stream) and comes out as one block with whole JSON — never as a
+    tool_use with unparseable partial_json plus a nameless second block."""
+    frames = [
+        _tool_fragment(0, '{"ci', call_id="call_1", name="get_weather"),
+        _text_chunk("thinking..."),
+        _tool_fragment(0, 'ty": "SF"}'),
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    starts = [(d["content_block"]["type"], d["content_block"].get("name"))
+              for n, d in events if n == "content_block_start"]
+    assert starts == [("text", None), ("tool_use", "get_weather")]
+    partial = [d["delta"]["partial_json"] for n, d in events
+               if n == "content_block_delta" and d["delta"]["type"] == "input_json_delta"]
+    assert partial == ['{"city": "SF"}']
+
+
+async def test_delta_carrying_both_text_and_a_tool_fragment_emits_text_first():
+    """OpenAI semantics put a message's content before its tool_calls, so a
+    single delta with both closes the text block, then buffers the call."""
+    frame = {
+        "id": "chatcmpl-1", "model": "gpt-4o-mini",
+        "choices": [{"index": 0, "delta": {
+            "content": "Let me check.",
+            "tool_calls": [{"index": 0, "id": "call_1",
+                            "function": {"name": "f", "arguments": "{}"}}],
+        }, "finish_reason": None}],
+    }
+    events = await _collect([frame, _FINISH_CHUNK, _USAGE_CHUNK])
+    starts = [(d["index"], d["content_block"]["type"])
+              for n, d in events if n == "content_block_start"]
+    assert starts == [(0, "text"), (1, "tool_use")]
+    assert [e for e, _, _ in _block_sequence(events)] == [
+        "content_block_start", "content_block_delta", "content_block_stop",
+        "content_block_start", "content_block_delta", "content_block_stop",
+    ]
+
+
+async def test_close_at_the_error_event_still_drains_the_engine_source():
+    """The client may disconnect while the error event is in flight, i.e.
+    with the transformer suspended at that yield. Its finally must still
+    DRAIN the engine (natural completion → 503 + real error type logged),
+    not forward a close into it — so the [DONE] has to be consumed before
+    the event is yielded, not after."""
+    state = {"exit": None}
+
+    async def engine_sse():
+        try:
+            yield 'data: {"error": {"message": "boom", "type": "rate_limit_error"}}\n\n'
+            yield "data: [DONE]\n\n"
+            state["exit"] = "completed"
+        except GeneratorExit:
+            state["exit"] = "generator_exit"
+            raise
+
+    gen = stream_events(OpenAIFrameStream(engine_sse()))
+    first = await gen.__anext__()
+    assert first.startswith("event: error\n")
+    await gen.aclose()  # client gone while the error event was in flight
+    assert state["exit"] == "completed"

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -254,6 +254,9 @@ async def test_engine_error_frame_becomes_error_event():
     ("overloaded_error", "overloaded_error"),
     ("context_length_exceeded", "invalid_request_error"),
     ("model_not_found", "not_found_error"),
+    # OUR provider credential — permanent, must not present as retryable
+    # (SDKs back off and retry api_error/500, but never a 4xx type).
+    ("upstream_auth_error", "permission_error"),
     ("upstream_timeout", "api_error"),
     ("something_unknown", "api_error"),
     (None, "api_error"),

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -272,7 +272,9 @@ async def test_engine_error_frame_becomes_error_event():
     # OUR provider credential — permanent, must not present as retryable
     # (SDKs back off and retry api_error/500, but never a 4xx type).
     ("upstream_auth_error", "permission_error"),
-    ("upstream_timeout", "api_error"),
+    # transient by definition — the taxonomy's "busy" status, not a generic
+    # api_error the caller cannot tell apart from a fault in this server
+    ("upstream_timeout", "overloaded_error"),
     ("something_unknown", "api_error"),
     (None, "api_error"),
 ])

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -1,0 +1,236 @@
+"""Anthropic streaming transformer — pure-transformer unit tests (slice S4).
+
+Feeds synthetic OpenAI chunk dicts (what `iter_openai_frames` yields after
+parsing the engine's SSE) and asserts the exact Anthropic event sequence.
+Also covers `iter_openai_frames` itself.
+"""
+
+from __future__ import annotations
+
+import json
+
+from app.protocols.anthropic import stream_events
+from app.protocols.sse import iter_openai_frames
+
+
+async def _agen(items):
+    for item in items:
+        yield item
+
+
+def _parse_events(raw_frames: list[str]) -> list[tuple[str, dict]]:
+    """Each transformer output frame is `event: <name>\\ndata: {json}\\n\\n`."""
+    out = []
+    for frame in raw_frames:
+        assert frame.endswith("\n\n")
+        lines = frame.strip().splitlines()
+        assert lines[0].startswith("event: ")
+        assert lines[1].startswith("data: ")
+        out.append((lines[0][len("event: "):], json.loads(lines[1][len("data: "):])))
+    return out
+
+
+async def _collect(frames_dicts: list[dict]) -> list[tuple[str, dict]]:
+    raw = [f async for f in stream_events(_agen(frames_dicts))]
+    return _parse_events(raw)
+
+
+def _text_chunk(text: str, model="gpt-4o-mini") -> dict:
+    return {
+        "id": "chatcmpl-1", "object": "chat.completion.chunk", "model": model,
+        "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+    }
+
+
+_FINISH_CHUNK = {
+    "id": "chatcmpl-1", "object": "chat.completion.chunk", "model": "gpt-4o-mini",
+    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+}
+
+_USAGE_CHUNK = {
+    "id": "chatcmpl-1", "object": "chat.completion.chunk", "model": "gpt-4o-mini",
+    "choices": [],
+    "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+}
+
+
+# ── stream_events ──
+
+
+async def test_text_stream_event_sequence():
+    events = await _collect([
+        _text_chunk("Hello"), _text_chunk(" world"), _FINISH_CHUNK, _USAGE_CHUNK,
+    ])
+    names = [n for n, _ in events]
+    assert names == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    # every event's data carries its own type field matching the event name
+    for name, data in events:
+        assert data["type"] == name
+
+    start = events[0][1]["message"]
+    assert start["id"].startswith("msg_")
+    assert start["model"] == "gpt-4o-mini"
+
+    deltas = [d["delta"]["text"] for n, d in events if n == "content_block_delta"]
+    assert "".join(deltas) == "Hello world"
+
+    msg_delta = events[-2][1]
+    assert msg_delta["delta"]["stop_reason"] == "end_turn"
+    assert msg_delta["usage"]["output_tokens"] == 2
+    assert msg_delta["usage"]["input_tokens"] == 4
+
+
+async def test_usage_frame_missing_still_terminates_with_zero_usage():
+    events = await _collect([_text_chunk("hi"), _FINISH_CHUNK])
+    names = [n for n, _ in events]
+    assert names[-2:] == ["message_delta", "message_stop"]
+    assert events[-2][1]["usage"]["output_tokens"] == 0
+
+
+async def test_length_finish_maps_to_max_tokens():
+    finish = {
+        "id": "chatcmpl-1", "model": "gpt-4o-mini",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "length"}],
+    }
+    events = await _collect([_text_chunk("hi"), finish])
+    assert events[-2][1]["delta"]["stop_reason"] == "max_tokens"
+
+
+async def test_tool_call_stream_emits_tool_use_block_and_json_deltas():
+    frames = [
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "id": "call_1", "type": "function",
+                "function": {"name": "get_weather", "arguments": ""},
+            }]}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "function": {"arguments": '{"city": '},
+            }]}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "function": {"arguments": '"SF"}'},
+            }]}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+        },
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    names = [n for n, _ in events]
+    assert names == [
+        "message_start",
+        "content_block_start",
+        "content_block_delta",
+        "content_block_delta",
+        "content_block_stop",
+        "message_delta",
+        "message_stop",
+    ]
+    start = [d for n, d in events if n == "content_block_start"][0]
+    assert start["content_block"]["type"] == "tool_use"
+    assert start["content_block"]["id"] == "call_1"
+    assert start["content_block"]["name"] == "get_weather"
+
+    partials = [d["delta"]["partial_json"] for n, d in events if n == "content_block_delta"]
+    assert json.loads("".join(partials)) == {"city": "SF"}
+    assert events[-2][1]["delta"]["stop_reason"] == "tool_use"
+
+
+async def test_text_then_tool_call_uses_two_block_indexes():
+    frames = [
+        _text_chunk("thinking..."),
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "id": "call_1",
+                "function": {"name": "f", "arguments": "{}"},
+            }]}, "finish_reason": None}],
+        },
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    starts = [(d["index"], d["content_block"]["type"])
+              for n, d in events if n == "content_block_start"]
+    stops = [d["index"] for n, d in events if n == "content_block_stop"]
+    assert starts == [(0, "text"), (1, "tool_use")]
+    assert stops == [0, 1]
+
+
+async def test_engine_error_frame_becomes_error_event():
+    frames = [
+        _text_chunk("partial"),
+        {"error": {"message": "Upstream provider error: boom", "type": "upstream_error"}},
+    ]
+    events = await _collect(frames)
+    names = [n for n, _ in events]
+    assert names[-1] == "error"
+    err = events[-1][1]
+    assert err["type"] == "error"
+    assert err["error"]["type"] == "api_error"
+    assert "boom" in err["error"]["message"]
+    assert "message_stop" not in names
+
+
+async def test_empty_stream_still_emits_valid_skeleton():
+    events = await _collect([])
+    names = [n for n, _ in events]
+    assert names == ["message_start", "message_delta", "message_stop"]
+
+
+# ── iter_openai_frames ──
+
+
+async def test_iter_openai_frames_parses_and_stops_at_done():
+    async def producer():
+        yield 'data: {"a": 1}\n\n'
+        yield 'data: {"b": 2}\n\n'
+        yield "data: [DONE]\n\n"
+        yield 'data: {"never": true}\n\n'
+
+    frames = [f async for f in iter_openai_frames(producer())]
+    assert frames == [{"a": 1}, {"b": 2}]
+
+
+async def test_iter_openai_frames_handles_split_and_bytes_frames():
+    async def producer():
+        yield b'data: {"a"'
+        yield b': 1}\n\ndata: [DONE]\n\n'
+
+    frames = [f async for f in iter_openai_frames(producer())]
+    assert frames == [{"a": 1}]
+
+
+async def test_iter_openai_frames_forwards_close_to_source():
+    closed = {"value": False}
+
+    class _Source:
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            return 'data: {"a": 1}\n\n'
+
+        async def aclose(self):
+            closed["value"] = True
+
+    gen = iter_openai_frames(_Source())
+    assert (await gen.__anext__()) == {"a": 1}
+    await gen.aclose()
+    assert closed["value"] is True

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -104,7 +104,9 @@ async def test_length_finish_maps_to_max_tokens():
     assert events[-2][1]["delta"]["stop_reason"] == "max_tokens"
 
 
-async def test_tool_call_stream_emits_tool_use_block_and_json_deltas():
+async def test_tool_call_stream_buffers_into_one_complete_tool_use_block():
+    """Fragments are buffered per index and flushed as ONE complete block
+    at end-of-stream (start → single full input_json_delta → stop)."""
     frames = [
         {
             "id": "chatcmpl-1", "model": "gpt-4o-mini",
@@ -137,7 +139,6 @@ async def test_tool_call_stream_emits_tool_use_block_and_json_deltas():
         "message_start",
         "content_block_start",
         "content_block_delta",
-        "content_block_delta",
         "content_block_stop",
         "message_delta",
         "message_stop",
@@ -149,6 +150,63 @@ async def test_tool_call_stream_emits_tool_use_block_and_json_deltas():
 
     partials = [d["delta"]["partial_json"] for n, d in events if n == "content_block_delta"]
     assert json.loads("".join(partials)) == {"city": "SF"}
+    assert events[-2][1]["delta"]["stop_reason"] == "tool_use"
+
+
+def _tool_fragment(index: int, args: str, call_id: str | None = None,
+                   name: str | None = None) -> dict:
+    tcd: dict = {"index": index, "function": {"arguments": args}}
+    if call_id:
+        tcd["id"] = call_id
+    if name:
+        tcd["function"]["name"] = name
+    return {
+        "id": "chatcmpl-1", "model": "gpt-4o-mini",
+        "choices": [{"index": 0, "delta": {"tool_calls": [tcd]}, "finish_reason": None}],
+    }
+
+
+async def test_interleaved_tool_call_fragments_stay_in_their_own_blocks():
+    """Regression: OpenAI-format streams interleave argument fragments of
+    concurrent tool calls across frames. The old block-reopen logic emitted
+    a NEW block (random id, empty name) per index switch, scattering each
+    call's JSON across nameless blocks. Buffered per index, the output must
+    be exactly one complete block per call, sequential, ids/names intact."""
+    frames = [
+        _tool_fragment(0, '{"ci', call_id="call_a", name="get_weather"),
+        _tool_fragment(1, '{"tz', call_id="call_b", name="get_time"),
+        _tool_fragment(0, 'ty": "SF"}'),
+        _tool_fragment(1, '": "UTC"}'),
+        {
+            "id": "chatcmpl-1", "model": "gpt-4o-mini",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+        },
+        _USAGE_CHUNK,
+    ]
+    events = await _collect(frames)
+    starts = [d for n, d in events if n == "content_block_start"]
+    assert [(s["content_block"]["id"], s["content_block"]["name"]) for s in starts] == [
+        ("call_a", "get_weather"), ("call_b", "get_time"),
+    ]
+
+    # one complete input_json_delta per block, correctly reassembled
+    deltas = [d for n, d in events if n == "content_block_delta"]
+    by_index = {d["index"]: json.loads(d["delta"]["partial_json"]) for d in deltas}
+    assert by_index == {
+        starts[0]["index"]: {"city": "SF"},
+        starts[1]["index"]: {"tz": "UTC"},
+    }
+
+    # blocks are strictly sequential: start(i) → delta(i) → stop(i)
+    block_events = [(n, d["index"]) for n, d in events
+                    if n.startswith("content_block_")]
+    i0, i1 = starts[0]["index"], starts[1]["index"]
+    assert block_events == [
+        ("content_block_start", i0), ("content_block_delta", i0),
+        ("content_block_stop", i0),
+        ("content_block_start", i1), ("content_block_delta", i1),
+        ("content_block_stop", i1),
+    ]
     assert events[-2][1]["delta"]["stop_reason"] == "tool_use"
 
 
@@ -186,6 +244,30 @@ async def test_engine_error_frame_becomes_error_event():
     assert err["error"]["type"] == "api_error"
     assert "boom" in err["error"]["message"]
     assert "message_stop" not in names
+
+
+async def test_error_frame_drains_engine_source_instead_of_closing_it():
+    """Regression: after a mid-stream upstream error the engine emits an
+    error frame + [DONE] and then completes, logging 503 + the real error
+    type. The transformer must DRAIN the frame source to that natural
+    completion — aclose() raises GeneratorExit at the engine's suspended
+    yield, which its disconnect branch mislogs as a 499 client disconnect."""
+    state = {"exit": None}
+
+    async def engine_sse():
+        try:
+            yield 'data: {"error": {"message": "boom", "type": "rate_limit_error"}}\n\n'
+            yield "data: [DONE]\n\n"
+            state["exit"] = "completed"
+        except GeneratorExit:
+            state["exit"] = "generator_exit"
+            raise
+
+    raw = [f async for f in stream_events(iter_openai_frames(engine_sse()))]
+    events = _parse_events(raw)
+    assert events[-1][0] == "error"
+    assert events[-1][1]["error"]["type"] == "rate_limit_error"
+    assert state["exit"] == "completed"
 
 
 async def test_empty_stream_still_emits_valid_skeleton():

--- a/tests/unit/test_anthropic_stream_transform.py
+++ b/tests/unit/test_anthropic_stream_transform.py
@@ -7,7 +7,10 @@ Also covers `iter_openai_frames` itself.
 
 from __future__ import annotations
 
+import asyncio
 import json
+
+import pytest
 
 from app.protocols.anthropic import stream_events
 from app.protocols.sse import iter_openai_frames
@@ -246,6 +249,28 @@ async def test_engine_error_frame_becomes_error_event():
     assert "message_stop" not in names
 
 
+@pytest.mark.parametrize("engine_type,anthropic_type", [
+    ("rate_limit_error", "rate_limit_error"),
+    ("overloaded_error", "overloaded_error"),
+    ("context_length_exceeded", "invalid_request_error"),
+    ("model_not_found", "not_found_error"),
+    ("upstream_timeout", "api_error"),
+    ("something_unknown", "api_error"),
+    (None, "api_error"),
+])
+async def test_engine_error_type_maps_to_anthropic_taxonomy(engine_type, anthropic_type):
+    """The engine's translated error types must map into the Anthropic
+    taxonomy — a context overflow or missing model presented as a generic
+    api_error would be retried by clients even though it can never
+    succeed."""
+    err: dict = {"message": "boom"}
+    if engine_type is not None:
+        err["type"] = engine_type
+    events = await _collect([{"error": err}])
+    assert events[-1][0] == "error"
+    assert events[-1][1]["error"]["type"] == anthropic_type
+
+
 async def test_error_frame_drains_engine_source_instead_of_closing_it():
     """Regression: after a mid-stream upstream error the engine emits an
     error frame + [DONE] and then completes, logging 503 + the real error
@@ -315,4 +340,39 @@ async def test_iter_openai_frames_forwards_close_to_source():
     gen = iter_openai_frames(_Source())
     assert (await gen.__anext__()) == {"a": 1}
     await gen.aclose()
+    assert closed["value"] is True
+
+
+async def test_close_during_post_done_drain_still_forwards_close_to_source():
+    """Regression: a cancel/close landing DURING the post-[DONE] drain must
+    still forward the close to the source — otherwise the engine generator
+    stays suspended at its [DONE] yield and its request-log writeback only
+    runs at GC finalization (or never, if the process exits first)."""
+    closed = {"value": False}
+    drain_entered = asyncio.Event()
+
+    class _Source:
+        def __init__(self):
+            self._sent = False
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if not self._sent:
+                self._sent = True
+                return 'data: {"a": 1}\n\ndata: [DONE]\n\n'
+            drain_entered.set()
+            await asyncio.Event().wait()  # suspend in the drain until cancelled
+
+        async def aclose(self):
+            closed["value"] = True
+
+    gen = iter_openai_frames(_Source())
+    assert (await gen.__anext__()) == {"a": 1}
+    task = asyncio.create_task(gen.__anext__())
+    await drain_entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
     assert closed["value"] is True

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -195,6 +195,11 @@ def test_thinking_param_and_history_blocks_dropped_not_rejected():
     assert out["messages"][0] == {"role": "assistant", "content": "answer"}
 
 
+def test_stop_sequences_truncated_to_openai_cap():
+    out = to_openai_request(_req(stop_sequences=["a", "b", "c", "d", "e"]))
+    assert out["stop"] == ["a", "b", "c", "d"]
+
+
 def test_thinking_only_assistant_message_keeps_empty_content():
     """Regression: an assistant turn of ONLY thinking blocks (Claude Code
     sends these on extended-thinking/compacted histories) must not become

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -380,6 +380,19 @@ def test_stop_reason_mapping(finish, expected):
     assert to_anthropic_response(resp)["stop_reason"] == expected
 
 
+def test_multipart_list_content_flattens_to_a_text_block():
+    """The OpenAI wire format allows a response message's content to be a
+    list of parts. Emitting it verbatim would produce a text block whose
+    `text` is an array, which the Anthropic SDK cannot parse."""
+    resp = _openai_response()
+    resp["choices"][0]["message"]["content"] = [
+        {"type": "text", "text": "Hello "},
+        {"type": "text", "text": "world"},
+    ]
+    out = to_anthropic_response(resp)
+    assert out["content"] == [{"type": "text", "text": "Hello world"}]
+
+
 def test_empty_content_and_no_tools_yields_empty_blocks():
     resp = _openai_response()
     resp["choices"][0]["message"]["content"] = None

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -1,0 +1,311 @@
+"""Anthropic Messages API translation — pure-function unit tests (slice S2).
+
+Request direction: Anthropic wire format → internal OpenAI dict.
+Response direction: OpenAI response dict → Anthropic message dict.
+No app, no mocks — the translators are pure.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import HTTPException
+from pydantic import ValidationError
+
+from app.protocols.anthropic import (
+    AnthropicMessagesRequest,
+    to_anthropic_response,
+    to_openai_request,
+)
+
+
+def _req(**overrides) -> AnthropicMessagesRequest:
+    base = {
+        "model": "claude-3-5-sonnet-latest",
+        "max_tokens": 128,
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    base.update(overrides)
+    return AnthropicMessagesRequest.model_validate(base)
+
+
+# ── Request translation ──
+
+
+def test_minimal_request_maps_model_max_tokens_stream():
+    out = to_openai_request(_req())
+    assert out["model"] == "claude-3-5-sonnet-latest"
+    assert out["max_tokens"] == 128
+    assert out["stream"] is False
+    assert out["messages"] == [{"role": "user", "content": "hi"}]
+
+
+def test_missing_max_tokens_fails_validation():
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest.model_validate({
+            "model": "m", "messages": [{"role": "user", "content": "hi"}],
+        })
+
+
+def test_system_string_becomes_leading_system_message():
+    out = to_openai_request(_req(system="be brief"))
+    assert out["messages"][0] == {"role": "system", "content": "be brief"}
+    assert out["messages"][1]["role"] == "user"
+
+
+def test_system_blocks_join_text_and_drop_cache_control():
+    out = to_openai_request(_req(system=[
+        {"type": "text", "text": "part one", "cache_control": {"type": "ephemeral"}},
+        {"type": "text", "text": "part two"},
+    ]))
+    assert out["messages"][0] == {"role": "system", "content": "part one\n\npart two"}
+
+
+def test_image_base64_block_becomes_data_uri_part():
+    out = to_openai_request(_req(messages=[{
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "look"},
+            {"type": "image", "source": {
+                "type": "base64", "media_type": "image/png", "data": "aGk=",
+            }},
+        ],
+    }]))
+    parts = out["messages"][0]["content"]
+    assert parts[0] == {"type": "text", "text": "look"}
+    assert parts[1] == {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,aGk="},
+    }
+
+
+def test_image_url_source_passes_url_through():
+    out = to_openai_request(_req(messages=[{
+        "role": "user",
+        "content": [{"type": "image", "source": {"type": "url", "url": "https://x/y.png"}}],
+    }]))
+    parts = out["messages"][0]["content"]
+    assert parts == [{"type": "image_url", "image_url": {"url": "https://x/y.png"}}]
+
+
+def test_single_text_block_collapses_to_plain_string():
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": [{"type": "text", "text": "just text"}]},
+    ]))
+    assert out["messages"][0] == {"role": "user", "content": "just text"}
+
+
+def test_assistant_tool_use_becomes_tool_calls():
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": [
+            {"type": "text", "text": "checking"},
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather",
+             "input": {"city": "SF"}},
+        ]},
+    ]))
+    assistant = out["messages"][1]
+    assert assistant["content"] == "checking"
+    (tc,) = assistant["tool_calls"]
+    assert tc["id"] == "toolu_1"
+    assert tc["function"]["name"] == "get_weather"
+    assert json.loads(tc["function"]["arguments"]) == {"city": "SF"}
+
+
+def test_tool_result_splits_into_tool_message_then_user_message():
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "toolu_1", "name": "get_weather", "input": {}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1", "content": "72F"},
+            {"type": "text", "text": "and tomorrow?"},
+        ]},
+    ]))
+    tool_msg = out["messages"][2]
+    assert tool_msg == {"role": "tool", "tool_call_id": "toolu_1", "content": "72F"}
+    assert out["messages"][3] == {"role": "user", "content": "and tomorrow?"}
+
+
+def test_multiple_tool_results_emit_in_order():
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "toolu_1",
+             "content": [{"type": "text", "text": "A"}]},
+            {"type": "tool_result", "tool_use_id": "toolu_2", "content": "B"},
+        ]},
+    ]))
+    assert [m["tool_call_id"] for m in out["messages"]] == ["toolu_1", "toolu_2"]
+    assert [m["content"] for m in out["messages"]] == ["A", "B"]
+
+
+def test_tools_translate_and_server_tool_types_rejected():
+    out = to_openai_request(_req(tools=[
+        {"name": "f", "description": "d", "input_schema": {"type": "object"}},
+        {"type": "custom", "name": "g", "input_schema": {"type": "object"}},
+    ]))
+    assert out["tools"][0] == {
+        "type": "function",
+        "function": {"name": "f", "parameters": {"type": "object"}, "description": "d"},
+    }
+    assert out["tools"][1]["function"]["name"] == "g"
+
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(tools=[{"type": "web_search_20250305", "name": "web_search"}]))
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("tc,expected", [
+    ({"type": "auto"}, "auto"),
+    ({"type": "any"}, "required"),
+    ({"type": "none"}, "none"),
+    ({"type": "tool", "name": "f"}, {"type": "function", "function": {"name": "f"}}),
+])
+def test_tool_choice_variants(tc, expected):
+    out = to_openai_request(_req(tool_choice=tc))
+    assert out["tool_choice"] == expected
+
+
+def test_sampling_and_metadata_mapping():
+    out = to_openai_request(_req(
+        temperature=0.5, top_p=0.9, top_k=40,
+        stop_sequences=["END"], metadata={"user_id": "u-1"},
+    ))
+    assert out["temperature"] == 0.5
+    assert out["top_p"] == 0.9
+    assert out["stop"] == ["END"]
+    assert out["user"] == "u-1"
+    assert "top_k" not in out  # dropped, documented
+
+
+def test_thinking_param_and_history_blocks_dropped_not_rejected():
+    out = to_openai_request(_req(
+        thinking={"type": "enabled", "budget_tokens": 1024},
+        messages=[
+            {"role": "assistant", "content": [
+                {"type": "thinking", "thinking": "...", "signature": "s"},
+                {"type": "text", "text": "answer"},
+            ]},
+            {"role": "user", "content": "ok"},
+        ],
+    ))
+    assert "thinking" not in out
+    assert out["messages"][0] == {"role": "assistant", "content": "answer"}
+
+
+def test_document_block_rejected_with_400():
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(messages=[{
+            "role": "user",
+            "content": [{"type": "document", "source": {"type": "base64", "data": "x"}}],
+        }]))
+    assert exc.value.status_code == 400
+
+
+def test_system_role_inside_messages_is_tolerated():
+    """Claude Code 2.x sends role:"system" entries inside messages[] on some
+    internal requests (spec says top-level `system` only). They must
+    translate to OpenAI system messages, not 400 — a 400 breaks Claude Code."""
+    out = to_openai_request(_req(messages=[
+        {"role": "system", "content": "internal instruction"},
+        {"role": "user", "content": "hi"},
+    ]))
+    assert out["messages"][0] == {"role": "system", "content": "internal instruction"}
+    # block-form content flattens to text
+    out2 = to_openai_request(_req(messages=[
+        {"role": "system", "content": [{"type": "text", "text": "as blocks"}]},
+        {"role": "user", "content": "hi"},
+    ]))
+    assert out2["messages"][0] == {"role": "system", "content": "as blocks"}
+
+
+def test_invalid_role_rejected_with_400():
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(messages=[{"role": "tool", "content": "nope"}]))
+    assert exc.value.status_code == 400
+
+
+# ── Response translation ──
+
+
+def _openai_response(**overrides) -> dict:
+    base = {
+        "id": "chatcmpl-1",
+        "model": "gpt-4o-mini",
+        "object": "chat.completion",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hello world"},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_text_response_maps_to_anthropic_shape():
+    out = to_anthropic_response(_openai_response())
+    assert out["type"] == "message"
+    assert out["role"] == "assistant"
+    assert out["id"].startswith("msg_")
+    assert out["model"] == "gpt-4o-mini"
+    assert out["content"] == [{"type": "text", "text": "Hello world"}]
+    assert out["stop_reason"] == "end_turn"
+    assert out["usage"] == {"input_tokens": 4, "output_tokens": 2}
+
+
+def test_tool_calls_become_tool_use_blocks_with_parsed_input():
+    out = to_anthropic_response(_openai_response(choices=[{
+        "index": 0,
+        "message": {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [{
+                "id": "call_9",
+                "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+            }],
+        },
+        "finish_reason": "tool_calls",
+    }]))
+    assert out["stop_reason"] == "tool_use"
+    (block,) = out["content"]
+    assert block == {
+        "type": "tool_use", "id": "call_9",
+        "name": "get_weather", "input": {"city": "SF"},
+    }
+
+
+def test_malformed_tool_arguments_fall_back_to_empty_object():
+    out = to_anthropic_response(_openai_response(choices=[{
+        "index": 0,
+        "message": {
+            "role": "assistant", "content": None,
+            "tool_calls": [{
+                "id": "c", "type": "function",
+                "function": {"name": "f", "arguments": "{not json"},
+            }],
+        },
+        "finish_reason": "tool_calls",
+    }]))
+    assert out["content"][0]["input"] == {}
+
+
+@pytest.mark.parametrize("finish,expected", [
+    ("length", "max_tokens"),
+    ("content_filter", "refusal"),
+    (None, "end_turn"),
+])
+def test_stop_reason_mapping(finish, expected):
+    resp = _openai_response()
+    resp["choices"][0]["finish_reason"] = finish
+    assert to_anthropic_response(resp)["stop_reason"] == expected
+
+
+def test_empty_content_and_no_tools_yields_empty_blocks():
+    resp = _openai_response()
+    resp["choices"][0]["message"]["content"] = None
+    assert to_anthropic_response(resp)["content"] == []

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -195,6 +195,23 @@ def test_thinking_param_and_history_blocks_dropped_not_rejected():
     assert out["messages"][0] == {"role": "assistant", "content": "answer"}
 
 
+def test_thinking_only_assistant_message_keeps_empty_content():
+    """Regression: an assistant turn of ONLY thinking blocks (Claude Code
+    sends these on extended-thinking/compacted histories) must not become
+    content=None with no tool_calls — the engine's exclude_none dump would
+    then send a bare {"role": "assistant"}, which OpenAI-compatible
+    upstreams reject with a 400."""
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [
+            {"type": "thinking", "thinking": "...", "signature": "s"},
+            {"type": "redacted_thinking", "data": "x"},
+        ]},
+        {"role": "user", "content": "and?"},
+    ]))
+    assert out["messages"][1] == {"role": "assistant", "content": ""}
+
+
 def test_document_block_rejected_with_400():
     with pytest.raises(HTTPException) as exc:
         to_openai_request(_req(messages=[{

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -124,6 +124,48 @@ def test_assistant_tool_use_becomes_tool_calls():
     assert json.loads(tc["function"]["arguments"]) == {"city": "SF"}
 
 
+@pytest.mark.parametrize("field,value", [
+    ("temperature", 1.5),
+    ("temperature", -0.1),
+    ("top_p", 1.5),
+    ("top_k", -1),
+])
+def test_out_of_range_sampling_params_fail_validation(field, value):
+    """Out-of-range values are rejected by the upstream as a BadRequest,
+    which the engine reports as a retryable 500 api_error — bound them
+    here so the caller gets an honest 400 instead."""
+    with pytest.raises(ValidationError):
+        _req(**{field: value})
+
+
+def test_tool_result_image_rides_along_in_the_following_user_message():
+    """An OpenAI tool message can only carry text, so an image returned by
+    a tool (a screenshot, the common case) is attached to the user message
+    that follows the tool results rather than being dropped."""
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "look"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "call_1", "name": "shot", "input": {}},
+        ]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "call_1", "content": [
+                {"type": "text", "text": "captured"},
+                {"type": "image", "source": {
+                    "type": "base64", "media_type": "image/png", "data": "AAAA",
+                }},
+            ]},
+        ]},
+    ]))
+    tool_msg, user_msg = out["messages"][-2], out["messages"][-1]
+    assert tool_msg == {
+        "role": "tool", "tool_call_id": "call_1", "content": "captured",
+    }
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == [
+        {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}},
+    ]
+
+
 def test_tool_result_splits_into_tool_message_then_user_message():
     out = to_openai_request(_req(messages=[
         {"role": "user", "content": "weather?"},

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -397,3 +397,70 @@ def test_empty_content_and_no_tools_yields_empty_blocks():
     resp = _openai_response()
     resp["choices"][0]["message"]["content"] = None
     assert to_anthropic_response(resp)["content"] == []
+
+
+# ── wire-type validation: tools, tool_choice, text values ──
+
+
+@pytest.mark.parametrize("tool", [
+    {"name": 123, "input_schema": {"type": "object"}},
+    {"name": "", "input_schema": {"type": "object"}},
+    {"name": "f", "input_schema": "oops"},
+    {"name": "f", "input_schema": ["not", "a", "schema"]},
+    {"name": "f", "input_schema": {"type": "object"}, "description": 42},
+])
+def test_malformed_tool_definitions_render_native_400(tool):
+    """`tools` is list[dict] with no inner validation. A numeric name or a
+    string input_schema used to pass every layer and reach the upstream,
+    whose BadRequest came back as a retryable 503 the SDK keeps retrying
+    for a request that can never succeed."""
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(tools=[tool]))
+    assert exc.value.status_code == 400
+
+
+def test_tool_choice_with_non_string_name_rejected():
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(tool_choice={"type": "tool", "name": 7}))
+    assert exc.value.status_code == 400
+
+
+def test_tool_without_input_schema_gets_an_empty_object_schema():
+    out = to_openai_request(_req(tools=[{"name": "f"}]))
+    assert out["tools"][0]["function"]["parameters"] == {"type": "object", "properties": {}}
+    assert "description" not in out["tools"][0]["function"]
+
+
+@pytest.mark.parametrize("payload", [
+    {"system": [{"type": "text", "text": 123}]},
+    {"messages": [{"role": "user", "content": [{"type": "text", "text": ["x"]}]}]},
+    {"messages": [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": [{"type": "text", "text": 1.5}]},
+    ]},
+    {"messages": [{"role": "user", "content": [
+        {"type": "tool_result", "tool_use_id": "t1",
+         "content": [{"type": "text", "text": 0}]},
+    ]}]},
+])
+def test_non_string_text_values_render_native_400(payload):
+    """A non-string `text` used to crash the message join with a TypeError
+    (a 500 the SDK retries) or ride through to the upstream as a malformed
+    part; either way a 400 is the honest answer."""
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(**payload))
+    assert exc.value.status_code == 400
+
+
+def test_null_text_values_are_treated_as_empty():
+    out = to_openai_request(_req(
+        system=[{"type": "text", "text": None}],
+        messages=[{"role": "user", "content": [
+            {"type": "text", "text": None}, {"type": "text", "text": "hi"},
+        ]}],
+    ))
+    # an all-empty system yields no system message at all
+    assert out["messages"][0]["role"] == "user"
+    assert out["messages"][0]["content"] == [
+        {"type": "text", "text": ""}, {"type": "text", "text": "hi"},
+    ]

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -48,6 +48,17 @@ def test_missing_max_tokens_fails_validation():
         })
 
 
+@pytest.mark.parametrize("value", [0, -1])
+def test_non_positive_max_tokens_fails_validation(value):
+    """A budget < 1 can never succeed upstream; rejecting it here keeps it
+    a 400 invalid_request_error instead of a retryable 500 api_error."""
+    with pytest.raises(ValidationError):
+        AnthropicMessagesRequest.model_validate({
+            "model": "m", "max_tokens": value,
+            "messages": [{"role": "user", "content": "hi"}],
+        })
+
+
 def test_system_string_becomes_leading_system_message():
     out = to_openai_request(_req(system="be brief"))
     assert out["messages"][0] == {"role": "system", "content": "be brief"}

--- a/tests/unit/test_anthropic_translation.py
+++ b/tests/unit/test_anthropic_translation.py
@@ -453,6 +453,9 @@ def test_non_string_text_values_render_native_400(payload):
 
 
 def test_null_text_values_are_treated_as_empty():
+    """A null/empty text block carries nothing: it is left out rather than
+    emitted as an empty part (which upstreams reject, coming back as a
+    retryable 5xx). Here the turn still has real text, so it survives."""
     out = to_openai_request(_req(
         system=[{"type": "text", "text": None}],
         messages=[{"role": "user", "content": [
@@ -460,7 +463,42 @@ def test_null_text_values_are_treated_as_empty():
         ]}],
     ))
     # an all-empty system yields no system message at all
-    assert out["messages"][0]["role"] == "user"
-    assert out["messages"][0]["content"] == [
-        {"type": "text", "text": ""}, {"type": "text", "text": "hi"},
-    ]
+    assert out["messages"] == [{"role": "user", "content": "hi"}]
+
+
+@pytest.mark.parametrize("content", [
+    "",
+    [{"type": "text", "text": ""}],
+    [{"type": "text", "text": None}],
+    [{"type": "text", "text": ""}, {"type": "text", "text": ""}],
+])
+def test_user_turn_with_only_empty_text_is_rejected(content):
+    """`{"role": "user", "content": ""}` reaching the upstream is a
+    BadRequest there, which the engine reports as a retryable 5xx for a
+    request that can never succeed. The real API rejects it as a 400."""
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(_req(messages=[{"role": "user", "content": content}]))
+    assert exc.value.status_code == 400
+
+
+def test_empty_text_alongside_a_tool_result_leaves_just_the_tool_message():
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "go"},
+        {"role": "assistant", "content": [
+            {"type": "tool_use", "id": "t1", "name": "f", "input": {}}]},
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": "done"},
+            {"type": "text", "text": ""},
+        ]},
+    ]))
+    assert out["messages"][-1] == {"role": "tool", "tool_call_id": "t1", "content": "done"}
+
+
+def test_empty_assistant_content_is_still_preserved():
+    """Only USER turns are rejected — a thinking-only assistant turn keeps
+    its empty content so the turn is not lost from the history."""
+    out = to_openai_request(_req(messages=[
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": ""},
+    ]))
+    assert out["messages"][-1] == {"role": "assistant", "content": ""}

--- a/tests/unit/test_catalog.py
+++ b/tests/unit/test_catalog.py
@@ -88,3 +88,33 @@ def test_catalog_pricing_metadata_available():
     gpt4o = CATALOG_BY_ID["gpt-4o"]
     assert gpt4o.input_cost_per_token > 0
     assert gpt4o.output_cost_per_token > 0
+
+
+def test_catalog_lists_hosted_free_models_with_zero_cost():
+    """The zero-credit O2 models are discoverable in the catalog (feeding
+    GET /v1/models and /v1beta/models) under the provider-qualified wire
+    IDs O2's own listing uses — each has a matching hosted deployment via
+    HOSTED_MODEL_ALIASES."""
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+    from packages.litellm_adapter.hosted_catalog import HOSTED_MODEL_ALIASES
+
+    for wire_id in HOSTED_MODEL_ALIASES:
+        m = CATALOG_BY_ID.get(wire_id)
+        assert m is not None, f"{wire_id} missing from catalog"
+        assert m.input_cost_per_token == 0.0
+        assert m.output_cost_per_token == 0.0
+
+
+def test_free_models_are_listed_but_not_auto_eligible():
+    """Deliberate interaction: choose_auto_model excludes zero-blended-cost
+    entries (unpriced ≠ free in litellm's catalog, and zero-cost wins would
+    skew the savings math), so the free models are discoverable + pinnable
+    but never auto-selected."""
+    from app.auto_routing import choose_auto_model
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID
+
+    m = CATALOG_BY_ID["orcarouter/free"]
+    chosen, _ = choose_auto_model(
+        needs=set(), deployable={"orcarouter/free"}, candidates=[m],
+    )
+    assert chosen == []

--- a/tests/unit/test_delivered_status.py
+++ b/tests/unit/test_delivered_status.py
@@ -20,9 +20,11 @@ from app.protocols import gemini as gemini_proto
     (422, "no_capable_provider", 403),
     (429, "rate_limit_error", 429),
     (422, "context_length_exceeded", 400),
+    # transient upstream failure → the taxonomy's "busy" status (kept by
+    # the envelope, which only collapses the OTHER 5xx)
+    (503, "upstream_timeout", 529),
     # unmapped generic failures: the envelope collapses them to 500
     (503, "upstream_error", 500),
-    (503, "upstream_timeout", 500),
     (503, "something_unknown", 500),
     (422, None, 400),
     # not an error the envelope rewrites

--- a/tests/unit/test_delivered_status.py
+++ b/tests/unit/test_delivered_status.py
@@ -1,0 +1,61 @@
+"""`delivered_status` on both native surfaces (PR #64 round 12).
+
+It is what `execute_chat(log_status=...)` persists, so it must equal the
+status `error_response` actually renders — native_status alone leaves a
+generic upstream 5xx at 503 while the Anthropic envelope delivers 500.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.protocols import anthropic as anthropic_proto
+from app.protocols import gemini as gemini_proto
+
+
+@pytest.mark.parametrize("engine_status,error_type,expected", [
+    (422, "model_not_found", 404),
+    (503, "upstream_auth_error", 403),
+    (503, "no_providers_configured", 403),
+    (422, "no_capable_provider", 403),
+    (429, "rate_limit_error", 429),
+    (422, "context_length_exceeded", 400),
+    # unmapped generic failures: the envelope collapses them to 500
+    (503, "upstream_error", 500),
+    (503, "upstream_timeout", 500),
+    (503, "something_unknown", 500),
+    (422, None, 400),
+    # not an error the envelope rewrites
+    (499, "client_disconnect", 499),
+])
+def test_anthropic_delivered_status_matches_the_rendered_envelope(
+    engine_status, error_type, expected,
+):
+    assert anthropic_proto.delivered_status(engine_status, error_type) == expected
+    rendered = anthropic_proto.error_response(
+        anthropic_proto.native_status(engine_status, error_type), "boom",
+    )
+    assert rendered.status_code == expected
+
+
+@pytest.mark.parametrize("engine_status,error_type,expected", [
+    (422, "model_not_found", 404),
+    (503, "upstream_auth_error", 403),
+    (503, "no_providers_configured", 403),
+    (422, "no_capable_provider", 403),
+    (429, "rate_limit_error", 429),
+    (422, "context_length_exceeded", 400),
+    (503, "upstream_error", 503),
+    (503, "upstream_timeout", 503),
+    (503, "something_unknown", 503),
+    (422, None, 400),
+    (499, "client_disconnect", 499),
+])
+def test_gemini_delivered_status_matches_the_rendered_envelope(
+    engine_status, error_type, expected,
+):
+    assert gemini_proto.delivered_status(engine_status, error_type) == expected
+    rendered = gemini_proto.error_response(
+        gemini_proto.native_status(engine_status, error_type), "boom",
+    )
+    assert rendered.status_code == expected

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -172,3 +172,94 @@ async def test_final_chunk_reaches_the_client_before_the_engine_writeback():
         )
 
     assert order == ["content", "final", "engine_writeback"]
+
+
+# ── part ordering: text ↔ function calls ──
+
+
+def _tool_fragment(index: int, args: str, name: str | None = None) -> dict:
+    tcd: dict = {"index": index, "function": {"arguments": args}}
+    if name:
+        tcd["function"]["name"] = name
+    return {
+        "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+        "choices": [{"index": 0, "delta": {"tool_calls": [tcd]}, "finish_reason": None}],
+    }
+
+
+def _part_kinds(chunks: list[dict]) -> list[str]:
+    kinds = []
+    for c in chunks:
+        for cand in c.get("candidates") or []:
+            for p in cand["content"]["parts"]:
+                kinds.append("functionCall" if "functionCall" in p else "text")
+    return kinds
+
+
+async def test_text_after_a_function_call_is_delivered_after_the_call_part():
+    """Regression: buffered functionCall parts were flushed only at
+    end-of-stream while text passed through immediately, so text the model
+    produced AFTER the call reached the client BEFORE it."""
+    chunks = await _collect([
+        _tool_fragment(0, '{"ci', name="get_weather"),
+        _tool_fragment(0, 'ty": "SF"}'),
+        _text_chunk("Checking."),
+        _FINISH_CHUNK,
+        _USAGE_CHUNK,
+    ])
+    assert _part_kinds(chunks) == ["functionCall", "text"]
+    fc = chunks[0]["candidates"][0]["content"]["parts"][0]["functionCall"]
+    assert fc == {"name": "get_weather", "args": {"city": "SF"}}
+    assert chunks[-1]["candidates"][0]["finishReason"] == "STOP"
+
+
+async def test_function_call_between_two_text_runs_keeps_the_model_order():
+    chunks = await _collect([
+        _text_chunk("A"),
+        _tool_fragment(0, '{"x": 1}', name="f"),
+        _text_chunk("B"),
+        _FINISH_CHUNK,
+    ])
+    assert _part_kinds(chunks) == ["text", "functionCall", "text"]
+    texts = [p["text"] for c in chunks for cand in c.get("candidates") or []
+             for p in cand["content"]["parts"] if "text" in p]
+    assert texts == ["A", "B"]
+
+
+async def test_text_between_argument_fragments_of_one_call_does_not_split_it():
+    """A text delta between two argument fragments of the same call must not
+    flush the half-built call — that would emit functionCall{args: {}} (the
+    parse failure is swallowed) plus a nameless second call. It waits for
+    end-of-stream and comes out whole."""
+    chunks = await _collect([
+        _tool_fragment(0, '{"ci', name="get_weather"),
+        _text_chunk("thinking..."),
+        _tool_fragment(0, 'ty": "SF"}'),
+        _FINISH_CHUNK,
+    ])
+    assert _part_kinds(chunks) == ["text", "functionCall"]
+    calls = [p["functionCall"] for c in chunks for cand in c.get("candidates") or []
+             for p in cand["content"]["parts"] if "functionCall" in p]
+    assert calls == [{"name": "get_weather", "args": {"city": "SF"}}]
+
+
+async def test_close_at_the_error_chunk_still_drains_the_engine_source():
+    """Mirror of the Anthropic test: a client gone while the error chunk is
+    in flight must not turn into a close forwarded into the engine — the
+    [DONE] is consumed before the chunk is yielded, so the finally drains."""
+    state = {"exit": None}
+
+    async def engine_sse():
+        try:
+            yield 'data: {"error": {"message": "boom", "type": "rate_limit_error"}}\n\n'
+            yield "data: [DONE]\n\n"
+            state["exit"] = "completed"
+        except GeneratorExit:
+            state["exit"] = "generator_exit"
+            raise
+
+    gen = stream_chunks(OpenAIFrameStream(engine_sse()))
+    first = await gen.__anext__()
+    assert first["error"]["status"] == "RESOURCE_EXHAUSTED"
+    await gen.aclose()  # client gone while the error chunk was in flight
+    assert state["exit"] == "completed"

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -115,6 +115,8 @@ async def test_engine_error_frame_becomes_google_error_chunk():
     ("rate_limit_error", 429, "RESOURCE_EXHAUSTED"),
     ("model_not_found", 404, "NOT_FOUND"),
     ("context_length_exceeded", 400, "INVALID_ARGUMENT"),
+    # OUR provider credential — permanent, must not present as retryable.
+    ("upstream_auth_error", 403, "PERMISSION_DENIED"),
     ("upstream_timeout", 503, "UNAVAILABLE"),
     ("something_unknown", 500, "INTERNAL"),
     (None, 500, "INTERNAL"),

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -1,0 +1,108 @@
+"""Gemini streaming transformer — pure-transformer unit tests (slice S8).
+
+Feeds synthetic OpenAI chunk dicts and asserts the GenerateContentResponse
+chunk stream: text deltas pass through one-to-one, tool-call fragments are
+buffered into a single complete functionCall part, and the final chunk
+carries finishReason + usageMetadata.
+"""
+
+from __future__ import annotations
+
+from app.protocols.gemini import stream_chunks
+
+
+async def _agen(items):
+    for item in items:
+        yield item
+
+
+async def _collect(frames: list[dict]) -> list[dict]:
+    return [c async for c in stream_chunks(_agen(frames))]
+
+
+def _text_chunk(text: str) -> dict:
+    return {
+        "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+        "choices": [{"index": 0, "delta": {"content": text}, "finish_reason": None}],
+    }
+
+
+_FINISH_CHUNK = {
+    "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+}
+
+_USAGE_CHUNK = {
+    "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+    "choices": [],
+    "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+}
+
+
+async def test_text_deltas_stream_one_to_one_with_final_usage_chunk():
+    chunks = await _collect([
+        _text_chunk("Hello"), _text_chunk(" world"), _FINISH_CHUNK, _USAGE_CHUNK,
+    ])
+    assert len(chunks) == 3
+    texts = [c["candidates"][0]["content"]["parts"][0]["text"] for c in chunks[:2]]
+    assert texts == ["Hello", " world"]
+    for c in chunks[:2]:
+        assert "finishReason" not in c["candidates"][0]
+        assert c["modelVersion"] == "gemini-1.5-flash"
+        assert c["responseId"] == "chatcmpl-1"
+
+    final = chunks[-1]
+    assert final["candidates"][0]["finishReason"] == "STOP"
+    assert final["usageMetadata"] == {
+        "promptTokenCount": 4, "candidatesTokenCount": 2, "totalTokenCount": 6,
+    }
+
+
+async def test_tool_call_fragments_buffer_into_single_complete_part():
+    frames = [
+        {
+            "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "id": "call_1",
+                "function": {"name": "get_weather", "arguments": '{"ci'},
+            }]}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+            "choices": [{"index": 0, "delta": {"tool_calls": [{
+                "index": 0, "function": {"arguments": 'ty": "SF"}'},
+            }]}, "finish_reason": None}],
+        },
+        {
+            "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "tool_calls"}],
+        },
+        _USAGE_CHUNK,
+    ]
+    chunks = await _collect(frames)
+    # exactly one functionCall chunk (complete, never partial) + final chunk
+    assert len(chunks) == 2
+    parts = chunks[0]["candidates"][0]["content"]["parts"]
+    assert parts == [{"functionCall": {"name": "get_weather", "args": {"city": "SF"}}}]
+    assert chunks[-1]["candidates"][0]["finishReason"] == "STOP"
+
+
+async def test_length_finish_maps_to_max_tokens():
+    finish = {
+        "id": "chatcmpl-1", "model": "gemini-1.5-flash",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "length"}],
+    }
+    chunks = await _collect([_text_chunk("hi"), finish])
+    assert chunks[-1]["candidates"][0]["finishReason"] == "MAX_TOKENS"
+
+
+async def test_engine_error_frame_becomes_google_error_chunk():
+    chunks = await _collect([
+        _text_chunk("partial"),
+        {"error": {"message": "boom", "type": "upstream_error"}},
+    ])
+    assert chunks[-1] == {
+        "error": {"code": 500, "message": "boom", "status": "INTERNAL"},
+    }
+    # no final finishReason chunk after an error
+    assert all("usageMetadata" not in c for c in chunks)

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -243,6 +243,48 @@ async def test_text_between_argument_fragments_of_one_call_does_not_split_it():
     assert calls == [{"name": "get_weather", "args": {"city": "SF"}}]
 
 
+async def test_first_fragment_with_empty_arguments_is_not_flushed_by_following_text():
+    chunks = await _collect([
+        _tool_fragment(0, "", name="get_weather"),
+        _text_chunk("thinking..."),
+        _tool_fragment(0, '{"city": "SF"}'),
+        _FINISH_CHUNK,
+    ])
+    assert _part_kinds(chunks) == ["text", "functionCall"]
+    calls = [p["functionCall"] for c in chunks for cand in c.get("candidates") or []
+             for p in cand["content"]["parts"] if "functionCall" in p]
+    assert calls == [{"name": "get_weather", "args": {"city": "SF"}}]
+
+
+async def test_client_cancel_during_the_final_drain_still_lets_the_engine_finish():
+    """Mirror of the Anthropic test: the shielded `finally` must still drive
+    the engine to completion when the body task is cancelled mid-drain."""
+    import asyncio
+
+    import anyio
+
+    drain_started = asyncio.Event()
+    order: list[str] = []
+
+    async def engine_sse():
+        yield 'data: {"id":"c1","model":"m","choices":[{"index":0,' \
+              '"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+        drain_started.set()
+        await asyncio.sleep(0.05)
+        order.append("engine_writeback")
+
+    async def consume():
+        async for _ in stream_chunks(OpenAIFrameStream(engine_sse())):
+            pass
+
+    async with anyio.create_task_group() as tg:
+        tg.start_soon(consume)
+        await drain_started.wait()
+        tg.cancel_scope.cancel()
+    assert order == ["engine_writeback"]
+
+
 async def test_close_at_the_error_chunk_still_drains_the_engine_source():
     """Mirror of the Anthropic test: a client gone while the error chunk is
     in flight must not turn into a close forwarded into the engine — the

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -8,7 +8,10 @@ carries finishReason + usageMetadata.
 
 from __future__ import annotations
 
+import pytest
+
 from app.protocols.gemini import stream_chunks
+from app.protocols.sse import iter_openai_frames
 
 
 async def _agen(items):
@@ -102,7 +105,48 @@ async def test_engine_error_frame_becomes_google_error_chunk():
         {"error": {"message": "boom", "type": "upstream_error"}},
     ])
     assert chunks[-1] == {
-        "error": {"code": 500, "message": "boom", "status": "INTERNAL"},
+        "error": {"code": 503, "message": "boom", "status": "UNAVAILABLE"},
     }
     # no final finishReason chunk after an error
     assert all("usageMetadata" not in c for c in chunks)
+
+
+@pytest.mark.parametrize("etype,code,status", [
+    ("rate_limit_error", 429, "RESOURCE_EXHAUSTED"),
+    ("model_not_found", 404, "NOT_FOUND"),
+    ("context_length_exceeded", 400, "INVALID_ARGUMENT"),
+    ("upstream_timeout", 503, "UNAVAILABLE"),
+    ("something_unknown", 500, "INTERNAL"),
+    (None, 500, "INTERNAL"),
+])
+async def test_engine_error_type_maps_to_google_status(etype, code, status):
+    """The engine's translated error type must surface as the matching
+    Google status — client retry/backoff keys off it (a provider rate
+    limit presented as INTERNAL would not be backed off)."""
+    err: dict = {"message": "boom"}
+    if etype is not None:
+        err["type"] = etype
+    chunks = await _collect([{"error": err}])
+    assert chunks == [{"error": {"code": code, "message": "boom", "status": status}}]
+
+
+async def test_error_frame_drains_engine_source_instead_of_closing_it():
+    """Regression: after a mid-stream upstream error the engine emits an
+    error frame + [DONE] and then completes, logging 503 + the real error
+    type. The transformer must DRAIN the frame source to that natural
+    completion — aclose() raises GeneratorExit at the engine's suspended
+    yield, which its disconnect branch mislogs as a 499 client disconnect."""
+    state = {"exit": None}
+
+    async def engine_sse():
+        try:
+            yield 'data: {"error": {"message": "boom", "type": "rate_limit_error"}}\n\n'
+            yield "data: [DONE]\n\n"
+            state["exit"] = "completed"
+        except GeneratorExit:
+            state["exit"] = "generator_exit"
+            raise
+
+    chunks = [c async for c in stream_chunks(iter_openai_frames(engine_sse()))]
+    assert chunks[-1]["error"]["status"] == "RESOURCE_EXHAUSTED"
+    assert state["exit"] == "completed"

--- a/tests/unit/test_gemini_stream_transform.py
+++ b/tests/unit/test_gemini_stream_transform.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import pytest
 
 from app.protocols.gemini import stream_chunks
-from app.protocols.sse import iter_openai_frames
+from app.protocols.sse import OpenAIFrameStream
 
 
 async def _agen(items):
@@ -149,6 +149,26 @@ async def test_error_frame_drains_engine_source_instead_of_closing_it():
             state["exit"] = "generator_exit"
             raise
 
-    chunks = [c async for c in stream_chunks(iter_openai_frames(engine_sse()))]
+    chunks = [c async for c in stream_chunks(OpenAIFrameStream(engine_sse()))]
     assert chunks[-1]["error"]["status"] == "RESOURCE_EXHAUSTED"
     assert state["exit"] == "completed"
+
+
+async def test_final_chunk_reaches_the_client_before_the_engine_writeback():
+    """Ordering regression: resuming the engine past [DONE] runs its
+    RequestLog commit, which must not sit between the last content chunk
+    and the terminal finishReason chunk."""
+    order: list[str] = []
+
+    async def engine_sse():
+        yield 'data: {"id":"c1","model":"m","choices":[{"index":0,' \
+              '"delta":{"content":"hi"},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+        order.append("engine_writeback")
+
+    async for chunk in stream_chunks(OpenAIFrameStream(engine_sse())):
+        order.append(
+            "final" if "usageMetadata" in chunk else "content"
+        )
+
+    assert order == ["content", "final", "engine_writeback"]

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -138,6 +138,51 @@ def test_tool_config_any_with_single_allowed_name_pins_function():
     assert out["tool_choice"] == {"type": "function", "function": {"name": "f"}}
 
 
+def test_empty_model_turn_keeps_empty_content():
+    """Regression: a model turn with empty/missing parts (safety-filtered
+    or compacted history echoes) must not become content=None with no
+    tool_calls — the engine's exclude_none dump would send a bare
+    {"role": "assistant"}, which upstreams reject."""
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "hi"}]},
+        {"role": "model", "parts": []},
+        {"role": "user", "parts": [{"text": "and?"}]},
+    ]})
+    assert out["messages"][1] == {"role": "assistant", "content": ""}
+
+
+def test_thought_parts_dropped_payload_parts_kept():
+    """Thought(-summary)/signature parts are dropped like Anthropic
+    thinking blocks; a functionCall carrying a thoughtSignature is a real
+    payload and survives. A thought-only turn keeps content ""."""
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "hi"}]},
+        {"role": "model", "parts": [
+            {"thought": True, "text": "internal reasoning"},
+            {"thoughtSignature": "sig"},
+            {"functionCall": {"name": "f", "args": {"x": 1}}, "thoughtSignature": "sig2"},
+        ]},
+        {"role": "user", "parts": [{"functionResponse": {"name": "f", "response": {}}}]},
+    ]})
+    model_msg = out["messages"][1]
+    assert model_msg["tool_calls"][0]["function"]["name"] == "f"
+    assert "internal reasoning" not in json.dumps(out)  # thought text never leaks
+
+    thought_only = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "hi"}]},
+        {"role": "model", "parts": [{"thought": True, "text": "internal"}]},
+    ]})
+    assert thought_only["messages"][1] == {"role": "assistant", "content": ""}
+
+
+def test_stop_sequences_truncated_to_openai_cap():
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "generationConfig": {"stopSequences": ["a", "b", "c", "d", "e"]},
+    })
+    assert out["stop"] == ["a", "b", "c", "d"]
+
+
 def test_tool_config_any_with_multiple_names_constrains_tools_to_subset():
     """Google's ANY + allowedFunctionNames means "must call one of THESE";
     OpenAI "required" alone means "must call some tool", so the declared

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -1,0 +1,272 @@
+"""Gemini API translation — pure-function unit tests (slice S6).
+
+Request direction: Gemini wire format → internal OpenAI dict (camelCase
+AND snake_case accepted, proto type enums normalized).
+Response direction: OpenAI response dict → GenerateContentResponse dict.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from app.protocols.gemini import (
+    GeminiGenerateRequest,
+    normalize_gemini_schema,
+    to_gemini_response,
+    to_openai_request,
+)
+
+
+def _translate(payload: dict, model: str = "gemini-1.5-flash", stream: bool = False) -> dict:
+    req = GeminiGenerateRequest.model_validate(payload)
+    return to_openai_request(req, model=model, stream=stream)
+
+
+# ── Request translation ──
+
+
+def test_text_contents_and_roles():
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "hi"}]},
+        {"role": "model", "parts": [{"text": "hello"}]},
+        {"parts": [{"text": "no role defaults to user"}]},
+    ]})
+    assert out["model"] == "gemini-1.5-flash"
+    assert out["stream"] is False
+    assert out["messages"] == [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "hello"},
+        {"role": "user", "content": "no role defaults to user"},
+    ]
+
+
+def test_inline_data_camel_and_snake_become_data_uri():
+    for key, mime_key in (("inlineData", "mimeType"), ("inline_data", "mime_type")):
+        out = _translate({"contents": [{
+            "role": "user",
+            "parts": [{"text": "look"}, {key: {mime_key: "image/png", "data": "aGk="}}],
+        }]})
+        parts = out["messages"][0]["content"]
+        assert parts[1] == {
+            "type": "image_url",
+            "image_url": {"url": "data:image/png;base64,aGk="},
+        }
+
+
+def test_system_instruction_camel_and_snake():
+    camel = _translate({
+        "systemInstruction": {"parts": [{"text": "be brief"}]},
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+    })
+    snake = _translate({
+        "system_instruction": {"parts": [{"text": "be brief"}]},
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+    })
+    for out in (camel, snake):
+        assert out["messages"][0] == {"role": "system", "content": "be brief"}
+
+
+def test_function_declarations_normalize_uppercase_type_enums():
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "tools": [{"functionDeclarations": [{
+            "name": "get_weather",
+            "description": "d",
+            "parameters": {
+                "type": "OBJECT",
+                "properties": {"city": {"type": "STRING"},
+                               "days": {"type": "INTEGER"}},
+                "required": ["city"],
+            },
+        }]}],
+    })
+    (tool,) = out["tools"]
+    params = tool["function"]["parameters"]
+    assert params["type"] == "object"
+    assert params["properties"]["city"]["type"] == "string"
+    assert params["properties"]["days"]["type"] == "integer"
+    assert params["required"] == ["city"]
+
+
+def test_schema_normalization_recurses_and_spares_property_named_type():
+    schema = {
+        "type": "OBJECT",
+        "properties": {
+            "type": {"type": "STRING", "enum": ["A", "B"]},
+            "items": {"type": "ARRAY", "items": {"type": "NUMBER"}},
+        },
+    }
+    norm = normalize_gemini_schema(schema)
+    assert norm["type"] == "object"
+    assert norm["properties"]["type"]["type"] == "string"
+    assert norm["properties"]["type"]["enum"] == ["A", "B"]  # enum values untouched
+    assert norm["properties"]["items"]["items"]["type"] == "number"
+
+
+def test_server_side_tools_rejected():
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "tools": [{"googleSearch": {}}],
+        })
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.parametrize("mode,expected", [
+    ("AUTO", "auto"),
+    ("NONE", "none"),
+    ("ANY", "required"),
+])
+def test_tool_config_modes(mode, expected):
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "toolConfig": {"functionCallingConfig": {"mode": mode}},
+    })
+    assert out["tool_choice"] == expected
+
+
+def test_tool_config_any_with_single_allowed_name_pins_function():
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "tool_config": {"function_calling_config": {
+            "mode": "ANY", "allowed_function_names": ["f"],
+        }},
+    })
+    assert out["tool_choice"] == {"type": "function", "function": {"name": "f"}}
+
+
+def test_generation_config_full_mapping():
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "generationConfig": {
+            "temperature": 0.3, "topP": 0.8, "topK": 40,
+            "maxOutputTokens": 256, "stopSequences": ["END"], "seed": 7,
+            "responseMimeType": "application/json",
+        },
+    })
+    assert out["temperature"] == 0.3
+    assert out["top_p"] == 0.8
+    assert out["max_tokens"] == 256
+    assert out["stop"] == ["END"]
+    assert out["seed"] == 7
+    assert out["response_format"] == {"type": "json_object"}
+    assert "top_k" not in out and "topK" not in out
+
+
+def test_candidate_count_above_one_rejected():
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {"candidateCount": 2},
+        })
+    assert exc.value.status_code == 400
+
+
+def test_function_call_history_gets_synthetic_ids_paired_with_responses():
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "weather in SF and NY"}]},
+        {"role": "model", "parts": [
+            {"functionCall": {"name": "get_weather", "args": {"city": "SF"}}},
+            {"functionCall": {"name": "get_weather", "args": {"city": "NY"}}},
+        ]},
+        {"role": "user", "parts": [
+            {"functionResponse": {"name": "get_weather", "response": {"temp": 72}}},
+            {"functionResponse": {"name": "get_weather", "response": {"temp": 55}}},
+        ]},
+    ]})
+    assistant = out["messages"][1]
+    ids = [tc["id"] for tc in assistant["tool_calls"]]
+    assert len(set(ids)) == 2
+    assert json.loads(assistant["tool_calls"][0]["function"]["arguments"]) == {"city": "SF"}
+
+    tool_msgs = out["messages"][2:4]
+    # earliest unmatched call pairs first (positional semantics)
+    assert [m["tool_call_id"] for m in tool_msgs] == ids
+    assert json.loads(tool_msgs[0]["content"]) == {"temp": 72}
+
+
+def test_file_data_and_cached_content_rejected():
+    with pytest.raises(HTTPException):
+        _translate({"contents": [{
+            "role": "user",
+            "parts": [{"fileData": {"fileUri": "gs://x"}}],
+        }]})
+    with pytest.raises(HTTPException):
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "cachedContent": "cachedContents/123",
+        })
+
+
+def test_invalid_role_rejected():
+    with pytest.raises(HTTPException) as exc:
+        _translate({"contents": [{"role": "function", "parts": [{"text": "x"}]}]})
+    assert exc.value.status_code == 400
+
+
+def test_bare_string_contents_wraps_to_user_message():
+    out = _translate({"contents": "just a prompt"})
+    assert out["messages"] == [{"role": "user", "content": "just a prompt"}]
+
+
+# ── Response translation ──
+
+
+def _openai_response(**overrides) -> dict:
+    base = {
+        "id": "chatcmpl-1",
+        "model": "gemini-1.5-flash",
+        "choices": [{
+            "index": 0,
+            "message": {"role": "assistant", "content": "Hello world"},
+            "finish_reason": "stop",
+        }],
+        "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+    }
+    base.update(overrides)
+    return base
+
+
+def test_text_response_maps_to_gemini_shape():
+    out = to_gemini_response(_openai_response())
+    (cand,) = out["candidates"]
+    assert cand["content"] == {"role": "model", "parts": [{"text": "Hello world"}]}
+    assert cand["finishReason"] == "STOP"
+    assert out["usageMetadata"] == {
+        "promptTokenCount": 4, "candidatesTokenCount": 2, "totalTokenCount": 6,
+    }
+    assert out["modelVersion"] == "gemini-1.5-flash"
+    assert out["responseId"] == "chatcmpl-1"
+
+
+def test_tool_calls_become_function_call_parts():
+    out = to_gemini_response(_openai_response(choices=[{
+        "index": 0,
+        "message": {
+            "role": "assistant", "content": None,
+            "tool_calls": [{
+                "id": "call_1", "type": "function",
+                "function": {"name": "get_weather", "arguments": '{"city": "SF"}'},
+            }],
+        },
+        "finish_reason": "tool_calls",
+    }]))
+    (cand,) = out["candidates"]
+    assert cand["content"]["parts"] == [
+        {"functionCall": {"name": "get_weather", "args": {"city": "SF"}}},
+    ]
+    assert cand["finishReason"] == "STOP"
+
+
+@pytest.mark.parametrize("finish,expected", [
+    ("length", "MAX_TOKENS"),
+    ("content_filter", "SAFETY"),
+    (None, "STOP"),
+])
+def test_finish_reason_mapping(finish, expected):
+    resp = _openai_response()
+    resp["choices"][0]["finish_reason"] = finish
+    assert to_gemini_response(resp)["candidates"][0]["finishReason"] == expected

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -106,6 +106,25 @@ def test_schema_normalization_recurses_and_spares_property_named_type():
     assert norm["properties"]["items"]["items"]["type"] == "number"
 
 
+@pytest.mark.parametrize("tools", [
+    # a single declaration sent as a bare object instead of a list: the
+    # loop would iterate the dict's KEYS and AttributeError into a 500
+    [{"functionDeclarations": {"name": "foo", "parameters": {}}}],
+    [{"functionDeclarations": ["not-an-object"]}],
+    [{"functionDeclarations": [{"name": {"nested": 1}}]}],
+    [{"functionDeclarations": [{"name": "f", "parameters": "not-a-schema"}]}],
+])
+def test_malformed_function_declarations_render_native_400(tools):
+    """Google's API 400s these; a 500 would make SDKs back off and retry a
+    request that can never succeed."""
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "tools": tools,
+        })
+    assert exc.value.status_code == 400
+
+
 def test_server_side_tools_rejected():
     with pytest.raises(HTTPException) as exc:
         _translate({
@@ -173,6 +192,32 @@ def test_thought_parts_dropped_payload_parts_kept():
         {"role": "model", "parts": [{"thought": True, "text": "internal"}]},
     ]})
     assert thought_only["messages"][1] == {"role": "assistant", "content": ""}
+
+
+def test_thought_flagged_part_keeps_its_payload():
+    """Regression: `thought` is part METADATA that can sit next to a real
+    payload (Google attaches signatures to functionCall parts and requires
+    them echoed back). Dropping the whole part would silently delete a
+    tool call from the turn — a wrong answer, not a rejection. Only the
+    thought text goes."""
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "hi"}]},
+        {"role": "model", "parts": [
+            {"thought": True, "text": "reasoning", "functionCall": {
+                "name": "f", "args": {"x": 1},
+            }},
+        ]},
+        {"role": "user", "parts": [
+            {"thought": True, "functionResponse": {"name": "f", "response": {"ok": 1}}},
+        ]},
+    ]})
+    model_msg = out["messages"][1]
+    assert model_msg["tool_calls"][0]["function"]["name"] == "f"
+    assert model_msg["content"] is None or "reasoning" not in model_msg["content"]
+    assert "reasoning" not in json.dumps(out)  # thought text never leaks
+    # the paired tool response survives too
+    assert out["messages"][2]["role"] == "tool"
+    assert json.loads(out["messages"][2]["content"]) == {"ok": 1}
 
 
 def test_stop_sequences_truncated_to_openai_cap():

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -138,6 +138,23 @@ def test_tool_config_any_with_single_allowed_name_pins_function():
     assert out["tool_choice"] == {"type": "function", "function": {"name": "f"}}
 
 
+@pytest.mark.parametrize("fcc", [
+    {"mode": {"x": 1}},                                     # mode not a string
+    {"mode": "ANY", "allowedFunctionNames": {"f": {}}},     # names not a list
+    {"mode": "ANY", "allowedFunctionNames": [{"name": "f"}]},  # entry not a string
+])
+def test_tool_config_wrong_field_types_render_native_400(fcc):
+    """toolConfig is free-form in the wire schema; wrong field types must
+    raise the native 400, not an AttributeError/KeyError that the route's
+    blanket except turns into a 500."""
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "toolConfig": {"functionCallingConfig": fcc},
+        })
+    assert exc.value.status_code == 400
+
+
 def test_generation_config_full_mapping():
     out = _translate({
         "contents": [{"role": "user", "parts": [{"text": "hi"}]}],

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -419,6 +419,41 @@ def test_text_response_maps_to_gemini_shape():
     assert out["responseId"] == "chatcmpl-1"
 
 
+def test_multipart_list_content_flattens_to_a_text_part():
+    """The OpenAI wire format allows a response message's content to be a
+    list of parts. Emitting it verbatim would produce a text part whose
+    `text` is an array, which google-genai cannot parse."""
+    out = to_gemini_response(_openai_response(choices=[{
+        "index": 0,
+        "message": {"role": "assistant", "content": [
+            {"type": "text", "text": "Hello "},
+            {"type": "text", "text": "world"},
+        ]},
+        "finish_reason": "stop",
+    }]))
+    assert out["candidates"][0]["content"]["parts"] == [{"text": "Hello world"}]
+
+
+def test_non_text_system_instruction_parts_are_logged_when_dropped():
+    """systemInstruction is text in every documented use, but a dropped
+    part must not vanish silently — the Anthropic sibling logs too."""
+    from structlog.testing import capture_logs
+
+    with capture_logs() as logs:
+        out = _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "systemInstruction": {"parts": [
+                {"text": "be terse"},
+                {"inlineData": {"mimeType": "image/png", "data": "AAAA"}},
+            ]},
+        })
+    assert out["messages"][0] == {"role": "system", "content": "be terse"}
+    assert any(
+        e["event"] == "gemini_non_text_system_part_dropped" and e["count"] == 1
+        for e in logs
+    )
+
+
 def test_tool_calls_become_function_call_parts():
     out = to_gemini_response(_openai_response(choices=[{
         "index": 0,

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -248,6 +248,25 @@ def test_generation_config_full_mapping():
     assert "top_k" not in out and "topK" not in out
 
 
+@pytest.mark.parametrize("field,value", [
+    ("temperature", 2.5),
+    ("temperature", -0.5),
+    ("temperature", "hot"),
+    ("topP", 1.5),
+    ("topP", -1),
+])
+def test_out_of_range_sampling_params_rejected(field, value):
+    """Out-of-range values are rejected by the upstream as a BadRequest,
+    which reaches the caller as a retryable 500/503 — bound them here so
+    the failure stays an honest native 400."""
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {field: value},
+        })
+    assert exc.value.status_code == 400
+
+
 @pytest.mark.parametrize("value", [0, -5, 1.5, "100", True])
 def test_non_positive_max_output_tokens_rejected(value):
     """A budget < 1 (or a non-integral one) can never succeed upstream;

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -248,6 +248,27 @@ def test_generation_config_full_mapping():
     assert "top_k" not in out and "topK" not in out
 
 
+@pytest.mark.parametrize("value", [0, -5, 1.5, "100", True])
+def test_non_positive_max_output_tokens_rejected(value):
+    """A budget < 1 (or a non-integral one) can never succeed upstream;
+    rejecting it here keeps it a native 400 instead of a retryable 500."""
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "generationConfig": {"maxOutputTokens": value},
+        })
+    assert exc.value.status_code == 400
+
+
+def test_integral_float_max_output_tokens_accepted():
+    """JSON numbers may decode as floats — 256.0 is a valid budget."""
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "generationConfig": {"maxOutputTokens": 256.0},
+    })
+    assert out["max_tokens"] == 256
+
+
 def test_candidate_count_above_one_rejected():
     with pytest.raises(HTTPException) as exc:
         _translate({

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -138,6 +138,36 @@ def test_tool_config_any_with_single_allowed_name_pins_function():
     assert out["tool_choice"] == {"type": "function", "function": {"name": "f"}}
 
 
+def test_tool_config_any_with_multiple_names_constrains_tools_to_subset():
+    """Google's ANY + allowedFunctionNames means "must call one of THESE";
+    OpenAI "required" alone means "must call some tool", so the declared
+    tools must be restricted to the allowed subset (undeclared allowed
+    names are ignored, lenient)."""
+    out = _translate({
+        "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+        "tools": [{"functionDeclarations": [
+            {"name": "a"}, {"name": "b"}, {"name": "c"},
+        ]}],
+        "toolConfig": {"functionCallingConfig": {
+            "mode": "ANY", "allowedFunctionNames": ["c", "a", "ghost"],
+        }},
+    })
+    assert out["tool_choice"] == "required"
+    assert [t["function"]["name"] for t in out["tools"]] == ["a", "c"]
+
+
+def test_tool_config_any_with_no_matching_names_rejected():
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "tools": [{"functionDeclarations": [{"name": "a"}]}],
+            "toolConfig": {"functionCallingConfig": {
+                "mode": "ANY", "allowedFunctionNames": ["x", "y"],
+            }},
+        })
+    assert exc.value.status_code == 400
+
+
 @pytest.mark.parametrize("fcc", [
     {"mode": {"x": 1}},                                     # mode not a string
     {"mode": "ANY", "allowedFunctionNames": {"f": {}}},     # names not a list

--- a/tests/unit/test_gemini_translation.py
+++ b/tests/unit/test_gemini_translation.py
@@ -482,3 +482,55 @@ def test_finish_reason_mapping(finish, expected):
     resp = _openai_response()
     resp["choices"][0]["finish_reason"] = finish
     assert to_gemini_response(resp)["candidates"][0]["finishReason"] == expected
+
+
+def test_empty_text_system_part_is_not_counted_as_dropped():
+    """The dropped-part diagnostic must count only genuinely non-text
+    parts: `{"text": ""}` IS a text part (nothing dropped), so it must
+    neither fire the warning nor inflate the count — the Anthropic
+    sibling already counts this way."""
+    from structlog.testing import capture_logs
+
+    with capture_logs() as logs:
+        out = _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "systemInstruction": {"parts": [{"text": "be terse"}, {"text": ""}]},
+        })
+    assert out["messages"][0] == {"role": "system", "content": "be terse"}
+    assert not any(e["event"] == "gemini_non_text_system_part_dropped" for e in logs)
+
+    with capture_logs() as logs:
+        _translate({
+            "contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+            "systemInstruction": {"parts": [
+                {"text": ""},
+                {"inlineData": {"mimeType": "image/png", "data": "AAAA"}},
+                "not-even-an-object",
+            ]},
+        })
+    dropped = [e for e in logs if e["event"] == "gemini_non_text_system_part_dropped"]
+    assert [e["count"] for e in dropped] == [2]
+
+
+@pytest.mark.parametrize("payload", [
+    {"contents": [{"role": "user", "parts": [{"text": 123}]}]},
+    {"contents": [{"role": "user", "parts": [{"text": "hi"}]}],
+     "systemInstruction": {"parts": [{"text": ["x"]}]}},
+])
+def test_non_string_text_parts_render_native_400(payload):
+    """A non-string text used to crash the message join (a 500 the SDK
+    retries) instead of the honest native 400."""
+    with pytest.raises(HTTPException) as exc:
+        _translate(payload)
+    assert exc.value.status_code == 400
+
+
+def test_function_declaration_with_non_string_description_rejected():
+    with pytest.raises(HTTPException) as exc:
+        _translate({
+            "contents": "hi",
+            "tools": [{"functionDeclarations": [
+                {"name": "f", "description": 42, "parameters": {"type": "OBJECT"}},
+            ]}],
+        })
+    assert exc.value.status_code == 400

--- a/tests/unit/test_hosted_alias_deployments.py
+++ b/tests/unit/test_hosted_alias_deployments.py
@@ -1,0 +1,76 @@
+"""Hosted wire-id aliases are ONE upstream under two names (PR #64 round 4).
+
+`build_deployments` registers both the bare id ("free") and the wire id
+("orcarouter/free") so either spelling routes. LiteLLM Router derives a
+deployment id per entry, so without pinning it the two names carry
+independent cooldown / allowed-fails state: a dead upstream gets probed
+(and paid for) once per alias before each spelling cools down.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from packages.litellm_adapter.client import OrcaLiteLLMClient
+from packages.litellm_adapter.hosted_catalog import HOSTED_MODEL_ALIASES
+from packages.litellm_adapter.types import ProviderDeployment
+
+
+def test_aliased_hosted_models_share_one_deployment_id(monkeypatch):
+    from app import config as cfg
+    from app import router_cache
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-hosted")
+    cfg.get_settings.cache_clear()
+    try:
+        deployments = router_cache.build_deployments(
+            env_keys={}, db_keys=[], settings=cfg.get_settings(),
+        )
+    finally:
+        cfg.get_settings.cache_clear()
+
+    by_name = {d.model_name: d for d in deployments}
+    assert HOSTED_MODEL_ALIASES, "expected at least one aliased hosted model"
+    for wire_id in HOSTED_MODEL_ALIASES:
+        bare_id = wire_id.split("/", 1)[1]
+        assert wire_id in by_name and bare_id in by_name
+        # same upstream → same pinned id → shared cooldown/health state
+        assert by_name[wire_id].litellm_model == by_name[bare_id].litellm_model
+        assert by_name[wire_id].deployment_id == by_name[bare_id].deployment_id
+        assert by_name[wire_id].deployment_id
+
+
+def test_pinned_deployment_id_reaches_the_litellm_router():
+    """LiteLLM would otherwise hash a distinct id per entry — the two names
+    must resolve to the same deployment id in the built Router."""
+    pytest.importorskip("litellm")
+    shared = "hosted::orcarouter/free"
+    client = OrcaLiteLLMClient(
+        [
+            ProviderDeployment(
+                model_name=name, litellm_model="orcarouter/free", api_key="k",
+                api_base="http://localhost:1", provider="orcarouter",
+                custom_llm_provider="openai", deployment_id=shared,
+            )
+            for name in ("free", "orcarouter/free")
+        ],
+        cooldown_time=0,
+    )
+    ids = {
+        d["model_name"]: d["model_info"]["id"] for d in client._router.get_model_list()
+    }
+    assert ids == {"free": shared, "orcarouter/free": shared}
+
+
+def test_unpinned_deployments_keep_litellms_own_ids():
+    pytest.importorskip("litellm")
+    client = OrcaLiteLLMClient(
+        [ProviderDeployment(
+            model_name="gpt-4o-mini", litellm_model="openai/gpt-4o-mini", api_key="k",
+            provider="openai",
+        )],
+        cooldown_time=0,
+    )
+    entry = client._router.get_model_list()[0]
+    assert entry["model_info"]["id"]  # generated, not ours
+    assert not entry["model_info"]["id"].startswith("hosted::")

--- a/tests/unit/test_model_turn_translation.py
+++ b/tests/unit/test_model_turn_translation.py
@@ -1,0 +1,68 @@
+"""Gemini model-turn parts and the role-less Content form.
+
+A `role:"model"` turn is translated into an OpenAI assistant message, which
+carries only text and tool calls — so `inlineData` and `functionResponse`
+parts had nowhere to go and were dropped without a word (a functionResponse
+even consumed a pending call id, mispairing a later genuine response). Both
+are now rejected, mirroring the functionCall-in-a-user-turn rule.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.protocols.gemini import GeminiGenerateRequest
+from app.protocols.gemini import to_openai_request as translate
+
+
+def _translate(payload: dict) -> dict:
+    return translate(GeminiGenerateRequest.model_validate(payload), model="m", stream=False)
+
+
+@pytest.mark.parametrize("part", [
+    {"inlineData": {"mimeType": "image/png", "data": "AAAA"}},
+    {"inline_data": {"mime_type": "image/png", "data": "AAAA"}},
+    {"functionResponse": {"name": "f", "response": {"ok": True}}},
+    {"function_response": {"name": "f", "response": {"ok": True}}},
+])
+def test_unrepresentable_model_turn_parts_are_rejected(part):
+    with pytest.raises(HTTPException) as exc:
+        _translate({"contents": [
+            {"role": "user", "parts": [{"text": "hi"}]},
+            {"role": "model", "parts": [part]},
+        ]})
+    assert exc.value.status_code == 400
+
+
+def test_model_turn_text_and_function_call_still_translate():
+    out = _translate({"contents": [
+        {"role": "user", "parts": [{"text": "weather?"}]},
+        {"role": "model", "parts": [
+            {"text": "checking"},
+            {"functionCall": {"name": "get_weather", "args": {"city": "SF"}}},
+        ]},
+        {"role": "user", "parts": [
+            {"functionResponse": {"name": "get_weather", "response": {"c": 20}}}]},
+    ]})
+    assert [m["role"] for m in out["messages"]] == ["user", "assistant", "tool"]
+    call = out["messages"][1]["tool_calls"][0]
+    assert call["function"]["name"] == "get_weather"
+    # the response pairs to that call's synthesized id
+    assert out["messages"][2]["tool_call_id"] == call["id"]
+
+
+def test_role_less_content_with_a_function_call_is_read_as_a_model_turn():
+    """`role` is optional in the REST API; a turn carrying functionCall can
+    only be the model's, so it must not be rejected as a user turn."""
+    out = _translate({"contents": [
+        {"parts": [{"text": "weather?"}]},
+        {"parts": [{"functionCall": {"name": "get_weather", "args": {}}}]},
+        {"parts": [{"functionResponse": {"name": "get_weather", "response": {"c": 20}}}]},
+    ]})
+    assert [m["role"] for m in out["messages"]] == ["user", "assistant", "tool"]
+
+
+def test_role_less_plain_content_is_still_a_user_turn():
+    out = _translate({"contents": [{"parts": [{"text": "hi"}]}]})
+    assert out["messages"] == [{"role": "user", "content": "hi"}]

--- a/tests/unit/test_prompt_cache.py
+++ b/tests/unit/test_prompt_cache.py
@@ -76,6 +76,10 @@ def test_cache_key_differs_on_model():
     ("tool_choice", {"type": "function", "function": {"name": "f"}}),
     ("top_p", 0.5),
     ("n", 2),
+    # Both shift the logits before decoding, so they change the output
+    # even at temperature 0 — the only case that is cacheable at all.
+    ("presence_penalty", 1.5),
+    ("frequency_penalty", 1.5),
 ])
 def test_cache_key_differs_on_every_output_shaping_parameter(field, other):
     """Regression: the key covered only model/messages/temperature/tools/
@@ -111,14 +115,30 @@ def test_should_cache_skips_streaming_and_high_temperature():
 
     base = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]}
 
-    # Cacheable: temp=0 (or unset, defaults to 0 for safety) and not streaming
+    # Cacheable: an explicit temp=0, not streaming
     assert is_cacheable({**base, "temperature": 0.0, "stream": False}) is True
-    assert is_cacheable({**base, "stream": False}) is True  # temp unset → treat as deterministic
+    assert is_cacheable({**base, "temperature": 0, "stream": False}) is True
 
     # Not cacheable
     assert is_cacheable({**base, "stream": True}) is False
     assert is_cacheable({**base, "temperature": 0.7}) is False
     assert is_cacheable({**base, "temperature": 0.1}) is False
+
+
+def test_absent_temperature_is_not_treated_as_deterministic():
+    """Regression: an omitted temperature was assumed to be 0. Every
+    upstream defaults it to 1.0 (OpenAI, Anthropic, Gemini), so the
+    response is a sample — caching it replays one arbitrary sample to
+    every later caller. The native surfaces only forward a temperature
+    the client actually sent, and Claude Code never sends one, so this
+    was the default path for the new ingress."""
+    from app.prompt_cache import is_cacheable
+
+    base = {"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]}
+    assert is_cacheable(base) is False
+    assert is_cacheable({**base, "temperature": None}) is False
+    # ...unless a seed pins the sample
+    assert is_cacheable({**base, "seed": 7}) is True
 
 
 def test_should_cache_skips_when_seed_unspecified_with_high_temp():

--- a/tests/unit/test_prompt_cache.py
+++ b/tests/unit/test_prompt_cache.py
@@ -96,6 +96,21 @@ def test_cache_key_differs_on_every_output_shaping_parameter(field, other):
     assert cache_key(**base) != cache_key(**base, **{field: other})
 
 
+def test_cache_key_distinguishes_absent_temperature_from_explicit_zero():
+    """Regression: an absent temperature was normalized to 0.0 in the key.
+    Both forms are cacheable when a seed pins them, but they are different
+    computations — the upstream defaults an absent temperature to 1.0 (a
+    seeded sample) while 0 is the greedy argmax — so sharing one entry
+    served one caller the other's response."""
+    from app.prompt_cache import cache_key
+
+    base = dict(
+        model="m", messages=[{"role": "user", "content": "hi"}],
+        tools=None, response_format=None, seed=7,
+    )
+    assert cache_key(**base, temperature=None) != cache_key(**base, temperature=0.0)
+
+
 def test_cache_key_ignores_user_identifier():
     """`user` is an abuse-monitoring hint that does not change the
     completion; keying on it would fragment the cache per caller."""

--- a/tests/unit/test_prompt_cache.py
+++ b/tests/unit/test_prompt_cache.py
@@ -114,14 +114,20 @@ def test_cache_key_distinguishes_absent_temperature_from_explicit_zero():
 def test_cache_key_ignores_user_identifier():
     """`user` is an abuse-monitoring hint that does not change the
     completion; keying on it would fragment the cache per caller."""
+    import inspect
+
     from app.prompt_cache import cache_key
 
+    # `user` is not even an input to the key — the caller (chat.py) cannot
+    # feed it in by accident, so two callers' identical requests share.
+    assert "user" not in inspect.signature(cache_key).parameters
     base = dict(
         model="m", messages=[{"role": "user", "content": "hi"}],
         temperature=0.0, tools=None, response_format=None, seed=None,
         max_tokens=64,
     )
-    assert cache_key(**base) == cache_key(**base)
+    with pytest.raises(TypeError):
+        cache_key(**base, user="alice")
 
 
 def test_should_cache_skips_streaming_and_high_temperature():

--- a/tests/unit/test_prompt_cache.py
+++ b/tests/unit/test_prompt_cache.py
@@ -1,8 +1,9 @@
 """Cross-provider prompt cache.
 
 LiteLLM only does prompt caching for Anthropic. Lite ships an exact-match
-cache that works for any provider — same (model, messages, temperature,
-tools, response_format, seed) → cached response, no upstream call.
+cache that works for any provider — same request inputs (every parameter
+that shapes the completion, not just the prompt) → cached response, no
+upstream call.
 
 Backed by Redis when REDIS_URL is set, falls back to an in-process LRU
 otherwise so it works in single-pod docker-compose / on a laptop.
@@ -67,6 +68,41 @@ def test_cache_key_differs_on_model():
     b = cache_key(model="claude-3-5-sonnet-latest", messages=msgs,
                   temperature=0.0, tools=None, response_format=None, seed=None)
     assert a != b
+
+
+@pytest.mark.parametrize("field,other", [
+    ("max_tokens", 4096),
+    ("stop", ["END"]),
+    ("tool_choice", {"type": "function", "function": {"name": "f"}}),
+    ("top_p", 0.5),
+    ("n", 2),
+])
+def test_cache_key_differs_on_every_output_shaping_parameter(field, other):
+    """Regression: the key covered only model/messages/temperature/tools/
+    response_format/seed, so two requests differing solely in max_tokens,
+    stop or tool_choice collided — the second was served the first's
+    response (truncated, or prose where a tool call was forced). The
+    native surfaces send these on every request."""
+    from app.prompt_cache import cache_key
+
+    base = dict(
+        model="m", messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0, tools=None, response_format=None, seed=None,
+    )
+    assert cache_key(**base) != cache_key(**base, **{field: other})
+
+
+def test_cache_key_ignores_user_identifier():
+    """`user` is an abuse-monitoring hint that does not change the
+    completion; keying on it would fragment the cache per caller."""
+    from app.prompt_cache import cache_key
+
+    base = dict(
+        model="m", messages=[{"role": "user", "content": "hi"}],
+        temperature=0.0, tools=None, response_format=None, seed=None,
+        max_tokens=64,
+    )
+    assert cache_key(**base) == cache_key(**base)
 
 
 def test_should_cache_skips_streaming_and_high_temperature():

--- a/tests/unit/test_router_cache.py
+++ b/tests/unit/test_router_cache.py
@@ -100,14 +100,17 @@ def test_orcarouter_api_key_adds_hosted_upstream_per_model(monkeypatch):
     """
     from app.config import Settings
     from app.router_cache import build_deployments
-    from packages.litellm_adapter.hosted_catalog import HOSTED_MODELS
+    from packages.litellm_adapter.hosted_catalog import (
+        HOSTED_MODEL_ALIASES,
+        HOSTED_MODELS,
+    )
 
     monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-hosted-xyz")
     s = Settings(_env_file=None)
 
     deps = build_deployments(env_keys={}, db_keys=[], settings=s)
     orca_deps = [d for d in deps if d.provider == "orcarouter"]
-    assert len(orca_deps) == len(HOSTED_MODELS)
+    assert len(orca_deps) == len(HOSTED_MODELS) + len(HOSTED_MODEL_ALIASES)
     for d in orca_deps:
         assert d.api_base == "https://api.orcarouter.ai/v1"
         assert d.api_key == "sk-orca-hosted-xyz"
@@ -138,7 +141,10 @@ def test_orcarouter_db_row_enables_hosted_upstream():
     from app.router_cache import build_deployments
     from packages.auth.encryption import encrypt_credential
     from packages.db.models.provider_key import ProviderKey
-    from packages.litellm_adapter.hosted_catalog import HOSTED_MODELS
+    from packages.litellm_adapter.hosted_catalog import (
+        HOSTED_MODEL_ALIASES,
+        HOSTED_MODELS,
+    )
 
     s = Settings(_env_file=None)
     db_row = ProviderKey(
@@ -150,10 +156,27 @@ def test_orcarouter_db_row_enables_hosted_upstream():
     )
     deps = build_deployments(env_keys={}, db_keys=[db_row], settings=s)
     orca_deps = [d for d in deps if d.provider == "orcarouter"]
-    assert len(orca_deps) == len(HOSTED_MODELS)
+    assert len(orca_deps) == len(HOSTED_MODELS) + len(HOSTED_MODEL_ALIASES)
     for d in orca_deps:
         assert d.api_key == "sk-orca-from-dashboard"
         assert d.api_base == "https://api.orcarouter.ai/v1"
+
+
+def test_hosted_free_models_accept_exact_wire_ids(monkeypatch):
+    """Free hosted IDs copied from O2's model list work unchanged in Lite."""
+    from app.config import Settings
+    from app.router_cache import build_deployments
+    from packages.litellm_adapter.hosted_catalog import HOSTED_MODEL_ALIASES
+
+    monkeypatch.setenv("ORCAROUTER_API_KEY", "sk-orca-hosted-xyz")
+    s = Settings(_env_file=None)
+    deps = build_deployments(env_keys={}, db_keys=[], settings=s)
+
+    by_group = {d.model_name: d for d in deps}
+    assert HOSTED_MODEL_ALIASES <= by_group.keys()
+    for wire_id in HOSTED_MODEL_ALIASES:
+        assert by_group[wire_id].litellm_model == wire_id
+        assert by_group[wire_id].provider == "orcarouter"
 
 
 def test_orcarouter_db_row_overrides_env_key(monkeypatch):

--- a/tests/unit/test_tool_block_validation.py
+++ b/tests/unit/test_tool_block_validation.py
@@ -1,0 +1,56 @@
+"""Tool-block id/name validation in both request translators (PR #64
+round 11): empty or non-string ids reach the upstream as malformed tool
+messages and come back as a retryable 503 — they must fail as a native 400."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.protocols.anthropic import AnthropicMessagesRequest, to_openai_request
+from app.protocols.gemini import GeminiGenerateRequest
+from app.protocols.gemini import to_openai_request as gemini_to_openai
+
+
+@pytest.mark.parametrize("messages", [
+    [{"role": "user", "content": [{"type": "tool_result", "content": "x"}]}],
+    [{"role": "user", "content": [{"type": "tool_result", "tool_use_id": 5, "content": "x"}]}],
+    [{"role": "user", "content": "hi"},
+     {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "input": {}}]}],
+    [{"role": "user", "content": "hi"},
+     {"role": "assistant", "content": [{"type": "tool_use", "id": "t1", "name": "", "input": {}}]}],
+])
+def test_anthropic_malformed_tool_block_ids_render_native_400(messages):
+    req = AnthropicMessagesRequest.model_validate({
+        "model": "m", "max_tokens": 8, "messages": messages,
+    })
+    with pytest.raises(HTTPException) as exc:
+        to_openai_request(req)
+    assert exc.value.status_code == 400
+
+
+def test_anthropic_well_formed_tool_blocks_still_translate():
+    req = AnthropicMessagesRequest.model_validate({
+        "model": "m", "max_tokens": 8, "messages": [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": [
+                {"type": "tool_use", "id": "t1", "name": "f", "input": {"a": 1}}]},
+            {"role": "user", "content": [
+                {"type": "tool_result", "tool_use_id": "t1", "content": "ok"}]},
+        ],
+    })
+    out = to_openai_request(req)
+    assert out["messages"][1]["tool_calls"][0]["function"]["name"] == "f"
+    assert out["messages"][2] == {"role": "tool", "tool_call_id": "t1", "content": "ok"}
+
+
+@pytest.mark.parametrize("contents", [
+    [{"role": "user", "parts": [{"functionCall": {"name": "f", "args": {}}}]}],
+    [{"role": "model", "parts": [{"functionCall": {"args": {}}}]}],
+    [{"role": "model", "parts": [{"functionCall": {"name": 3, "args": {}}}]}],
+])
+def test_gemini_function_call_in_user_turn_or_without_name_rejected(contents):
+    req = GeminiGenerateRequest.model_validate({"contents": contents})
+    with pytest.raises(HTTPException) as exc:
+        gemini_to_openai(req, model="m", stream=False)
+    assert exc.value.status_code == 400


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Let Anthropic SDK / Claude Code and google-genai SDK connect to Lite directly, without any client-side changes, by adding two native protocol endpoints that fully reuse the existing pipeline (auto routing, prompt cache, RequestLog, hosted fallback):

- POST /v1/messages (blocking + SSE streaming) and POST /v1/messages/count_tokens for Anthropic clients
- POST /v1beta/models/{model}:generateContent / :streamGenerateContent (alt=sse and JSON array) and GET /v1beta/models for google-genai

Auth middleware now accepts x-api-key, x-goog-api-key, and ?key= (scoped to /v1beta) in addition to Bearer; 401 errors render per-protocol error envelopes. Also closes a gap where /v1beta routes bypassed authentication.

Bug fixes found during verification:
- auth: close /v1beta auth bypass
- sse: drain engine generator after [DONE] instead of aclose(), which threw GeneratorExit at a suspended yield point and mislogged normally completed streams as 499 disconnects
- anthropic: tolerate role:"system" entries inside messages[] (Claude Code 2.x sends them on internal requests; spec puts system at top level) — translate to OpenAI system messages
- main: guard startup banner against UnicodeEncodeError on GBK-codepage Windows consoles

Tests: +100 (Anthropic 53, Gemini 40, middleware 6, streaming disconnect 1); full suite 403 passed / 0 failed, ruff clean; scripts/smoke_native.py passes 20/20 checks against a live server with official anthropic 1.0.0 and google-genai 2.19.0 SDKs, plus a real Claude Code CLI end-to-end session.

Docs: integrations/claude-code.md, integrations/gemini-sdk.md, README native endpoints section + test table, 12-language README sync, DEMO.md smoke guide.