### PR TITLE
docs: put the failover demo GIF in the README hero

### DIFF
--- a/DEMO.md
+++ b/DEMO.md
@@ -82,7 +82,8 @@ Trim to ≤30s. Export under 8 MB so GitHub renders inline in the README.
 
 ## Where to publish
 
-- README hero (replace the placeholder image link)
+- README hero — already wired: save the recording as `demo.gif` in the repo
+  root and every `README*.md` picks it up (the image sits under the badges)
 - Show HN cover image
 - Twitter/Threads launch post
 - ProductHunt gallery

--- a/README.de.md
+++ b/README.de.md
@@ -9,6 +9,10 @@ OpenAI-kompatibel. BYOK. Einzelner Workspace. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite Failover-Demo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` fängt einen Provider-Ausfall in Echtzeit ab — ohne Codeänderung. Aufnahme-Anleitung: [DEMO.md](./DEMO.md).*
+
 ## Sprachen
 
 - [English](./README.md)

--- a/README.es.md
+++ b/README.es.md
@@ -9,6 +9,10 @@ Compatible con OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Demo de failover de OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` absorbe una caída de proveedor en tiempo real — sin cambiar el código. Cómo se grabó: [DEMO.md](./DEMO.md).*
+
 ## Idiomas
 
 - [English](./README.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -9,6 +9,10 @@ Compatible OpenAI. BYOK. Workspace unique. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Démo de failover OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` absorbe une panne de fournisseur en temps réel — sans changement de code. Comment l’enregistrer : [DEMO.md](./DEMO.md).*
+
 ## Langues
 
 - [English](./README.md)

--- a/README.hi.md
+++ b/README.hi.md
@@ -9,6 +9,10 @@ OpenAI-compatible। BYOK। एकल-वर्कस्पेस। स्ट�
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite फेलओवर डेमो](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` रीयल-टाइम में प्रोवाइडर आउटेज को सोख लेता है — कोड में कोई बदलाव नहीं। रिकॉर्डिंग तरीका: [DEMO.md](./DEMO.md)।*
+
 ## भाषाएँ
 
 - [English](./README.md)

--- a/README.it.md
+++ b/README.it.md
@@ -9,6 +9,10 @@ Compatibile con OpenAI. BYOK. Workspace singolo. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Demo di failover di OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` assorbe un guasto del provider in tempo reale — senza modifiche al codice. Come registrarlo: [DEMO.md](./DEMO.md).*
+
 ## Lingue
 
 - [English](./README.md)

--- a/README.ja.md
+++ b/README.ja.md
@@ -9,6 +9,10 @@ OpenAI対応。ビヨク。単一のワークスペース。ストリーミン�
 [![モデル](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![ライセンス](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite フェイルオーバーデモ](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` がプロバイダー障害をリアルタイムで吸収 — コード変更なし。収録手順: [DEMO.md](./DEMO.md)。*
+
 ## 言語
 
 - [英語](./README.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -9,6 +9,10 @@ OpenAI 호환. BYOK. 단일 작업 공간. 스트리밍. `모델="자동"`.
 [![모델](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![라이센스](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite 장애 조치 데모](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"`가 프로바이더 장애를 실시간으로 흡수 — 코드 변경 없음. 녹화 방법: [DEMO.md](./DEMO.md).*
+
 ## 언어
 
 - [한국어](./README.md)

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ OpenAI-compatible. BYOK. Single-workspace. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite failover demo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` absorbing a provider outage in real time — no code change. How it was recorded: [DEMO.md](./DEMO.md).*
+
 ## Languages
 
 - [English](./README.md)

--- a/README.pt.md
+++ b/README.pt.md
@@ -9,6 +9,10 @@ Compatível com OpenAI. BYOK. Workspace único. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Demo de failover do OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` absorve uma falha de provedor em tempo real — sem mudar o código. Como gravar: [DEMO.md](./DEMO.md).*
+
 ## Idiomas
 
 - [English](./README.md)

--- a/README.ru.md
+++ b/README.ru.md
@@ -9,6 +9,10 @@ OpenAI-совместимый. BYOK. Один рабочий пространс�
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Демо failover OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` в реальном времени поглощает сбой провайдера — без изменений в коде. Как записать: [DEMO.md](./DEMO.md).*
+
 ## Языки
 
 - [English](./README.md)

--- a/README.vi.md
+++ b/README.vi.md
@@ -9,6 +9,10 @@ Tương thích OpenAI. BYOK. Workspace đơn. Streaming. `model="auto"`.
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![Demo failover của OrcaRouter Lite](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` hấp thụ sự cố nhà cung cấp theo thời gian thực — không đổi một dòng code. Cách ghi lại: [DEMO.md](./DEMO.md).*
+
 ## Ngôn ngữ
 
 - [English](./README.md)

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,6 +9,10 @@
 [![models](https://img.shields.io/badge/models-100%2B-blue)](#model-catalog)
 [![license](https://img.shields.io/badge/license-MIT-blue)](#license)
 
+![OrcaRouter Lite 故障转移演示](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)
+
+*`model="auto"` 实时吸收上游厂商故障 —— 无需改动任何代码。录制方式见 [DEMO.md](./DEMO.md)。*
+
 ## 语言
 
 - [English](./README.md)


### PR DESCRIPTION
## What

`demo.gif` (307 KB) has been sitting in the repo root unreferenced. This wires it into the hero slot of **all 12 READMEs** — directly under the badges, above the language list — with a localized alt text and one-line caption per language that links back to `DEMO.md`.

```markdown
![OrcaRouter Lite failover demo](https://github.com/Continuum-AI-Corp/OrcaRouter-Lite/blob/main/demo.gif?raw=true)

*`model="auto"` absorbing a provider outage in real time — no code change. How it was recorded: [DEMO.md](./DEMO.md).*
```

## Two judgment calls

**Absolute raw URL, not a relative path.** `pyproject.toml` uses `README.md` as the PyPI long-description, where a relative `./demo.gif` renders as a broken image. The absolute `?raw=true` URL works on both GitHub and PyPI, and matches what the logo line already does — so the `[tool.hatch.build.targets.sdist]` include list needs no change.

**The logo stays.** `DEMO.md` said to "replace the placeholder image link" in the README hero, but that image is the brand logo, not a placeholder. The GIF goes below it instead. That bullet in `DEMO.md` is now stale, so it's been rewritten to say where the GIF actually lands.

## Notes

- 307 KB, well under the 8 MB inline-render limit `DEMO.md` calls out.
- `Dockerfile` only `COPY`s `app/ packages/ design/ scripts/`, so the GIF never enters the image — no `.dockerignore` change needed.
- Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
