### PR TITLE
fix(auth): fail closed on dev key and version blobs

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,9 +52,16 @@ class Settings(BaseSettings):
     port: int = 8000
     log_level: str = "info"
 
-    # ── Encryption (auto-generated on first run if empty) ──
+    # ── Encryption ──
+    # NOTE: credential_encryption_key is NOT auto-generated. If empty, the
+    # app seals provider keys with a publicly-known dev key (with a loud
+    # warning), and packages.db.guards refuses to boot once real
+    # credentials are at stake. Generate one: `openssl rand -hex 32`.
     credential_encryption_key: str = ""
     api_key_pepper: str = ""
+    # Explicit opt-out from the startup guard that refuses to run with the
+    # publicly-known dev encryption key when real credentials are at stake.
+    allow_insecure_dev_key: bool = False
 
     # ── Provider keys via env (alternative to UI-stored keys) ──
     # Keep in sync with `_PROVIDERS_FROM_ENV` above. Pydantic-settings reads

--- a/app/main.py
+++ b/app/main.py
@@ -47,6 +47,19 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
 
+    # Fail closed before any traffic can be served: refuse to boot when
+    # provider credentials are (or would be) sealed with the publicly-known
+    # dev encryption key. Runs after create_all so a fresh database's empty
+    # provider_keys table counts as "no credentials at risk".
+    from packages.db.guards import assert_credential_encryption_ready
+
+    await assert_credential_encryption_ready(
+        make_session=async_sessionmaker(engine, expire_on_commit=False),
+        database_url=settings.database_url,
+        allow_insecure_dev_key=settings.allow_insecure_dev_key,
+        engine=engine,
+    )
+
     session_mod._session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
     from app.seed import seed_initial_state

--- a/packages/auth/encryption.py
+++ b/packages/auth/encryption.py
@@ -5,21 +5,69 @@ loaded Settings (which honors `.env`) with `os.environ` as a fallback for
 test fixtures that set the env var directly.
 
 If neither yields a key, derives a deterministic dev key from a fixed seed
-so local development doesn't require any setup. **In production, set a real
-64-char hex string** — the dev fallback is publicly known via the source
-code, so anyone with read access to the SQLite file could decrypt provider
-keys with it.
+so local development doesn't require any setup. The dev fallback is
+publicly known via the source code, so anyone with read access to the
+SQLite file could decrypt provider keys with it:
+
+- Every use logs a prominent WARNING (`insecure_dev_encryption_key`).
+- `packages.db.guards.assert_credential_encryption_ready` fail-closes at
+  startup when the fallback would protect real credentials (existing
+  provider rows, or any non-SQLite database) unless
+  ORCA_ALLOW_INSECURE_DEV_KEY=1 is set explicitly.
+
+Ciphertext format:
+
+- v1 (current): ``b"\\x01" + nonce(12) + ciphertext+tag``
+- legacy:       ``nonce(12) + ciphertext+tag`` (no version byte)
+
+Decrypt auto-detects. A legacy blob whose first nonce byte happens to be
+``0x01`` (~0.4% of legacy blobs) is attempted as v1 first and falls back
+to the legacy parse when authentication fails, so upgrades never brick
+stored credentials.
 """
 
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 
+from cryptography.exceptions import InvalidTag
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+logger = logging.getLogger("orca.encryption")
+
+VERSION_BYTE = b"\x01"
+_NONCE_LEN = 12
+_TAG_LEN = 16
+
+_dev_fallback_warned = False
+
+
+def _warn_dev_fallback_once() -> None:
+    global _dev_fallback_warned
+    if _dev_fallback_warned:
+        return
+    _dev_fallback_warned = True
+    logger.warning(
+        "insecure_dev_encryption_key: CREDENTIAL_ENCRYPTION_KEY is not set; "
+        "provider credentials are being sealed with a PUBLICLY-KNOWN dev "
+        "key. Anyone with read access to the database can decrypt them. "
+        "Generate one with `openssl rand -hex 32` (or set "
+        "ORCA_ALLOW_INSECURE_DEV_KEY=1 to silence this check)."
+    )
 
 
 def _get_encryption_key() -> bytes:
+    key, _source = _resolve_key_material()
+    return key
+
+
+def _resolve_key_material() -> tuple[bytes, str]:
+    """Return (key_bytes, source) where source names how the key was obtained.
+
+    Sources: "config" (Settings/.env), "env" (os.environ), "dev-fallback".
+    """
     # Prefer Settings (which loads .env) over raw os.environ, because
     # pydantic-settings does NOT propagate .env values into os.environ.
     # Without this lookup, a user who follows the README and writes
@@ -33,27 +81,61 @@ def _get_encryption_key() -> bytes:
         # Settings may not be importable in some isolated test contexts;
         # fall through to env-only behavior.
         pass
-    if not key_hex:
-        key_hex = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "")
     if key_hex:
         try:
             raw = bytes.fromhex(key_hex)
             if len(raw) >= 32:
-                return raw[:32]
+                return raw[:32], "config"
         except ValueError:
             pass
-        return hashlib.sha256(key_hex.encode()).digest()
+        return hashlib.sha256(key_hex.encode()).digest(), "config"
+    key_hex = os.environ.get("CREDENTIAL_ENCRYPTION_KEY", "")
+    if key_hex:
+        try:
+            raw = bytes.fromhex(key_hex)
+            if len(raw) >= 32:
+                return raw[:32], "env"
+        except ValueError:
+            pass
+        return hashlib.sha256(key_hex.encode()).digest(), "env"
     # Dev fallback so test fixtures and `docker compose up` Just Work.
-    return hashlib.sha256(b"orcarouter-lite-dev-key").digest()
+    _warn_dev_fallback_once()
+    return hashlib.sha256(b"orcarouter-lite-dev-key").digest(), "dev-fallback"
+
+
+def is_using_insecure_dev_key() -> bool:
+    try:
+        return _resolve_key_material()[1] == "dev-fallback"
+    except Exception:
+        return False
 
 
 def encrypt_credential(plaintext: str) -> bytes:
     aes = AESGCM(_get_encryption_key())
-    nonce = os.urandom(12)
-    return nonce + aes.encrypt(nonce, plaintext.encode("utf-8"), None)
+    nonce = os.urandom(_NONCE_LEN)
+    return VERSION_BYTE + nonce + aes.encrypt(nonce, plaintext.encode("utf-8"), None)
 
 
 def decrypt_credential(blob: bytes) -> str:
-    aes = AESGCM(_get_encryption_key())
-    nonce, ciphertext = blob[:12], blob[12:]
+    key = _get_encryption_key()
+    aes = AESGCM(key)
+
+    if blob[:1] == VERSION_BYTE and len(blob) >= 1 + _NONCE_LEN + _TAG_LEN:
+        try:
+            return aes.decrypt(
+                blob[1:1 + _NONCE_LEN], blob[1 + _NONCE_LEN:], None
+            ).decode("utf-8")
+        except InvalidTag:
+            # Could be a LEGACY blob whose first nonce byte happens to be
+            # 0x01 (~0.4%). Fall through and try the unversioned layout
+            # before giving up.
+            pass
+
+    # Legacy unversioned blob: nonce(12) || ciphertext+tag.
+    # Validate length explicitly so truncated/malformed input raises
+    # InvalidTag (the contract callers test for) rather than a bare
+    # ValueError from cryptography's parameter checks.
+    if len(blob) < _NONCE_LEN + _TAG_LEN:
+        raise InvalidTag("ciphertext too short")
+    nonce, ciphertext = blob[:_NONCE_LEN], blob[_NONCE_LEN:]
     return aes.decrypt(nonce, ciphertext, None).decode("utf-8")

--- a/packages/db/guards.py
+++ b/packages/db/guards.py
@@ -1,0 +1,137 @@
+"""Startup safety guards that need DB access.
+
+`assert_credential_encryption_ready` fail-closes boot when provider
+credentials would be (or are) protected by the publicly-known dev
+encryption key. Kept separate from `packages.auth.encryption` so the
+crypto module stays free of SQLAlchemy imports.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from packages.auth.encryption import is_using_insecure_dev_key
+
+_ALLOW_FLAG_ENV = "ORCA_ALLOW_INSECURE_DEV_KEY"
+
+
+def _allow_flag_enabled(settings_value: bool, os_environ) -> bool:
+    if settings_value:
+        return True
+    return str(os_environ.get(_ALLOW_FLAG_ENV, "")).lower() in ("1", "true", "yes")
+
+
+async def _count_provider_keys(session: AsyncSession) -> int:
+    from packages.db.models.provider_key import ProviderKey
+
+    return int(
+        (await session.execute(select(func.count()).select_from(ProviderKey))).scalar_one()
+    )
+
+
+async def assert_credential_encryption_ready(
+    *,
+    make_session,
+    database_url: str,
+    allow_insecure_dev_key: bool = False,
+    os_environ=None,
+    engine=None,
+) -> None:
+    """Refuse to start when the dev encryption key would guard real secrets.
+
+    - SQLite + zero stored provider keys  -> allowed (fresh dev install),
+      `encryption.py` warns loudly at first use.
+    - Anything else without a configured key -> RuntimeError with remediation.
+    """
+    import os as _os
+
+    environ = os_environ if os_environ is not None else _os.environ
+    if not is_using_insecure_dev_key():
+        return
+    if _allow_flag_enabled(allow_insecure_dev_key, environ):
+        return
+
+    is_sqlite = database_url.startswith("sqlite")
+
+    # Prefer an explicit engine for table-existence checks; fall back to
+    # extracting it from the session factory so we don't rely on fragile
+    # string-matching of exception messages.
+    if engine is None:
+        try:
+            engine = getattr(make_session, "kw", {}).get("bind")  # async_sessionmaker
+        except Exception:
+            engine = None
+        if engine is None:
+            engine = getattr(make_session, "bind", None)
+
+    if engine is not None:
+        # Use async-safe inspector: for AsyncEngine we must run through
+        # run_sync inside an async connection, otherwise MissingGreenlet.
+        has_table = False
+        try:
+            if hasattr(engine, "connect") and hasattr(engine, "sync_engine"):
+                # AsyncEngine path — use run_sync
+                async with engine.connect() as conn:
+                    def _check(sync_conn):
+                        from sqlalchemy import inspect as _inspect
+
+                        return _inspect(sync_conn).has_table("provider_keys")
+
+                    has_table = await conn.run_sync(_check)
+            else:
+                from sqlalchemy import inspect
+
+                sync_engine = engine.sync_engine if hasattr(engine, "sync_engine") else engine
+                has_table = inspect(sync_engine).has_table("provider_keys")
+        except RuntimeError:
+            raise
+        except Exception:
+            # Inspector itself failed — fail closed, don't silently allow boot.
+            raise
+        if not has_table:
+            key_rows = 0
+            if is_sqlite and key_rows == 0:
+                return
+            raise RuntimeError(
+                "CREDENTIAL_ENCRYPTION_KEY is not set, so provider API keys would be "
+                "sealed with a publicly-known development key. "
+                + "A non-SQLite database requires an explicit encryption key. "
+                + "Generate one with `openssl rand -hex 32`, set it as "
+                "CREDENTIAL_ENCRYPTION_KEY, and re-save your provider keys. "
+                "(If you knowingly want to keep using the insecure dev key, set "
+                "ORCA_ALLOW_INSECURE_DEV_KEY=1.)"
+            )
+        # Table exists — count rows; any failure here is not "missing table"
+        # and must fail closed.
+        async with make_session() as session:
+            key_rows = await _count_provider_keys(session)
+    else:
+        # No engine available (test helper without bind) — fall back to
+        # counting and narrowly treat only a missing-table error as zero.
+        try:
+            async with make_session() as session:
+                key_rows = await _count_provider_keys(session)
+        except Exception as exc:
+            msg = str(exc).lower()
+            if "no such table" in msg or "no such relation" in msg:
+                key_rows = 0
+            else:
+                raise
+
+    if is_sqlite and key_rows == 0:
+        return
+
+    raise RuntimeError(
+        "CREDENTIAL_ENCRYPTION_KEY is not set, so provider API keys would be "
+        "sealed with a publicly-known development key. "
+        + (
+            f"{key_rows} provider key(s) already exist in this database."
+            if key_rows
+            else "A non-SQLite database requires an explicit encryption key."
+        )
+        + " Generate one with `openssl rand -hex 32`, set it as "
+        "CREDENTIAL_ENCRYPTION_KEY, and re-save your provider keys. "
+        "(If you knowingly want to keep using the insecure dev key, set "
+        "ORCA_ALLOW_INSECURE_DEV_KEY=1.)"
+    )

--- a/tests/unit/test_encryption_format.py
+++ b/tests/unit/test_encryption_format.py
@@ -1,0 +1,84 @@
+"""Tests for the versioned ciphertext format and legacy-blob compatibility.
+
+The v1 format prefixes ``b"\\x01" + nonce + ct`` so key rotation becomes
+possible later; legacy unversioned blobs (and the ~0.4% of them whose first
+nonce byte collides with the version byte) must keep decrypting.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from cryptography.exceptions import InvalidTag
+
+
+@pytest.fixture
+def hex_key(monkeypatch):
+    """Pin a known 32-byte hex key via env (Settings-independent path)."""
+    monkeypatch.delenv("CREDENTIAL_ENCRYPTION_KEY", raising=False)
+
+    from app import config as cfg
+
+    cfg.get_settings.cache_clear()
+    s = cfg.Settings(_env_file=None, credential_encryption_key="ab" * 32)
+    monkeypatch.setattr(cfg, "get_settings", lambda: s)
+    return bytes.fromhex("ab" * 32)
+
+
+def test_encrypt_produces_versioned_blob(hex_key):
+    from packages.auth.encryption import VERSION_BYTE, decrypt_credential, encrypt_credential
+
+    blob = encrypt_credential("sk-secret")
+    assert blob[:1] == VERSION_BYTE
+    assert len(blob) == 1 + 12 + len(b"sk-secret") + 16  # ver+nonce+ct+tag
+    assert decrypt_credential(blob) == "sk-secret"
+
+
+def test_decrypt_handles_legacy_unversioned_blob(hex_key):
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    from packages.auth.encryption import decrypt_credential
+
+    aes = AESGCM(hex_key)
+    nonce = os.urandom(12)
+    assert nonce[:1] != b"\x01"
+    legacy = nonce + aes.encrypt(nonce, b"legacy-cred", None)
+    assert decrypt_credential(legacy) == "legacy-cred"
+
+
+def test_decrypt_recovers_legacy_blob_whose_nonce_starts_with_version_byte(hex_key):
+    """A legacy blob with nonce[0] == 0x01 (~0.4% of old blobs) must not brick."""
+    from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+    from packages.auth.encryption import VERSION_BYTE, decrypt_credential
+
+    aes = AESGCM(hex_key)
+    nonce = VERSION_BYTE + os.urandom(11)
+    tricky_legacy = nonce + aes.encrypt(nonce, b"tricky", None)
+    assert tricky_legacy[:1] == b"\x01"
+    assert decrypt_credential(tricky_legacy) == "tricky"
+
+
+def test_wrong_key_raises_invalid_tag(hex_key):
+    from app import config as cfg
+    from packages.auth.encryption import decrypt_credential, encrypt_credential
+
+    blob = encrypt_credential("x")
+
+    other = cfg.Settings(_env_file=None, credential_encryption_key="cd" * 32)
+    cfg_get = cfg.get_settings
+    cfg.get_settings = lambda: other  # not monkeypatched; restored below
+    try:
+        with pytest.raises(InvalidTag):
+            decrypt_credential(blob)
+    finally:
+        cfg.get_settings = cfg_get
+
+
+def test_truncated_blob_raises_rather_than_returning_garbage(hex_key):
+    from packages.auth.encryption import decrypt_credential, encrypt_credential
+
+    blob = encrypt_credential("x")
+    with pytest.raises(InvalidTag):
+        decrypt_credential(blob[:8])

--- a/tests/unit/test_startup_guards.py
+++ b/tests/unit/test_startup_guards.py
@@ -1,0 +1,141 @@
+"""Tests for packages.db.guards.assert_credential_encryption_ready.
+
+The guard must fail closed (RuntimeError) whenever the publicly-known dev
+encryption key would protect real credentials — existing provider rows, or
+any non-SQLite database — and allow fresh SQLite installs or explicit
+opt-in.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+def _allow_env(value: str) -> dict[str, str]:
+    return {"ORCA_ALLOW_INSECURE_DEV_KEY": value}
+
+
+@pytest.fixture
+async def guarded_db(tmp_sqlite_url):
+    """Engine + session factory over a fresh DB with tables created."""
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    yield tmp_sqlite_url, async_sessionmaker(engine, expire_on_commit=False)
+
+    await engine.dispose()
+
+
+async def _add_provider_key(make_session) -> None:
+    from packages.db.models.provider_key import ProviderKey
+
+    async with make_session() as s:
+        s.add(ProviderKey(provider="openai", encrypted_key=b"x" * 40, key_prefix="sk-...abcd"))
+        await s.commit()
+
+
+async def test_fresh_sqlite_without_keys_is_allowed(guarded_db, monkeypatch):
+    from packages.db.guards import assert_credential_encryption_ready
+
+    url, factory = guarded_db
+    await assert_credential_encryption_ready(
+        make_session=factory, database_url=url,
+    )
+
+
+async def test_existing_provider_keys_fail_closed(guarded_db):
+    from packages.db.guards import assert_credential_encryption_ready
+
+    url, factory = guarded_db
+    await _add_provider_key(factory)
+
+    with pytest.raises(RuntimeError, match="CREDENTIAL_ENCRYPTION_KEY"):
+        await assert_credential_encryption_ready(
+            make_session=factory, database_url=url,
+        )
+
+
+async def test_non_sqlite_requires_explicit_key_even_when_empty(guarded_db):
+    from packages.db.guards import assert_credential_encryption_ready
+
+    url, factory = guarded_db
+    with pytest.raises(RuntimeError, match="non-SQLite"):
+        await assert_credential_encryption_ready(
+            make_session=factory,
+            # storage stays on sqlite; only the *claimed* URL is postgres
+            database_url="postgresql+asyncpg://user:pw@db.example/orca",
+        )
+
+
+async def test_opt_in_flag_bypasses_the_guard(guarded_db):
+    from packages.db.guards import assert_credential_encryption_ready
+
+    url, factory = guarded_db
+    await _add_provider_key(factory)
+
+    await assert_credential_encryption_ready(
+        make_session=factory, database_url=url,
+        os_environ=_allow_env("1"),
+    )
+    await assert_credential_encryption_ready(
+        make_session=factory, database_url=url,
+        allow_insecure_dev_key=True,
+    )
+
+
+async def test_guard_no_ops_when_real_key_configured(guarded_db, monkeypatch):
+    """When Settings carries a real key, is_using_insecure_dev_key() is False
+    and the guard returns immediately regardless of stored rows."""
+    from app import config as cfg
+    from packages.db.guards import assert_credential_encryption_ready
+
+    cfg.get_settings.cache_clear()
+    monkeypatch.delenv("CREDENTIAL_ENCRYPTION_KEY", raising=False)
+    real = cfg.Settings(_env_file=None, credential_encryption_key="11" * 32)
+    monkeypatch.setattr(cfg, "get_settings", lambda: real)
+
+    url, factory = guarded_db
+    await _add_provider_key(factory)
+
+    await assert_credential_encryption_ready(
+        make_session=factory, database_url=url,
+    )
+
+
+async def test_guard_fails_closed_on_transient_db_error(guarded_db, monkeypatch):
+    """A transient DB error (e.g. 'database is locked') must not be
+    treated as 'table missing' — the guard must fail closed."""
+    from packages.db.guards import assert_credential_encryption_ready
+
+    url, factory = guarded_db
+
+    async def _boom(*_a, **_kw):
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr("packages.db.guards._count_provider_keys", _boom)
+    with pytest.raises(RuntimeError, match="database is locked"):
+        await assert_credential_encryption_ready(
+            make_session=factory, database_url=url,
+        )
+
+
+async def test_guard_allows_missing_table_on_fresh_sqlite(tmp_sqlite_url):
+    """A fresh DB pre-migration where provider_keys doesn't exist counts
+    as zero rows for sqlite (inspected via engine, not string matching)."""
+    from packages.db.engine import build_engine
+    from packages.db.guards import assert_credential_encryption_ready
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    engine = build_engine(tmp_sqlite_url)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    # No create_all — table genuinely missing.
+    await assert_credential_encryption_ready(
+        make_session=factory, database_url=tmp_sqlite_url, engine=engine,
+    )
+    await engine.dispose()


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":0,"p2":0,"p3":0,"push":1} -->

## Orca-Code-Review — push 1

| Severity | Count |
|---|---|
| P0 | 0 |
| P1 | 0 |
| P2 | 0 |
| P3 | 0 |

✅ no blocking findings
<!-- orca-cr-summary:end -->

Stacked from fix/startup-secret-logging split.

- encryption: versioned v1, legacy compat, explicit InvalidTag
- guards: fail-closed via inspect, re-raises transient errors
- config: allow_insecure_dev_key
- main: invoke guard after create_all
- tests: versioned, truncated, guard cases

Covers P2 and P3 plus Linus fixes.
Rebased on 9021c8f.
