### PR TITLE
fix(logging): stop writing API key and DB password to the log stream

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -23,7 +23,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     from app.config import get_settings
     from packages.db import session as session_mod
-    from packages.db.engine import dispose_engine, get_engine
+    from packages.db.engine import dispose_engine, get_engine, redacted_url
     from packages.db.models.base import Base
 
     settings = get_settings()
@@ -40,7 +40,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
         ),
     )
     log = structlog.get_logger()
-    log.info("lite_starting", database_url=settings.database_url)
+    # Redact: on the documented Postgres path the raw URL carries the DB
+    # password, and structured logs are retained by hosted aggregators.
+    log.info("lite_starting", database_url=redacted_url(settings.database_url))
 
     engine = get_engine(settings.database_url)
 
@@ -54,7 +56,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with session_mod._session_factory() as s:
         seed = await seed_initial_state(s)
         if seed.created and seed.api_key:
-            log.info("seed_complete", api_key=seed.api_key)
+            # No key material in the structured event: logs are retained by
+            # aggregators. The print() below is the one-time delivery channel.
+            log.info("seed_complete", workspace_id=seed.workspace_id)
             try:
                 print(f"\n  ✓ orcarouter-lite ready. API key: {seed.api_key}\n")
             except UnicodeEncodeError:

--- a/packages/db/engine.py
+++ b/packages/db/engine.py
@@ -5,7 +5,22 @@ SQLite is the default, Postgres opt-in via DATABASE_URL=postgresql+asyncpg://...
 
 from __future__ import annotations
 
+from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+
+def redacted_url(database_url: str) -> str:
+    """URL safe for logging: password replaced, garbage input never echoed.
+
+    Uses SQLAlchemy's own renderer so every driver scheme is handled the
+    same way (`postgresql+asyncpg://user:***@host/db`). Unparseable input
+    degrades to a fixed placeholder instead of being reflected back into
+    logs.
+    """
+    try:
+        return make_url(database_url).render_as_string(hide_password=True)
+    except Exception:
+        return "<unparseable-database-url>"
 
 
 def build_engine(database_url: str) -> AsyncEngine:

--- a/tests/unit/test_log_redaction.py
+++ b/tests/unit/test_log_redaction.py
@@ -1,0 +1,26 @@
+"""redacted_url() must never leak credentials into loggable strings."""
+
+from __future__ import annotations
+
+
+def test_hides_password_on_postgres_style_url():
+    from packages.db.engine import redacted_url
+
+    out = redacted_url("postgresql+asyncpg://user:sup3rsecret@db.example.com:5432/orca")
+    assert "sup3rsecret" not in out
+    assert out.startswith("postgresql+asyncpg://user:")
+    assert "@db.example.com:5432/orca" in out
+
+
+def test_password_free_url_survives_intact():
+    from packages.db.engine import redacted_url
+
+    url = "sqlite+aiosqlite:///./orca.db"
+    assert redacted_url(url) == url
+
+
+def test_unparseable_input_is_replaced_not_echoed():
+    from packages.db.engine import redacted_url
+
+    garbage = "://not a url at all\x00"
+    assert redacted_url(garbage) == "<unparseable-database-url>"


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Closes #78

- app/main.py: lite_starting now logs redacted_url(settings.database_url) via packages.db.engine.redacted_url (hide_password=True); seed_complete now logs workspace_id only, keeps print() as one-time delivery channel with GBK-safe fallback
- packages/db/engine.py: new redacted_url() helper using make_url(...).render_as_string(hide_password=True); unparseable URLs degrade to fixed placeholder instead of echoing raw input

Independent PR split from fix/startup-secret-logging. Rebased on 9021c8f.

Tests: tests/unit/test_log_redaction.py (3), ruff clean