### PR TITLE
Fix security and observability

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -45,6 +45,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     from packages.db import session as session_mod
     from packages.db.engine import dispose_engine, get_engine, redacted_url
     from packages.db.models.base import Base
+    from packages.db.schema import ensure_runtime_indexes
 
     settings = get_settings()
 
@@ -68,6 +69,9 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
 
     async with engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
+        # an upgraded database already has these tables, so create_all
+        # won't put the new index on them
+        await ensure_runtime_indexes(conn)
 
     # Fail closed before any traffic can be served: refuse to boot when
     # provider credentials are (or would be) sealed with the publicly-known

--- a/app/main.py
+++ b/app/main.py
@@ -180,6 +180,13 @@ def create_app() -> FastAPI:
 
     @app.exception_handler(Exception)
     async def unhandled(request, exc: Exception):
+        # i log it or i can't debug 500s later
+        structlog.get_logger().exception(
+            "unhandled_exception",
+            method=request.method,
+            path=request.url.path,
+            error=str(exc),
+        )
         native = _native_error(request, 500, "Internal server error")
         if native is not None:
             return native

--- a/app/middleware/auth.py
+++ b/app/middleware/auth.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import json
 from urllib.parse import parse_qs
 
+import structlog
+
 from packages.auth.key_validator import AuthError, validate_api_key
 from packages.db import session as session_mod
 
@@ -213,6 +215,12 @@ class AuthMiddleware:
                     except AuthError as e:
                         auth_error = e
         except Exception:
+            # db is down, i log why
+            structlog.get_logger().exception(
+                "auth_middleware_db_failure",
+                method=scope.get("method"),
+                path=path,
+            )
             await _send_error(send, scope, 503, "Service temporarily unavailable", "server_error")
             return
 

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import time
 import uuid
+import zlib
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
 from datetime import datetime, timedelta, timezone
 
@@ -271,29 +272,52 @@ async def chat_completions(
 # which died mid-flight stops blocking the key's budget.
 _HOLD_TTL = timedelta(minutes=15)
 
-# What i reserve for a request that doesn't cap its own output length.
-_RESERVE_OUTPUT_TOKENS = 4096
+# What i assume for output when the caller sets no max_tokens. The logged
+# cost is the real number, so this only has to not be wildly under it.
+_DEFAULT_OUTPUT_TOKENS = 8192
+
+# Images and audio bill per piece, not per character: a 1024px image is
+# around a thousand tokens while its str() is a URL of maybe sixty.
+_MEDIA_TOKENS = 2048
 
 
-def _estimate_reserve_microcents(body: ChatCompletionRequest, model_id: str | None) -> int:
-    """What i hold against the key until the real cost is logged.
+def _input_token_ceiling(body: ChatCompletionRequest) -> int:
+    """Upper bound on the tokens i get billed for the prompt.
 
-    Charging after the request is too late, the money is already gone. So
-    i reserve an upper bound first and hand the rest back once the spend
-    is in the log. A model i can't price reserves nothing: its logged cost
-    is 0 too, so there's nothing to protect against.
+    `content` turns into a list of parts as soon as vision or audio is
+    involved, and str() of that list counts an image as a few dozen
+    characters. Anything that isn't text gets a flat allowance instead.
     """
-    priced = _lookup_priced_model(model_id)
-    if priced is None:
+    total = 0
+    for m in body.messages:
+        for part in m.content if isinstance(m.content, list) else [m.content]:
+            if isinstance(part, dict) and not isinstance(part.get("text"), str):
+                total += _MEDIA_TOKENS
+            else:
+                total += len(str(part)) // 4
+    return max(1, total)
+
+
+def _estimate_reserve_microcents(body: ChatCompletionRequest, model_ids) -> int:
+    """Worst case over every model this request could end up paying for.
+
+    It only has to be an upper bound: the hold comes off once the real
+    cost is in the log, and under-reserving is what lets a request walk
+    past a cap the operator set in real money. Auto-routing can cascade,
+    so i price every candidate and keep the dearest. A model i can't price
+    reserves nothing — its logged cost is 0 too.
+    """
+    priced = [p for p in (_lookup_priced_model(m) for m in model_ids) if p]
+    if not priced:
         return 0
-    prompt = "".join(str(m.content) for m in body.messages)
-    input_tokens = max(1, len(prompt) // 4)  # rough, only needs to be an upper bound
-    output_tokens = body.max_tokens or _RESERVE_OUTPUT_TOKENS
-    cost_usd = (
-        input_tokens * priced.input_cost_per_token
-        + output_tokens * priced.output_cost_per_token
+    input_tokens = _input_token_ceiling(body)
+    # `n` bills a whole completion each time
+    output_tokens = (body.max_tokens or _DEFAULT_OUTPUT_TOKENS) * max(1, body.n or 1)
+    worst = max(
+        input_tokens * m.input_cost_per_token + output_tokens * m.output_cost_per_token
+        for m in priced
     )
-    return max(0, int(cost_usd * 1_000_000))
+    return max(0, int(worst * 1_000_000))
 
 
 class _BudgetHold:
@@ -301,8 +325,8 @@ class _BudgetHold:
 
     `acquire` is a single statement on purpose. Reading the total and then
     comparing it lets N parallel requests read the same total and all spend
-    past the cap. One INSERT..SELECT can't: sqlite serialises writers, so
-    the second caller sees the first one's hold.
+    past the cap. One INSERT..SELECT can't, so long as the writers are made
+    to queue: sqlite does that on its own, postgres needs the lock below.
     """
 
     def __init__(self, db: AsyncSession) -> None:
@@ -312,12 +336,23 @@ class _BudgetHold:
         # body is consumed, so the hold has to outlive this function.
         self.transferred = False
 
-    async def acquire(self, kc: KeyContext, body: ChatCompletionRequest, model_id: str) -> None:
+    async def acquire(self, kc: KeyContext, body: ChatCompletionRequest, model_ids) -> None:
         if kc.budget_limit_cents is None:
             return  # no cap on this key, nothing to hold
 
+        key_id = str(kc.key_id)
+        if self._db.get_bind().dialect.name == "postgresql":
+            # postgres hands every caller the same snapshot, so without
+            # this they'd all read the same remaining budget and all pass.
+            # One lock per key makes them queue; it drops when the insert
+            # commits. sqlite serialises writers itself and needs nothing.
+            await self._db.execute(
+                text("SELECT pg_advisory_xact_lock(:lock)"),
+                {"lock": zlib.crc32(key_id.encode())},
+            )
+
         now = datetime.now(timezone.utc)
-        reserve = _estimate_reserve_microcents(body, model_id)
+        reserve = _estimate_reserve_microcents(body, model_ids)
         hold_id = str(uuid.uuid4())
         result = await self._db.execute(
             text(
@@ -336,7 +371,7 @@ class _BudgetHold:
             ),
             {
                 "id": hold_id,
-                "key_id": str(kc.key_id),
+                "key_id": key_id,
                 "workspace_id": str(kc.workspace_id),
                 "reserve": reserve,
                 "now": now,
@@ -567,8 +602,9 @@ async def _run_chat(
 
     # Hold the budget now that i know which model i'm paying for. Doing it
     # after auto-resolution means "auto" reserves a real price too, and a
-    # cache hit never gets here because it returns below.
-    await hold.acquire(kc, body, resolved_model)
+    # cache hit never gets here because it returns below. The whole
+    # candidate list goes in because a cascade can land on any of them.
+    await hold.acquire(kc, body, candidates or [resolved_model])
 
     # ── Prompt cache (blocking deterministic requests only) ────────────
     cache_status = "BYPASS"

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -12,11 +12,13 @@ import json
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
+from datetime import datetime, timezone
 
 import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import prompt_cache, router_cache
@@ -263,6 +265,38 @@ async def chat_completions(
     return await execute_chat(body, kc, db)
 
 
+async def _assert_budget_available(db: AsyncSession, kc: KeyContext) -> None:
+    """Block the key once it has spent its budget.
+
+    The cap was loaded but never checked, so a leaked key spent freely.
+    I sum what's already logged for this key; the current request's own
+    cost is written after it finishes, so one request can overshoot
+    before the next one is refused. An unknown period sums all time,
+    which is stricter than guessing wrong. No budget set means skip.
+    """
+    if kc.budget_limit_cents is None:
+        return
+    stmt = select(func.coalesce(func.sum(RequestLog.cost_microcents), 0)).where(
+        RequestLog.api_key_id == kc.key_id
+    )
+    if kc.budget_period == "monthly":
+        now = datetime.now(timezone.utc)
+        stmt = stmt.where(
+            RequestLog.created_at
+            >= now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        )
+    spent_microcents = (await db.execute(stmt)).scalar_one()
+    if spent_microcents >= kc.budget_limit_cents * 10_000:  # cents → microcents
+        raise HTTPException(
+            status_code=429,
+            detail=(
+                "API key budget exhausted: "
+                f"{spent_microcents / 1_000_000:.4f} USD spent this period "
+                f"against a {kc.budget_limit_cents / 100:.2f} USD cap."
+            ),
+        )
+
+
 async def execute_chat(
     body: ChatCompletionRequest,
     kc: KeyContext,
@@ -290,6 +324,9 @@ async def execute_chat(
     # not the post-resolution primary.
     requested_model = body.model
     was_auto = body.model == "auto"
+
+    # i check the budget first, every ingress path funnels through here
+    await _assert_budget_available(db, kc)
 
     # Allowlist enforcement is split: pinned requests check up front, auto
     # requests defer to after resolution (since "auto" itself is never in

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -12,13 +12,13 @@ import json
 import time
 import uuid
 from collections.abc import AsyncGenerator, AsyncIterable, Callable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from sqlalchemy import func, select
+from sqlalchemy import delete, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import prompt_cache, router_cache
@@ -34,6 +34,7 @@ from app.protocols.sse import AdapterError
 from app.quality_scores import resolve_model_metrics
 from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
+from packages.db.models.budget_hold import BudgetHold
 from packages.db.models.request_log import RequestLog
 from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
 from packages.litellm_adapter.types import UpstreamProviderError
@@ -265,36 +266,107 @@ async def chat_completions(
     return await execute_chat(body, kc, db)
 
 
-async def _assert_budget_available(db: AsyncSession, kc: KeyContext) -> None:
-    """Block the key once it has spent its budget.
+# How long a hold still counts against the cap. Long enough that a slow
+# stream isn't released out from under itself, short enough that a request
+# which died mid-flight stops blocking the key's budget.
+_HOLD_TTL = timedelta(minutes=15)
 
-    The cap was loaded but never checked, so a leaked key spent freely.
-    I sum what's already logged for this key; the current request's own
-    cost is written after it finishes, so one request can overshoot
-    before the next one is refused. An unknown period sums all time,
-    which is stricter than guessing wrong. No budget set means skip.
+# What i reserve for a request that doesn't cap its own output length.
+_RESERVE_OUTPUT_TOKENS = 4096
+
+
+def _estimate_reserve_microcents(body: ChatCompletionRequest, model_id: str | None) -> int:
+    """What i hold against the key until the real cost is logged.
+
+    Charging after the request is too late, the money is already gone. So
+    i reserve an upper bound first and hand the rest back once the spend
+    is in the log. A model i can't price reserves nothing: its logged cost
+    is 0 too, so there's nothing to protect against.
     """
-    if kc.budget_limit_cents is None:
-        return
-    stmt = select(func.coalesce(func.sum(RequestLog.cost_microcents), 0)).where(
-        RequestLog.api_key_id == kc.key_id
+    priced = _lookup_priced_model(model_id)
+    if priced is None:
+        return 0
+    prompt = "".join(str(m.content) for m in body.messages)
+    input_tokens = max(1, len(prompt) // 4)  # rough, only needs to be an upper bound
+    output_tokens = body.max_tokens or _RESERVE_OUTPUT_TOKENS
+    cost_usd = (
+        input_tokens * priced.input_cost_per_token
+        + output_tokens * priced.output_cost_per_token
     )
-    if kc.budget_period == "monthly":
+    return max(0, int(cost_usd * 1_000_000))
+
+
+class _BudgetHold:
+    """A reservation against a key's budget, released once the spend is logged.
+
+    `acquire` is a single statement on purpose. Reading the total and then
+    comparing it lets N parallel requests read the same total and all spend
+    past the cap. One INSERT..SELECT can't: sqlite serialises writers, so
+    the second caller sees the first one's hold.
+    """
+
+    def __init__(self, db: AsyncSession) -> None:
+        self._db = db
+        self._id: str | None = None
+        # Set when the stream takes over: the response returns before the
+        # body is consumed, so the hold has to outlive this function.
+        self.transferred = False
+
+    async def acquire(self, kc: KeyContext, body: ChatCompletionRequest, model_id: str) -> None:
+        if kc.budget_limit_cents is None:
+            return  # no cap on this key, nothing to hold
+
         now = datetime.now(timezone.utc)
-        stmt = stmt.where(
-            RequestLog.created_at
-            >= now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
-        )
-    spent_microcents = (await db.execute(stmt)).scalar_one()
-    if spent_microcents >= kc.budget_limit_cents * 10_000:  # cents → microcents
-        raise HTTPException(
-            status_code=429,
-            detail=(
-                "API key budget exhausted: "
-                f"{spent_microcents / 1_000_000:.4f} USD spent this period "
-                f"against a {kc.budget_limit_cents / 100:.2f} USD cap."
+        reserve = _estimate_reserve_microcents(body, model_id)
+        hold_id = str(uuid.uuid4())
+        result = await self._db.execute(
+            text(
+                """
+                INSERT INTO budget_holds
+                    (id, api_key_id, workspace_id, reserve_microcents, created_at)
+                SELECT :id, :key_id, :workspace_id, :reserve, :now
+                WHERE (
+                    SELECT COALESCE(SUM(cost_microcents), 0) FROM requests_log
+                    WHERE api_key_id = :key_id AND created_at >= :period_start
+                ) + (
+                    SELECT COALESCE(SUM(reserve_microcents), 0) FROM budget_holds
+                    WHERE api_key_id = :key_id AND created_at > :hold_cutoff
+                ) + :reserve <= :cap
+                """
             ),
+            {
+                "id": hold_id,
+                "key_id": str(kc.key_id),
+                "workspace_id": str(kc.workspace_id),
+                "reserve": reserve,
+                "now": now,
+                "period_start": now.replace(day=1, hour=0, minute=0, second=0, microsecond=0),
+                "hold_cutoff": now - _HOLD_TTL,
+                "cap": kc.budget_limit_cents * 10_000,  # cents to microcents
+            },
         )
+        await self._db.commit()
+        if result.rowcount != 1:
+            raise HTTPException(
+                status_code=429,
+                detail=(
+                    "API key budget exhausted: "
+                    f"this request would pass the {kc.budget_limit_cents / 100:.2f} USD cap."
+                ),
+            )
+        self._id = hold_id
+
+    async def release(self) -> None:
+        """Drop the reservation. Safe twice, and safe when never held."""
+        if self._id is None:
+            return
+        hold_id, self._id = self._id, None
+        try:
+            await self._db.execute(delete(BudgetHold).where(BudgetHold.id == hold_id))
+            await self._db.commit()
+        except Exception as release_err:
+            # it clears itself once _HOLD_TTL runs out
+            logger.warning("budget_hold_release_failed", error=str(release_err))
 
 
 async def execute_chat(
@@ -303,6 +375,24 @@ async def execute_chat(
     db: AsyncSession,
     *,
     log_status: Callable[[int, str | None], int] | None = None,
+) -> JSONResponse | StreamingResponse:
+    """Every ingress path (OpenAI, Anthropic, Gemini) funnels through here,
+    so the budget is held in one place and covers all three."""
+    hold = _BudgetHold(db)
+    try:
+        return await _run_chat(body, kc, db, log_status=log_status, hold=hold)
+    finally:
+        if not hold.transferred:
+            await hold.release()
+
+
+async def _run_chat(
+    body: ChatCompletionRequest,
+    kc: KeyContext,
+    db: AsyncSession,
+    *,
+    log_status: Callable[[int, str | None], int] | None = None,
+    hold: _BudgetHold,
 ) -> JSONResponse | StreamingResponse:
     """Protocol-agnostic chat engine — the full pipeline behind
     POST /v1/chat/completions (allowlist → auto-resolution → prompt cache →
@@ -324,9 +414,6 @@ async def execute_chat(
     # not the post-resolution primary.
     requested_model = body.model
     was_auto = body.model == "auto"
-
-    # i check the budget first, every ingress path funnels through here
-    await _assert_budget_available(db, kc)
 
     # Allowlist enforcement is split: pinned requests check up front, auto
     # requests defer to after resolution (since "auto" itself is never in
@@ -477,6 +564,11 @@ async def execute_chat(
     per_call_kwargs: dict = {}
     if was_auto:
         per_call_kwargs["num_retries"] = settings.router_num_retries_auto
+
+    # Hold the budget now that i know which model i'm paying for. Doing it
+    # after auto-resolution means "auto" reserves a real price too, and a
+    # cache hit never gets here because it returns below.
+    await hold.acquire(kc, body, resolved_model)
 
     # ── Prompt cache (blocking deterministic requests only) ────────────
     cache_status = "BYPASS"
@@ -923,7 +1015,17 @@ async def execute_chat(
                         await _finalize()
                     except Exception:
                         pass
+                    # after the log row: the spend has to be counted before
+                    # the hold against it comes off
+                    try:
+                        await hold.release()
+                    except Exception:
+                        pass
 
+        # The response returns before the body is read, so execute_chat's
+        # finally would drop the hold too early — sse() owns it now. If the
+        # process dies mid-stream the row just sits until _HOLD_TTL clears it.
+        hold.transferred = True
         return StreamingResponse(
             sse(),
             media_type="text/event-stream",

--- a/app/routes/chat.py
+++ b/app/routes/chat.py
@@ -19,7 +19,7 @@ import anyio
 import structlog
 from fastapi import APIRouter, Depends, HTTPException, Request
 from fastapi.responses import JSONResponse, StreamingResponse
-from sqlalchemy import delete, text
+from sqlalchemy import delete, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app import prompt_cache, router_cache
@@ -37,7 +37,13 @@ from app.schemas import ChatCompletionRequest
 from packages.auth.types import KeyContext
 from packages.db.models.budget_hold import BudgetHold
 from packages.db.models.request_log import RequestLog
-from packages.litellm_adapter.catalog import CATALOG, CATALOG_BY_ID
+from packages.litellm_adapter.catalog import (
+    CATALOG,
+    CATALOG_BY_ID,
+    Priced,
+    litellm_max_output,
+    litellm_priced,
+)
 from packages.litellm_adapter.types import UpstreamProviderError
 
 logger = structlog.get_logger()
@@ -231,29 +237,48 @@ def _compute_cost_microcents(
     return max(0, int(cost_usd * 1_000_000))
 
 
-def _lookup_priced_model(model_id: str | None):
-    """Try four id-shape variants, return the first catalog hit or None.
+def _model_id_variants(model_id: str) -> tuple[str, ...]:
+    """The shapes a model id turns up in: as-is, prefix stripped, dated
+    alias stripped ("claude-3-5-sonnet-20241022" -> "claude-3-5-sonnet",
+    which is the only form in our catalog for some entries)."""
+    bare = model_id.split("/", 1)[-1] if "/" in model_id else model_id
+    base = canonical_model_base(bare)
+    return (model_id, bare, base) if base != bare else (model_id, bare)
 
-    Order:
-      1. as-is
-      2. provider-prefix stripped ("openai/gpt-4o" -> "gpt-4o")
-      3. version-suffix stripped (handles "claude-3-5-sonnet-20241022" ->
-         "claude-3-5-sonnet" when the response was a dated alias and only
-         the base form is in our catalog)
+
+def _lookup_priced_model(model_id: str | None):
+    """First catalog hit across the shapes a response can come back as."""
+    if not model_id:
+        return None
+    for variant in _model_id_variants(model_id):
+        m = CATALOG_BY_ID.get(variant)
+        if m is not None:
+            return m
+    return None
+
+
+def _priced(model_id: str | None) -> Priced | None:
+    """What one model bills: the catalog first, then litellm itself.
+
+    The catalog only holds the providers we route to by name, so a
+    deployment pointed anywhere else isn't in it — but litellm prices it
+    all the same, and that's the number that lands in the log. Neither
+    having it means litellm reports no cost either, so there's nothing to
+    reserve against.
     """
     if not model_id:
         return None
-    m = CATALOG_BY_ID.get(model_id)
-    if m is not None:
-        return m
-    bare = model_id.split("/", 1)[-1] if "/" in model_id else model_id
-    if bare != model_id:
-        m = CATALOG_BY_ID.get(bare)
-        if m is not None:
-            return m
-    base = canonical_model_base(bare)
-    if base != bare:
-        return CATALOG_BY_ID.get(base)
+    for variant in _model_id_variants(model_id):
+        m = CATALOG_BY_ID.get(variant)
+        if m is not None and (m.input_cost_per_token or m.output_cost_per_token):
+            return Priced(
+                m.input_cost_per_token,
+                m.output_cost_per_token,
+                litellm_max_output(variant),
+            )
+        p = litellm_priced(variant)
+        if p is not None:
+            return p
     return None
 
 
@@ -267,34 +292,59 @@ async def chat_completions(
     return await execute_chat(body, kc, db)
 
 
-# How long a hold still counts against the cap. Long enough that a slow
-# stream isn't released out from under itself, short enough that a request
-# which died mid-flight stops blocking the key's budget.
+# How long a hold still counts against the cap, and how often a live stream
+# refreshes it. Half the ttl: a hold that stops beating gets reaped, a slow
+# stream never slips out of the sum while it's still spending.
 _HOLD_TTL = timedelta(minutes=15)
+_HOLD_HEARTBEAT = _HOLD_TTL / 2
 
-# What i assume for output when the caller sets no max_tokens. The logged
-# cost is the real number, so this only has to not be wildly under it.
+# What i assume for output when neither the caller nor litellm caps it.
 _DEFAULT_OUTPUT_TOKENS = 8192
 
-# Images and audio bill per piece, not per character: a 1024px image is
-# around a thousand tokens while its str() is a URL of maybe sixty.
-_MEDIA_TOKENS = 2048
+# Images bill per piece, not per character: a 1024px image is around a
+# thousand tokens while its str() is a URL of maybe sixty.
+_IMAGE_TOKENS = 2048
+# Audio bills by duration, ~32 tokens per 6s: this covers a 25 minute clip.
+_AUDIO_TOKENS = 8192
+# Anthropic prices a cache write at 1.25x the base input rate, and that's
+# the dearest any provider prices a prompt token.
+_CACHE_WRITE_MULTIPLIER = 1.25
+
+
+def _text_token_ceiling(text: str) -> int:
+    """Upper bound on what a string bills as.
+
+    //4 is the english average, not a ceiling: chinese bills closer to one
+    token per character and emoji worse than that. Anything past ASCII gets
+    a token each, which over-counts some scripts and is right for the ones
+    that matter.
+    """
+    non_ascii = sum(1 for ch in text if ord(ch) > 127)
+    return (len(text) - non_ascii) // 4 + non_ascii
 
 
 def _input_token_ceiling(body: ChatCompletionRequest) -> int:
-    """Upper bound on the tokens i get billed for the prompt.
+    """Upper bound on the prompt tokens i get billed for.
 
-    `content` turns into a list of parts as soon as vision or audio is
-    involved, and str() of that list counts an image as a few dozen
-    characters. Anything that isn't text gets a flat allowance instead.
+    Tools are billed as input and can dwarf the messages they sit next to,
+    so they go in the same total. `content` turns into a list of parts as
+    soon as vision or audio is involved, and those bill by the piece.
     """
     total = 0
     for m in body.messages:
         for part in m.content if isinstance(m.content, list) else [m.content]:
-            if isinstance(part, dict) and not isinstance(part.get("text"), str):
-                total += _MEDIA_TOKENS
+            if not isinstance(part, dict):
+                total += _text_token_ceiling(str(part))
+            elif isinstance(part.get("text"), str):
+                total += _text_token_ceiling(part["text"])
+            elif "audio" in str(part.get("type", "")):
+                total += _AUDIO_TOKENS
             else:
-                total += len(str(part)) // 4
+                total += _IMAGE_TOKENS
+        if m.tool_calls:
+            total += _text_token_ceiling(json.dumps(m.tool_calls, default=str))
+    if body.tools:
+        total += _text_token_ceiling(json.dumps(body.tools, default=str))
     return max(1, total)
 
 
@@ -304,18 +354,21 @@ def _estimate_reserve_microcents(body: ChatCompletionRequest, model_ids) -> int:
     It only has to be an upper bound: the hold comes off once the real
     cost is in the log, and under-reserving is what lets a request walk
     past a cap the operator set in real money. Auto-routing can cascade,
-    so i price every candidate and keep the dearest. A model i can't price
-    reserves nothing — its logged cost is 0 too.
+    so i price every candidate and keep the dearest.
     """
-    priced = [p for p in (_lookup_priced_model(m) for m in model_ids) if p]
+    priced = [p for p in (_priced(m) for m in model_ids) if p]
     if not priced:
         return 0
     input_tokens = _input_token_ceiling(body)
     # `n` bills a whole completion each time
-    output_tokens = (body.max_tokens or _DEFAULT_OUTPUT_TOKENS) * max(1, body.n or 1)
+    n = max(1, body.n or 1)
     worst = max(
-        input_tokens * m.input_cost_per_token + output_tokens * m.output_cost_per_token
-        for m in priced
+        input_tokens * p.input_cost_per_token * _CACHE_WRITE_MULTIPLIER
+        # with no max_tokens the model's own ceiling is the bound; litellm
+        # doesn't publish one for every model, hence the fallback
+        + n * (body.max_tokens or p.max_output_tokens or _DEFAULT_OUTPUT_TOKENS)
+        * p.output_cost_per_token
+        for p in priced
     )
     return max(0, int(worst * 1_000_000))
 
@@ -335,6 +388,7 @@ class _BudgetHold:
         # Set when the stream takes over: the response returns before the
         # body is consumed, so the hold has to outlive this function.
         self.transferred = False
+        self._last_beat = 0.0
 
     async def acquire(self, kc: KeyContext, body: ChatCompletionRequest, model_ids) -> None:
         if kc.budget_limit_cents is None:
@@ -358,14 +412,14 @@ class _BudgetHold:
             text(
                 """
                 INSERT INTO budget_holds
-                    (id, api_key_id, workspace_id, reserve_microcents, created_at)
+                    (id, api_key_id, workspace_id, reserve_microcents, last_seen_at)
                 SELECT :id, :key_id, :workspace_id, :reserve, :now
                 WHERE (
                     SELECT COALESCE(SUM(cost_microcents), 0) FROM requests_log
                     WHERE api_key_id = :key_id AND created_at >= :period_start
                 ) + (
                     SELECT COALESCE(SUM(reserve_microcents), 0) FROM budget_holds
-                    WHERE api_key_id = :key_id AND created_at > :hold_cutoff
+                    WHERE api_key_id = :key_id AND last_seen_at > :hold_cutoff
                 ) + :reserve <= :cap
                 """
             ),
@@ -390,6 +444,32 @@ class _BudgetHold:
                 ),
             )
         self._id = hold_id
+
+    async def heartbeat(self) -> None:
+        """Keep a live stream's hold from ageing out of the cap sum.
+
+        The TTL reaps holds for requests that died, but it can't tell a
+        dead request from a slow one: the log row for a stream only lands
+        when the stream ends, so a stream past the TTL would stop counting
+        towards the cap while still spending against it. Called between
+        chunks; only writes when half the TTL is up.
+        """
+        if self._id is None:
+            return
+        now = time.monotonic()
+        if now - self._last_beat < _HOLD_HEARTBEAT.total_seconds():
+            return
+        self._last_beat = now
+        try:
+            await self._db.execute(
+                update(BudgetHold)
+                .where(BudgetHold.id == self._id)
+                .values(last_seen_at=datetime.now(timezone.utc))
+            )
+            await self._db.commit()
+        except Exception as beat_err:
+            # worst case it ages out the way a dead request's hold would
+            logger.warning("budget_hold_heartbeat_failed", error=str(beat_err))
 
     async def release(self) -> None:
         """Drop the reservation. Safe twice, and safe when never held."""
@@ -938,6 +1018,7 @@ async def _run_chat(
                     if d.get("model"):
                         agg_model = d["model"]
                     yield f"data: {json.dumps(d, separators=(',', ':'))}\n\n"
+                    await hold.heartbeat()
                 yield "data: [DONE]\n\n"
             except (asyncio.CancelledError, GeneratorExit):
                 # Client closed the connection (Ctrl+C, tab closed, browser

--- a/app/routes/keys.py
+++ b/app/routes/keys.py
@@ -24,12 +24,15 @@ class CreateKey(BaseModel):
 
 @router.get("")
 async def list_keys(
-    _kc: KeyContext = Depends(get_key_context),
+    kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
+    # i only list my own workspace, else any key could read them all
     rows = (
         await db.execute(
-            select(ApiKey).where(ApiKey.is_deleted == 0).order_by(ApiKey.created_at)
+            select(ApiKey)
+            .where(ApiKey.is_deleted == 0, ApiKey.workspace_id == kc.workspace_id)
+            .order_by(ApiKey.created_at)
         )
     ).scalars().all()
     return {
@@ -55,11 +58,15 @@ async def create_key(
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     full_key, key_hash, key_prefix = generate_api_key()
+    # the body only has a name, so i copy my own limits onto the new key
+    # or a restricted key could just mint itself an unrestricted sibling
     row = ApiKey(
         workspace_id=kc.workspace_id,
         name=body.name,
         key_hash=key_hash,
         key_prefix=key_prefix,
+        model_allowlist=kc.model_allowlist,
+        budget_limit_cents=kc.budget_limit_cents,
     )
     db.add(row)
     await db.commit()
@@ -76,12 +83,17 @@ async def create_key(
 @router.delete("/{key_id}", status_code=204)
 async def revoke_key(
     key_id: str,
-    _kc: KeyContext = Depends(get_key_context),
+    kc: KeyContext = Depends(get_key_context),
     db: AsyncSession = Depends(get_db),
 ) -> Response:
+    # same as list, i can only revoke keys in my own workspace
     row = (
         await db.execute(
-            select(ApiKey).where(ApiKey.id == key_id, ApiKey.is_deleted == 0)
+            select(ApiKey).where(
+                ApiKey.id == key_id,
+                ApiKey.is_deleted == 0,
+                ApiKey.workspace_id == kc.workspace_id,
+            )
         )
     ).scalar_one_or_none()
     if row is None:

--- a/packages/auth/types.py
+++ b/packages/auth/types.py
@@ -15,5 +15,4 @@ class KeyContext:
     key_type: str = "standard"
     role_label: str | None = None
     budget_limit_cents: int | None = None
-    budget_period: str = "monthly"
     model_allowlist: list[str] | None = None

--- a/packages/db/engine.py
+++ b/packages/db/engine.py
@@ -32,6 +32,10 @@ def _register_sqlite_pragmas(engine: AsyncEngine) -> None:
     during a write and busy_timeout makes writers wait instead of
     failing. WAL is saved in the db file, so existing deployments
     upgrade themselves on first connect.
+
+    The wait is 5s, not longer: it happens inside a request, so 30s would
+    pin that request for 30s and turn one slow write into a pile-up. A
+    lock held past 5s is a real fault and should surface as one.
     """
 
     @event.listens_for(engine.sync_engine, "connect")
@@ -40,7 +44,7 @@ def _register_sqlite_pragmas(engine: AsyncEngine) -> None:
         try:
             cursor.execute("PRAGMA journal_mode=WAL")
             cursor.execute("PRAGMA synchronous=NORMAL")
-            cursor.execute("PRAGMA busy_timeout=30000")
+            cursor.execute("PRAGMA busy_timeout=5000")
         finally:
             cursor.close()
 
@@ -48,7 +52,7 @@ def _register_sqlite_pragmas(engine: AsyncEngine) -> None:
 def build_engine(database_url: str) -> AsyncEngine:
     """Build an async engine for the given URL.
 
-    SQLite gets WAL and a 30s busy timeout (see `_register_sqlite_pragmas`);
+    SQLite gets WAL and a 5s busy timeout (see `_register_sqlite_pragmas`);
     Postgres uses defaults with pool pre-ping.
     """
     if database_url.startswith("sqlite"):

--- a/packages/db/engine.py
+++ b/packages/db/engine.py
@@ -5,6 +5,7 @@ SQLite is the default, Postgres opt-in via DATABASE_URL=postgresql+asyncpg://...
 
 from __future__ import annotations
 
+from sqlalchemy import event
 from sqlalchemy.engine import make_url
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
@@ -23,18 +24,41 @@ def redacted_url(database_url: str) -> str:
         return "<unparseable-database-url>"
 
 
+def _register_sqlite_pragmas(engine: AsyncEngine) -> None:
+    """Let SQLite survive concurrent writes.
+
+    Stock SQLite dies with "database is locked" the moment two writes
+    overlap, which showed up as 500/503 under load. WAL lets reads run
+    during a write and busy_timeout makes writers wait instead of
+    failing. WAL is saved in the db file, so existing deployments
+    upgrade themselves on first connect.
+    """
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _set_sqlite_pragmas(dbapi_conn, _record):
+        cursor = dbapi_conn.cursor()
+        try:
+            cursor.execute("PRAGMA journal_mode=WAL")
+            cursor.execute("PRAGMA synchronous=NORMAL")
+            cursor.execute("PRAGMA busy_timeout=30000")
+        finally:
+            cursor.close()
+
+
 def build_engine(database_url: str) -> AsyncEngine:
     """Build an async engine for the given URL.
 
-    SQLite gets `connect_args={"check_same_thread": False}` and a NullPool-equivalent
-    so concurrent test fixtures work; Postgres uses defaults.
+    SQLite gets WAL and a 30s busy timeout (see `_register_sqlite_pragmas`);
+    Postgres uses defaults with pool pre-ping.
     """
     if database_url.startswith("sqlite"):
-        return create_async_engine(
+        engine = create_async_engine(
             database_url,
             connect_args={"check_same_thread": False},
             future=True,
         )
+        _register_sqlite_pragmas(engine)
+        return engine
     return create_async_engine(database_url, future=True, pool_pre_ping=True)
 
 

--- a/packages/db/models/__init__.py
+++ b/packages/db/models/__init__.py
@@ -2,6 +2,7 @@
 
 from packages.db.models.api_key import ApiKey
 from packages.db.models.base import Base, SoftDeleteMixin, TimestampMixin, UUIDMixin
+from packages.db.models.budget_hold import BudgetHold
 from packages.db.models.provider_key import ProviderKey
 from packages.db.models.quality_score_override import QualityScoreOverride
 from packages.db.models.quality_score_snapshot import QualityScoreSnapshot
@@ -15,6 +16,7 @@ __all__ = [
     "TimestampMixin",
     "UUIDMixin",
     "ApiKey",
+    "BudgetHold",
     "ProviderKey",
     "QualityScoreOverride",
     "QualityScoreSnapshot",

--- a/packages/db/models/budget_hold.py
+++ b/packages/db/models/budget_hold.py
@@ -1,0 +1,28 @@
+"""In-flight spend reservations for the budget cap.
+
+The cap has to be checked before the upstream call, but the real cost
+is only known after. So a request reserves its worst case up front and
+the reservation is dropped once the spend is logged.
+
+A new table (not a new column on api_keys) on purpose: `create_all`
+creates missing tables on an existing database, but never adds columns
+or indexes to one that's already there.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import BigInteger, DateTime, Index, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from packages.db.models.base import Base
+
+
+class BudgetHold(Base):
+    __tablename__ = "budget_holds"
+    __table_args__ = (Index("ix_budget_holds_key_created", "api_key_id", "created_at"),)
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True)
+    api_key_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    workspace_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    reserve_microcents: Mapped[int] = mapped_column(BigInteger, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/packages/db/models/budget_hold.py
+++ b/packages/db/models/budget_hold.py
@@ -7,6 +7,11 @@ the reservation is dropped once the spend is logged.
 A new table (not a new column on api_keys) on purpose: `create_all`
 creates missing tables on an existing database, but never adds columns
 or indexes to one that's already there.
+
+`last_seen_at` is what the TTL reads, not when the hold was made: a slow
+stream has to keep refreshing it or it ages out of the cap sum while it's
+still spending. Rows are deleted on release, so nothing here is an audit
+trail and the creation time was never worth a column.
 """
 
 from datetime import datetime
@@ -19,10 +24,10 @@ from packages.db.models.base import Base
 
 class BudgetHold(Base):
     __tablename__ = "budget_holds"
-    __table_args__ = (Index("ix_budget_holds_key_created", "api_key_id", "created_at"),)
+    __table_args__ = (Index("ix_budget_holds_key_seen", "api_key_id", "last_seen_at"),)
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True)
     api_key_id: Mapped[str] = mapped_column(String(36), nullable=False)
     workspace_id: Mapped[str] = mapped_column(String(36), nullable=False)
     reserve_microcents: Mapped[int] = mapped_column(BigInteger, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    last_seen_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)

--- a/packages/db/models/request_log.py
+++ b/packages/db/models/request_log.py
@@ -15,7 +15,8 @@ class RequestLog(Base, UUIDMixin, SoftDeleteMixin):
     )
 
     workspace_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
-    api_key_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    # indexed for the budget sum i do per key in execute_chat
+    api_key_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     trace_id: Mapped[str] = mapped_column(String(36), nullable=False, index=True)
     model_requested: Mapped[str] = mapped_column(String(100), nullable=False)
     model_resolved: Mapped[str] = mapped_column(String(200), nullable=False)

--- a/packages/db/schema.py
+++ b/packages/db/schema.py
@@ -1,0 +1,27 @@
+"""Indexes that have to be created by hand on boot.
+
+`create_all` builds tables that are missing, but leaves alone any table
+that's already there — so an index I add to an existing table never
+reaches a deployment that upgraded. There's no migration tool in here to
+do it properly, so the ones the request path depends on get applied
+here instead.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncConnection
+
+# IF NOT EXISTS, so on a fresh database where create_all already made them
+# this is a no-op.
+_RUNTIME_INDEXES = (
+    # the per-key sum the budget cap does on every request
+    "CREATE INDEX IF NOT EXISTS ix_requests_log_api_key_id "
+    "ON requests_log (api_key_id)",
+)
+
+
+async def ensure_runtime_indexes(conn: AsyncConnection) -> None:
+    """Run after create_all, while the tables are known to exist."""
+    for ddl in _RUNTIME_INDEXES:
+        await conn.execute(text(ddl))

--- a/packages/litellm_adapter/catalog.py
+++ b/packages/litellm_adapter/catalog.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import date
+from typing import NamedTuple
 
 # ── Provider mapping: litellm prefix → (our provider id, litellm prefix string) ──
 # Each entry maps a litellm provider key (the part before the `/` in the model
@@ -243,6 +244,51 @@ try:
             CATALOG_BY_ID[_id] = _sm
 except ImportError:
     pass
+
+
+class Priced(NamedTuple):
+    """What a model bills, and the most output it will produce."""
+
+    input_cost_per_token: float
+    output_cost_per_token: float
+    max_output_tokens: int | None = None
+
+
+def _litellm_cost() -> dict:
+    """litellm's own cost table, read fresh (operators register models)."""
+    try:
+        import litellm
+    except Exception:
+        return {}
+    return getattr(litellm, "model_cost", {}) or {}
+
+
+def _max_output(entry: dict) -> int | None:
+    value = entry.get("max_output_tokens") or entry.get("max_tokens")
+    return int(value) if isinstance(value, (int, float)) and value > 0 else None
+
+
+def litellm_priced(model_id: str) -> Priced | None:
+    """The price litellm itself would bill, or None when it has no entry.
+
+    The catalog is a filtered view: it keeps only the providers we route to
+    by name, so a deployment pointing anywhere else is missing from it while
+    litellm still prices it. Same table litellm computes response_cost from,
+    so this is what a money cap has to be measured against.
+    """
+    entry = _litellm_cost().get(model_id)
+    if not isinstance(entry, dict):
+        return None
+    in_cost = entry.get("input_cost_per_token")
+    out_cost = entry.get("output_cost_per_token")
+    if not in_cost and not out_cost:
+        return None
+    return Priced(float(in_cost or 0.0), float(out_cost or 0.0), _max_output(entry))
+
+
+def litellm_max_output(model_id: str) -> int | None:
+    entry = _litellm_cost().get(model_id)
+    return _max_output(entry) if isinstance(entry, dict) else None
 
 
 def all_model_ids() -> list[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -132,3 +132,35 @@ async def db_session(tmp_sqlite_url) -> AsyncGenerator:
         yield session
 
     await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def lite_app(tmp_sqlite_url, monkeypatch) -> AsyncGenerator:
+    """Boot a fresh app against a tempfile SQLite."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    # i clear the cached settings so my new env is picked up
+    from app import config as cfg
+
+    cfg.get_settings.cache_clear()
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    # i point the session factory at this engine
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db import session as session_mod
+
+    session_mod._session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    from app.main import create_app
+
+    yield create_app()
+
+    await engine.dispose()
+    session_mod._session_factory = None

--- a/tests/integration/test_app_factory.py
+++ b/tests/integration/test_app_factory.py
@@ -1,40 +1,5 @@
 """Tests for app.main.create_app — boot, /health, error format, CORS."""
 
-import pytest
-
-
-@pytest.fixture
-async def lite_app(tmp_sqlite_url, monkeypatch):
-    """Boot a fresh app against a tempfile SQLite."""
-    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
-
-    # Reset the singleton settings so the new env is picked up
-    from app import config as cfg
-
-    cfg.get_settings.cache_clear()
-
-    from packages.db.engine import build_engine
-    from packages.db.models.base import Base
-
-    engine = build_engine(tmp_sqlite_url)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    # Register session factory bound to this engine
-    from sqlalchemy.ext.asyncio import async_sessionmaker
-
-    from packages.db import session as session_mod
-
-    session_mod._session_factory = async_sessionmaker(engine, expire_on_commit=False)
-
-    from app.main import create_app
-
-    yield create_app()
-
-    await engine.dispose()
-    session_mod._session_factory = None
-
-
 async def test_health_returns_ok(lite_app):
     from httpx import ASGITransport, AsyncClient
 

--- a/tests/integration/test_budget_enforcement.py
+++ b/tests/integration/test_budget_enforcement.py
@@ -1,13 +1,16 @@
 """Check i actually enforce budget_limit_cents.
 
 The column was loaded but never checked, so a leaked key spent freely.
-I check it in execute_chat against recorded spend. The current request's
-cost is logged after it finishes, so the overshoot is one request.
+I hold against it in execute_chat before the upstream call and hand the
+hold back once the real cost is in the log.
 """
 
+import asyncio
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import pytest
+from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 
@@ -125,3 +128,88 @@ async def test_key_without_budget_is_never_blocked(tmp_sqlite_url, monkeypatch):
         )
         # no budget set means no cap, so it fails downstream but never 429
         assert resp.status_code != 429
+
+
+def _claim_in_thread(url: str, kc, body, model: str) -> int:
+    """Claim on its own event loop, so the writers really overlap.
+
+    Twenty coroutines on one loop don't: they queue up and sqlite sees
+    them one at a time, so a read-then-write check looks perfectly safe.
+    A thread each means twenty connections racing for the same cap.
+    """
+    from app.routes.chat import _BudgetHold, _estimate_reserve_microcents
+
+    async def _run() -> int:
+        from sqlalchemy.ext.asyncio import async_sessionmaker
+
+        from packages.db.engine import build_engine
+
+        engine = build_engine(url)
+        try:
+            async with async_sessionmaker(engine, expire_on_commit=False)() as db:
+                hold = _BudgetHold(db)
+                try:
+                    await hold.acquire(kc, body, model)
+                except HTTPException:
+                    return 0  # refused
+                return _estimate_reserve_microcents(body, model)
+        finally:
+            await engine.dispose()
+
+    loop = asyncio.new_event_loop()
+    try:
+        return loop.run_until_complete(_run())
+    finally:
+        loop.close()
+
+
+@pytest.mark.asyncio
+async def test_requests_arriving_together_cannot_all_claim_the_cap(tmp_sqlite_url, monkeypatch):
+    """Twenty at once must not each get to spend the whole cap.
+
+    Reading the total and then comparing it lets every caller read an
+    empty ledger and all walk through it. One INSERT..SELECT can't: the
+    writer lock makes the second caller wait for the first one's row.
+    """
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from app.schemas import ChatCompletionRequest
+    from packages.auth.types import KeyContext
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        await seed_initial_state(s)
+        key = _mk_key("sk-orca-parallelkey1", budget_limit_cents=1)
+        s.add(key)
+        await s.commit()
+        key_id = key.id
+    await engine.dispose()
+
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+    )
+    kc = KeyContext(
+        key_id=key_id, workspace_id="default", name="parallel", budget_limit_cents=1
+    )
+
+    with ThreadPoolExecutor(max_workers=20) as pool:
+        claimed = list(
+            pool.map(
+                lambda _: _claim_in_thread(tmp_sqlite_url, kc, body, "gpt-4o-mini"),
+                range(20),
+            )
+        )
+
+    cap = 10_000  # budget_limit_cents=1, in microcents
+    # > 0 so the cap isn't just refusing everything, <= cap so twenty
+    # callers can't each reserve the whole thing
+    assert 0 < sum(claimed) <= cap

--- a/tests/integration/test_budget_enforcement.py
+++ b/tests/integration/test_budget_enforcement.py
@@ -1,0 +1,127 @@
+"""Check i actually enforce budget_limit_cents.
+
+The column was loaded but never checked, so a leaked key spent freely.
+I check it in execute_chat against recorded spend. The current request's
+cost is logged after it finishes, so the overshoot is one request.
+"""
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.main import create_app
+from app.seed import seed_initial_state
+from packages.auth.hashing import hash_api_key
+from packages.db import session as session_mod
+from packages.db.models.api_key import ApiKey
+from packages.db.models.request_log import RequestLog
+
+
+def _mk_key(raw: str, **extra) -> ApiKey:
+    return ApiKey(
+        workspace_id="default",
+        name=raw[-6:],
+        key_hash=hash_api_key(raw),
+        key_prefix="sk-orca-...." + raw[-4:],
+        **extra,
+    )
+
+
+def _log_row(key_id: str, cost_microcents: int) -> RequestLog:
+    return RequestLog(
+        workspace_id="default",
+        api_key_id=key_id,
+        trace_id=str(uuid.uuid4()),
+        model_requested="gpt-4o-mini",
+        model_resolved="gpt-4o-mini",
+        provider="openai",
+        routing_strategy="balanced",
+        input_tokens=10,
+        output_tokens=5,
+        cost_microcents=cost_microcents,
+        latency_ms=50,
+        status_code=200,
+    )
+
+
+@pytest.mark.asyncio
+async def test_exhausted_budget_returns_429_before_upstream(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        await seed_initial_state(s)
+        # 1 cent cap, 2 cents already spent
+        spent_out = _mk_key("sk-orca-spentoutkey1", budget_limit_cents=1)
+        s.add(spent_out)
+        await s.flush()
+        s.add(_log_row(spent_out.id, cost_microcents=20_000))
+        # 1 cent cap, nothing spent yet, so it should get through
+        has_room = _mk_key("sk-orca-hasroomkey1", budget_limit_cents=1)
+        s.add(has_room)
+        await s.commit()
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer sk-orca-spentoutkey1"},
+        )
+        assert resp.status_code == 429
+        assert "budget" in resp.json()["error"]["message"].lower()
+
+        # nothing spent, so it gets past my gate. no providers here, so it
+        # fails with 422 downstream. anything but 429 proves the gate passed.
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": "Bearer sk-orca-hasroomkey1"},
+        )
+        assert resp.status_code != 429
+
+
+@pytest.mark.asyncio
+async def test_key_without_budget_is_never_blocked(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+        s.add(_log_row(
+            (await s.execute(select(ApiKey).where(ApiKey.name == "default"))).scalar_one().id,
+            cost_microcents=999_999_999,
+        ))
+        await s.commit()
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/v1/chat/completions",
+            json={"model": "gpt-4o-mini", "messages": [{"role": "user", "content": "hi"}]},
+            headers={"Authorization": f"Bearer {seed.api_key}"},
+        )
+        # no budget set means no cap, so it fails downstream but never 429
+        assert resp.status_code != 429

--- a/tests/integration/test_budget_enforcement.py
+++ b/tests/integration/test_budget_enforcement.py
@@ -149,10 +149,10 @@ def _claim_in_thread(url: str, kc, body, model: str) -> int:
             async with async_sessionmaker(engine, expire_on_commit=False)() as db:
                 hold = _BudgetHold(db)
                 try:
-                    await hold.acquire(kc, body, model)
+                    await hold.acquire(kc, body, [model])
                 except HTTPException:
                     return 0  # refused
-                return _estimate_reserve_microcents(body, model)
+                return _estimate_reserve_microcents(body, [model])
         finally:
             await engine.dispose()
 

--- a/tests/integration/test_budget_enforcement.py
+++ b/tests/integration/test_budget_enforcement.py
@@ -199,8 +199,13 @@ async def test_requests_arriving_together_cannot_all_claim_the_cap(tmp_sqlite_ur
         key_id = key.id
     await engine.dispose()
 
+    # max_tokens pinned so the reserve doesn't move with whatever output
+    # ceiling this litellm build publishes. Sized so twenty of them are well
+    # past the cap: the point is the race, not the arithmetic.
     body = ChatCompletionRequest(
-        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "hi"}],
+        max_tokens=1600,
     )
     kc = KeyContext(
         key_id=key_id, workspace_id="default", name="parallel", budget_limit_cents=1

--- a/tests/integration/test_budget_enforcement.py
+++ b/tests/integration/test_budget_enforcement.py
@@ -8,17 +8,22 @@ hold back once the real cost is in the log.
 import asyncio
 import uuid
 from concurrent.futures import ThreadPoolExecutor
+from datetime import timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import HTTPException
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
+from structlog.testing import capture_logs
 
 from app.main import create_app
+from app.routes import chat
 from app.seed import seed_initial_state
 from packages.auth.hashing import hash_api_key
 from packages.db import session as session_mod
 from packages.db.models.api_key import ApiKey
+from packages.db.models.budget_hold import BudgetHold
 from packages.db.models.request_log import RequestLog
 
 
@@ -213,3 +218,80 @@ async def test_requests_arriving_together_cannot_all_claim_the_cap(tmp_sqlite_ur
     # > 0 so the cap isn't just refusing everything, <= cap so twenty
     # callers can't each reserve the whole thing
     assert 0 < sum(claimed) <= cap
+
+
+@pytest.mark.asyncio
+async def test_a_stream_beats_its_hold(tmp_sqlite_url, monkeypatch):
+    """The beat runs inside the chunk loop, where unit tests can't reach it.
+
+    Interval set to zero so every chunk writes one. A broken UPDATE would
+    not fail the request — heartbeat swallows its own errors so a slow
+    budget can't kill a working stream — so the warning is the only trace.
+    """
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+
+    from app import config as cfg
+    from app import router_cache
+
+    cfg.get_settings.cache_clear()
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        await seed_initial_state(s)
+        s.add(_mk_key("sk-orca-streambeatkey1", budget_limit_cents=100))
+        await s.commit()
+
+    async def _chunks():
+        yield {
+            "id": "c", "object": "chat.completion.chunk", "model": "gpt-4o-mini",
+            "created": 0,
+            "choices": [{"index": 0, "delta": {"content": "hi"}, "finish_reason": None}],
+        }
+        yield {
+            "id": "c", "object": "chat.completion.chunk", "model": "gpt-4o-mini",
+            "created": 0,
+            "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 4, "completion_tokens": 2, "total_tokens": 6},
+            "_orca_meta": {"provider": "openai", "latency_ms": 12},
+        }
+
+    fake_client = AsyncMock()
+    fake_client.acompletion = AsyncMock(return_value=_chunks())
+    monkeypatch.setattr(router_cache, "get_router", AsyncMock(return_value=fake_client))
+    monkeypatch.setattr(chat, "_HOLD_HEARTBEAT", timedelta(0))
+
+    app = create_app()
+    with capture_logs() as logs:
+        async with AsyncClient(
+            transport=ASGITransport(app=app, raise_app_exceptions=False),
+            base_url="http://t",
+        ) as client:
+            resp = await client.post(
+                "/v1/chat/completions",
+                json={
+                    "model": "gpt-4o-mini",
+                    "messages": [{"role": "user", "content": "hi"}],
+                    "stream": True,
+                },
+                headers={"Authorization": "Bearer sk-orca-streambeatkey1"},
+            )
+
+    assert resp.status_code == 200
+    assert "[DONE]" in resp.text
+    assert [e for e in logs if e.get("event") == "budget_hold_heartbeat_failed"] == []
+
+    # the stream owns the hold until the log row is in, then hands it back
+    async with factory() as s:
+        assert (await s.execute(select(BudgetHold))).scalars().all() == []
+    await engine.dispose()

--- a/tests/integration/test_keys_workspace_scoping.py
+++ b/tests/integration/test_keys_workspace_scoping.py
@@ -1,0 +1,136 @@
+"""Check i scope /v1/keys to my own workspace, and inherit restrictions.
+
+Two bugs i'm guarding against:
+
+- list and revoke ignored workspace_id, so any key could read and revoke
+  every key in the database.
+- create minted keys with a NULL allowlist and budget, so a restricted
+  key could make itself an unrestricted sibling.
+"""
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+
+from app.main import create_app
+from app.seed import seed_initial_state
+from packages.auth.hashing import hash_api_key
+from packages.db import session as session_mod
+from packages.db.models.api_key import ApiKey
+from packages.db.models.workspace import Workspace
+
+
+def _mk_key(raw: str, workspace_id: str, name: str, **extra) -> ApiKey:
+    return ApiKey(
+        workspace_id=workspace_id,
+        name=name,
+        key_hash=hash_api_key(raw),
+        key_prefix="sk-orca-...." + raw[-4:],
+        **extra,
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_and_revoke_are_scoped_to_callers_workspace(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+        # a second workspace with a key of its own
+        s.add(Workspace(id="other-ws", name="Other", slug="other"))
+        other_key = _mk_key("sk-orca-otherwskey0001", "other-ws", "other")
+        s.add(other_key)
+        await s.commit()
+        other_key_id = other_key.id
+
+    app = create_app()
+    auth = {"Authorization": f"Bearer {seed.api_key}"}
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        # listing must not show the other workspace's key
+        resp = await client.get("/v1/keys", headers=auth)
+        assert resp.status_code == 200
+        listed_ids = {k["id"] for k in resp.json()["keys"]}
+        assert other_key_id not in listed_ids
+
+        # revoking it must 404 and leave the key alone
+        resp = await client.delete(f"/v1/keys/{other_key_id}", headers=auth)
+        assert resp.status_code == 404
+
+    async with factory() as s:
+        row = (await s.execute(
+            select(ApiKey).where(ApiKey.id == other_key_id)
+        )).scalar_one()
+        assert row.is_active, "foreign key was revoked across the workspace boundary"
+
+
+@pytest.mark.asyncio
+async def test_created_key_inherits_caller_restrictions(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+    from packages.db.models.base import Base
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    session_mod._session_factory = factory
+
+    async with factory() as s:
+        seed = await seed_initial_state(s)
+        restricted = _mk_key(
+            "sk-orca-restrictedparent1",
+            "default",
+            "restricted",
+            model_allowlist=["gpt-4o-mini"],
+            budget_limit_cents=100,
+        )
+        s.add(restricted)
+        await s.commit()
+
+    app = create_app()
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/v1/keys",
+            json={"name": "escape-hatch"},
+            headers={"Authorization": "Bearer sk-orca-restrictedparent1"},
+        )
+        assert resp.status_code == 201
+        child_id = resp.json()["id"]
+
+    async with factory() as s:
+        child = (await s.execute(
+            select(ApiKey).where(ApiKey.id == child_id)
+        )).scalar_one()
+        # the child can never be less restricted than its parent
+        assert child.model_allowlist == ["gpt-4o-mini"]
+        assert child.budget_limit_cents == 100
+
+    # unrestricted stay unrestricted, so i can still mint admin keys
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.post(
+            "/v1/keys",
+            json={"name": "normal-child"},
+            headers={"Authorization": f"Bearer {seed.api_key}"},
+        )
+        assert resp.status_code == 201
+        child_id = resp.json()["id"]
+    async with factory() as s:
+        child = (await s.execute(
+            select(ApiKey).where(ApiKey.id == child_id)
+        )).scalar_one()
+        assert child.model_allowlist is None
+        assert child.budget_limit_cents is None

--- a/tests/integration/test_observability.py
+++ b/tests/integration/test_observability.py
@@ -1,0 +1,47 @@
+"""Check i log unhandled errors instead of dropping them."""
+
+from httpx import ASGITransport, AsyncClient
+from structlog.testing import capture_logs
+
+from packages.db import session as session_mod
+
+
+async def test_unhandled_exception_is_logged(lite_app):
+    def _boom(request):
+        raise RuntimeError("pg password hunter2")
+
+    lite_app.add_route("/boom", _boom)
+
+    with capture_logs() as cap:
+        # starlette sends the 500 then re-raises, so i stop httpx from raising
+        transport = ASGITransport(app=lite_app, raise_app_exceptions=False)
+        async with AsyncClient(transport=transport, base_url="http://t") as c:
+            r = await c.get("/boom")
+
+    assert r.status_code == 500
+    # the caller must not see my internals
+    assert "hunter2" not in r.text
+
+    logged = [e for e in cap if e["event"] == "unhandled_exception"]
+    assert logged, f"nothing logged: {[e.get('event') for e in cap]}"
+    assert logged[0]["method"] == "GET"
+    assert logged[0]["path"] == "/boom"
+    assert logged[0]["log_level"] == "error"
+
+
+async def test_auth_db_failure_is_logged(lite_app, monkeypatch):
+    def _broken():
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(session_mod, "_session_factory", _broken)
+
+    with capture_logs() as cap:
+        async with AsyncClient(transport=ASGITransport(app=lite_app), base_url="http://t") as c:
+            r = await c.get("/v1/models", headers={"Authorization": "Bearer sk-orca-x"})
+
+    assert r.status_code == 503
+
+    logged = [e for e in cap if e["event"] == "auth_middleware_db_failure"]
+    assert logged, f"nothing logged: {[e.get('event') for e in cap]}"
+    assert logged[0]["path"] == "/v1/models"
+    assert logged[0]["log_level"] == "error"

--- a/tests/unit/test_budget_hold_heartbeat.py
+++ b/tests/unit/test_budget_hold_heartbeat.py
@@ -1,0 +1,116 @@
+"""A live stream has to keep its hold alive.
+
+The TTL is what reaps holds for requests that died, but it can't tell a
+dead request from a slow one: a stream's log row only lands when the
+stream ends, so a stream still running past the TTL would drop out of the
+cap sum while carrying on spending against it.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import func, select, update
+
+from app.routes.chat import _BudgetHold
+from app.schemas import ChatCompletionRequest
+from packages.auth.types import KeyContext
+from packages.db.models.base import Base
+from packages.db.models.budget_hold import BudgetHold
+
+
+def _kc() -> KeyContext:
+    return KeyContext(
+        key_id="key-1", workspace_id="default", name="k", budget_limit_cents=100
+    )
+
+
+def _body() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+    )
+
+
+async def _factory(tmp_sqlite_url):
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import build_engine
+
+    engine = build_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    return engine, async_sessionmaker(engine, expire_on_commit=False)
+
+
+async def _live_holds(db) -> int:
+    """What the cap gate would actually count — same filter it uses."""
+    from app.routes.chat import _HOLD_TTL
+
+    return (
+        await db.execute(
+            select(func.count())
+            .select_from(BudgetHold)
+            .where(BudgetHold.last_seen_at > datetime.now(timezone.utc) - _HOLD_TTL)
+        )
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_a_beat_pulls_an_aged_hold_back_inside_the_ttl(tmp_sqlite_url, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    engine, factory = await _factory(tmp_sqlite_url)
+
+    async with factory() as db:
+        hold = _BudgetHold(db)
+        await hold.acquire(_kc(), _body(), ["gpt-4o-mini"])
+
+        # as the gate sees it, this request died over 15 minutes ago
+        await db.execute(
+            update(BudgetHold).values(
+                last_seen_at=datetime.now(timezone.utc) - timedelta(minutes=16)
+            )
+        )
+        await db.commit()
+        assert await _live_holds(db) == 0
+
+        await hold.heartbeat()
+        assert await _live_holds(db) == 1
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_beats_are_spaced_out(tmp_sqlite_url, monkeypatch):
+    """One write per stream per half-TTL, not one per chunk."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    engine, factory = await _factory(tmp_sqlite_url)
+
+    async with factory() as db:
+        hold = _BudgetHold(db)
+        await hold.acquire(_kc(), _body(), ["gpt-4o-mini"])
+        await hold.heartbeat()  # lands, and starts the interval
+
+        await db.execute(
+            update(BudgetHold).values(
+                last_seen_at=datetime.now(timezone.utc) - timedelta(minutes=16)
+            )
+        )
+        await db.commit()
+
+        for _ in range(5):
+            await hold.heartbeat()  # all inside the interval: no writes
+        assert await _live_holds(db) == 0
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_beating_a_hold_that_was_never_taken_is_a_no_op(tmp_sqlite_url, monkeypatch):
+    """No cap on the key means no row, and no key with a cap is ever refused."""
+    monkeypatch.setenv("DATABASE_URL", tmp_sqlite_url)
+    engine, factory = await _factory(tmp_sqlite_url)
+
+    async with factory() as db:
+        await _BudgetHold(db).heartbeat()
+        assert await _live_holds(db) == 0
+
+    await engine.dispose()

--- a/tests/unit/test_budget_hold_lock.py
+++ b/tests/unit/test_budget_hold_lock.py
@@ -1,0 +1,82 @@
+"""Postgres has to be made to queue; sqlite does it on its own.
+
+One INSERT..SELECT is only atomic where writers serialise. Postgres hands
+every caller the same MVCC snapshot, so without a lock they'd all read
+the same remaining budget and all pass the cap.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.routes.chat import _BudgetHold
+from app.schemas import ChatCompletionRequest
+from packages.auth.types import KeyContext
+
+_LOCK = "pg_advisory_xact_lock"
+_INSERT = "INSERT INTO budget_holds"
+
+
+class _RecordingDB:
+    """Stands in for AsyncSession. No server, just what would have run."""
+
+    def __init__(self, dialect: str) -> None:
+        self.calls: list[tuple[str, dict]] = []
+        self._bind = SimpleNamespace(dialect=SimpleNamespace(name=dialect))
+
+    @property
+    def statements(self) -> list[str]:
+        return [sql for sql, _ in self.calls]
+
+    def get_bind(self):
+        return self._bind
+
+    async def execute(self, stmt, params=None):
+        self.calls.append((str(stmt), params or {}))
+        return SimpleNamespace(rowcount=1)
+
+    async def commit(self):
+        self.calls.append(("COMMIT", {}))
+
+
+def _body() -> ChatCompletionRequest:
+    return ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": "hi"}]
+    )
+
+
+def _kc(key_id: str) -> KeyContext:
+    return KeyContext(
+        key_id=key_id, workspace_id="default", name="k", budget_limit_cents=100
+    )
+
+
+@pytest.mark.asyncio
+async def test_postgres_locks_the_key_before_it_reads_the_budget():
+    db = _RecordingDB("postgresql")
+    await _BudgetHold(db).acquire(_kc("k1"), _body(), ["gpt-4o-mini"])
+
+    lock = next(i for i, s in enumerate(db.statements) if _LOCK in s)
+    insert = next(i for i, s in enumerate(db.statements) if _INSERT in s)
+    commit = next(i for i, s in enumerate(db.statements) if s == "COMMIT")
+    assert lock < insert < commit
+
+
+@pytest.mark.asyncio
+async def test_the_lock_is_per_key_not_global():
+    """Two different keys must not queue behind each other."""
+    db = _RecordingDB("postgresql")
+    await _BudgetHold(db).acquire(_kc("k1"), _body(), ["gpt-4o-mini"])
+    await _BudgetHold(db).acquire(_kc("k2"), _body(), ["gpt-4o-mini"])
+
+    locks = [params["lock"] for sql, params in db.calls if _LOCK in sql]
+    assert len(locks) == 2
+    assert locks[0] != locks[1]
+
+
+@pytest.mark.asyncio
+async def test_sqlite_gets_no_lock():
+    """sqlite serialises writers itself, so the insert alone is enough."""
+    db = _RecordingDB("sqlite")
+    await _BudgetHold(db).acquire(_kc("k1"), _body(), ["gpt-4o-mini"])
+    assert not any(_LOCK in s for s in db.statements)

--- a/tests/unit/test_budget_reserve.py
+++ b/tests/unit/test_budget_reserve.py
@@ -1,0 +1,45 @@
+"""The reserve has to be an upper bound on what actually gets billed.
+
+Come in under and the request walks past a cap the operator set in real
+money, and by the time the real cost is logged the hold is already gone.
+"""
+
+from app.routes.chat import _estimate_reserve_microcents
+from app.schemas import ChatCompletionRequest
+
+_VISION = [{"type": "image_url", "image_url": {"url": "https://x/y.jpg"}}]
+_URL = "https://x/y.jpg"
+
+
+def _reserve(content="hi", models=("gpt-4o-mini",), **kw) -> int:
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": content}], **kw
+    )
+    return _estimate_reserve_microcents(body, list(models))
+
+
+def test_an_image_is_not_counted_as_its_own_url():
+    """content is a list of parts once vision is involved.
+
+    str() of that part is a fifteen character URL while the image itself
+    bills around a thousand tokens, so counting characters reserved next
+    to nothing against a real cost.
+    """
+    assert _reserve(content=_VISION, max_tokens=16) > 10 * _reserve(
+        content=_URL, max_tokens=16
+    )
+
+
+def test_n_multiplies_the_output_side():
+    """Each of the n completions is billed in full."""
+    assert _reserve(n=4) > 3 * _reserve(n=1)
+
+
+def test_a_cascade_reserves_the_dearest_candidate():
+    """Auto-routing can land on a fallback, so price them all."""
+    assert _reserve(models=("gpt-4o-mini", "gpt-4o")) == _reserve(models=("gpt-4o",))
+
+
+def test_an_unpriceable_model_reserves_nothing():
+    """Its logged cost is 0 too, so there's nothing to protect against."""
+    assert _reserve(models=("not-a-real-model",)) == 0

--- a/tests/unit/test_budget_reserve.py
+++ b/tests/unit/test_budget_reserve.py
@@ -4,11 +4,19 @@ Come in under and the request walks past a cap the operator set in real
 money, and by the time the real cost is logged the hold is already gone.
 """
 
-from app.routes.chat import _estimate_reserve_microcents
+import pytest
+
+from app.routes.chat import (
+    _estimate_reserve_microcents,
+    _input_token_ceiling,
+    _lookup_priced_model,
+    _priced,
+)
 from app.schemas import ChatCompletionRequest
 
 _VISION = [{"type": "image_url", "image_url": {"url": "https://x/y.jpg"}}]
 _URL = "https://x/y.jpg"
+_AUDIO = [{"type": "input_audio", "input_audio": {"data": "x" * 100, "format": "wav"}}]
 
 
 def _reserve(content="hi", models=("gpt-4o-mini",), **kw) -> int:
@@ -16,6 +24,13 @@ def _reserve(content="hi", models=("gpt-4o-mini",), **kw) -> int:
         model="gpt-4o-mini", messages=[{"role": "user", "content": content}], **kw
     )
     return _estimate_reserve_microcents(body, list(models))
+
+
+def _ceiling(content="hi", **kw) -> int:
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini", messages=[{"role": "user", "content": content}], **kw
+    )
+    return _input_token_ceiling(body)
 
 
 def test_an_image_is_not_counted_as_its_own_url():
@@ -40,6 +55,100 @@ def test_a_cascade_reserves_the_dearest_candidate():
     assert _reserve(models=("gpt-4o-mini", "gpt-4o")) == _reserve(models=("gpt-4o",))
 
 
-def test_an_unpriceable_model_reserves_nothing():
-    """Its logged cost is 0 too, so there's nothing to protect against."""
+def test_a_model_nobody_can_price_reserves_nothing():
+    """Not the catalog, not litellm — and litellm is who reports the cost.
+
+    If it has no price for the model it reports none, so there is no spend
+    for the cap to be protecting against.
+    """
     assert _reserve(models=("not-a-real-model",)) == 0
+
+
+def test_a_model_the_catalog_dropped_still_reserves():
+    """The catalog only keeps the providers i route to by name.
+
+    litellm prices everything in its own cost table and bills from it, so
+    a deployment pointed at a provider the catalog filtered out used to
+    reserve nothing at all while the log recorded a real cost.
+    """
+    from packages.litellm_adapter.catalog import CATALOG_BY_ID, _litellm_cost
+
+    outside = [
+        mid
+        for mid, meta in _litellm_cost().items()
+        if isinstance(meta, dict)
+        and (meta.get("input_cost_per_token") or meta.get("output_cost_per_token"))
+        and mid not in CATALOG_BY_ID
+    ]
+    if not outside:
+        pytest.skip("this litellm build has no priced model outside the catalog")
+    assert _reserve(models=(outside[0],)) > 0
+
+
+def test_a_zero_priced_catalog_entry_is_not_treated_as_a_price():
+    """Free tiers sit in the catalog at 0.0, which reserves nothing — but
+    i have to read past them to litellm rather than stop at the first hit."""
+    assert _priced("orcarouter/free") is None
+    assert _lookup_priced_model("orcarouter/free") is not None
+
+
+def test_an_unset_max_tokens_uses_the_models_own_ceiling():
+    """gpt-4o answers with far more than the flat 8192 i used to assume."""
+    ceiling = _priced("gpt-4o").max_output_tokens
+    if not ceiling:
+        pytest.skip("this litellm build publishes no output ceiling for gpt-4o")
+    assert _reserve(models=("gpt-4o",), max_tokens=ceiling) == _reserve(models=("gpt-4o",))
+
+
+def test_tools_are_billed_as_input():
+    """A tool schema can dwarf the messages it sits next to."""
+    tool = {"type": "function", "function": {"name": "search", "description": "x" * 4000}}
+    assert _ceiling(tools=[tool]) > _ceiling() + 900
+
+
+def test_tool_calls_in_the_transcript_are_billed_as_input():
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "x" * 4000},
+                    }
+                ],
+            }
+        ],
+    )
+    assert _input_token_ceiling(body) > 900
+
+
+def test_non_ascii_text_is_not_counted_as_a_quarter_token():
+    """//4 is the english average: chinese bills about one token a character."""
+    assert _ceiling(content="啊" * 100) > 3 * _ceiling(content="a" * 100)
+
+
+def test_audio_reserves_more_than_a_single_image():
+    """Audio bills by duration, so a clip is dearer than one image."""
+    assert _ceiling(content=_AUDIO) > _ceiling(content=_VISION)
+
+
+def test_a_cache_write_is_reserved_at_the_dearest_input_rate():
+    """Anthropic bills a cache write at 1.25x base input, a read at 0.1x."""
+    price = _priced("gpt-4o-mini")
+    body = ChatCompletionRequest(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": "a" * 40_000}],
+        max_tokens=1,
+    )
+    flat = int(
+        (
+            _input_token_ceiling(body) * price.input_cost_per_token
+            + price.output_cost_per_token
+        )
+        * 1_000_000
+    )
+    assert _estimate_reserve_microcents(body, ["gpt-4o-mini"]) > flat

--- a/tests/unit/test_runtime_indexes.py
+++ b/tests/unit/test_runtime_indexes.py
@@ -1,0 +1,53 @@
+"""Check the index the budget sum needs reaches an upgraded database.
+
+`create_all` skips tables that already exist, so on a deployment that
+upgrades, adding `index=True` to a column does nothing — the index is
+never created and the per-key sum stays a full scan. I create it by
+hand on boot instead.
+"""
+
+import pytest
+from sqlalchemy import text
+
+from packages.db.engine import build_engine
+from packages.db.models.base import Base
+from packages.db.schema import ensure_runtime_indexes
+
+_INDEX = "ix_requests_log_api_key_id"
+
+
+def _indexes(sync_conn) -> set[str]:
+    return {r[0] for r in sync_conn.execute(text("SELECT name FROM sqlite_master WHERE type='index'"))}
+
+
+@pytest.mark.asyncio
+async def test_missing_index_is_created_on_an_existing_database(tmp_sqlite_url):
+    engine = build_engine(tmp_sqlite_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+            # what an upgrade looks like: the table is already there
+            await conn.execute(text(f"DROP INDEX {_INDEX}"))
+            await ensure_runtime_indexes(conn)
+
+        async with engine.connect() as conn:
+            names = await conn.run_sync(_indexes)
+        assert _INDEX in names
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_running_twice_is_harmless(tmp_sqlite_url):
+    engine = build_engine(tmp_sqlite_url)
+    try:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+            await ensure_runtime_indexes(conn)
+            await ensure_runtime_indexes(conn)
+
+        async with engine.connect() as conn:
+            names = await conn.run_sync(_indexes)
+        assert _INDEX in names
+    finally:
+        await engine.dispose()

--- a/tests/unit/test_sqlite_engine_pragmas.py
+++ b/tests/unit/test_sqlite_engine_pragmas.py
@@ -1,7 +1,7 @@
 """Check SQLite survives concurrent writes.
 
 Stock SQLite turns two overlapping writes into "database is locked",
-which hit us as 500/503. I now set WAL, synchronous=NORMAL and a 30s
+which hit us as 500/503. I now set WAL, synchronous=NORMAL and a 5s
 busy timeout on every connection.
 """
 
@@ -20,7 +20,7 @@ async def test_sqlite_engine_enables_wal_and_busy_timeout(tmp_sqlite_url):
             busy_timeout = (await conn.execute(text("PRAGMA busy_timeout"))).scalar()
             synchronous = (await conn.execute(text("PRAGMA synchronous"))).scalar()
         assert journal_mode.lower() == "wal"
-        assert busy_timeout == 30000
+        assert busy_timeout == 5000
         # 1 = NORMAL (0 = OFF, 2 = FULL).
         assert synchronous == 1
     finally:

--- a/tests/unit/test_sqlite_engine_pragmas.py
+++ b/tests/unit/test_sqlite_engine_pragmas.py
@@ -1,0 +1,64 @@
+"""Check SQLite survives concurrent writes.
+
+Stock SQLite turns two overlapping writes into "database is locked",
+which hit us as 500/503. I now set WAL, synchronous=NORMAL and a 30s
+busy timeout on every connection.
+"""
+
+import pytest
+from sqlalchemy import select, text
+
+from packages.db.engine import build_engine
+
+
+@pytest.mark.asyncio
+async def test_sqlite_engine_enables_wal_and_busy_timeout(tmp_sqlite_url):
+    engine = build_engine(tmp_sqlite_url)
+    try:
+        async with engine.connect() as conn:
+            journal_mode = (await conn.execute(text("PRAGMA journal_mode"))).scalar()
+            busy_timeout = (await conn.execute(text("PRAGMA busy_timeout"))).scalar()
+            synchronous = (await conn.execute(text("PRAGMA synchronous"))).scalar()
+        assert journal_mode.lower() == "wal"
+        assert busy_timeout == 30000
+        # 1 = NORMAL (0 = OFF, 2 = FULL).
+        assert synchronous == 1
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writers_do_not_error(tmp_sqlite_url):
+    """Two sessions committing at once must both succeed.
+
+    This failed with "database is locked" before i set WAL and a busy
+    timeout. Now the second writer waits for the first.
+    """
+    import asyncio
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    from packages.db.engine import get_engine
+    from packages.db.models.base import Base
+    from packages.db.models.workspace import Workspace
+
+    engine = get_engine(tmp_sqlite_url)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    async def _write(n: int) -> None:
+        async with factory() as s:
+            s.add(Workspace(id=f"ws-{n}", name=f"ws-{n}", slug=f"ws-{n}"))
+            await s.commit()
+
+    await asyncio.gather(_write(1), _write(2), _write(3), _write(4))
+
+    async with factory() as s:
+        rows = (await s.execute(select(Workspace))).scalars().all()
+        assert {w.id for w in rows} == {"ws-1", "ws-2", "ws-3", "ws-4"}
+
+    from packages.db.engine import dispose_engine
+
+    await dispose_engine()


### PR DESCRIPTION
<!-- orca-cr-summary:start -->
<!-- orca-code-review-summary -->
<!-- orca-cr-state: {"p0":0,"p1":4,"p2":0,"p3":0,"push":4} -->

## Orca-Code-Review — push 4

| Severity | Count | Δ vs previous push |
|---|---|---|
| P0 | 0 | 0 |
| P1 | 4 | +3 |
| P2 | 0 | 0 |
| P3 | 0 | 0 |

❌ 4 findings block merge
<!-- orca-cr-summary:end -->

## Four fixes, each with tests

### 1. Unhandled 500s left no trace (#80)

The catch-all exception handler returned a bare 500 and threw the traceback away — no traceback, no type, no request path. The auth middleware's DB-failure branch did the same with a bare 503. Both now log through structlog with method and path.

Responses stay generic, so nothing leaks to the caller.

### 2. Any key could read and revoke every other key (#74, #70)

`GET /v1/keys` and `DELETE /v1/keys/{id}` didn't filter on `workspace_id`, so a single authenticated key could enumerate and revoke keys across every workspace. Both now scope to the caller.

Separately, `POST /v1/keys` minted new keys with `model_allowlist` and `budget_limit_cents` both NULL — a deliberately restricted key could create itself an unrestricted sibling and escape its own limits. Created keys now inherit the caller's restrictions, so a child key is never less restricted than the key that made it.

### 3. SQLite fell over under concurrent writes (#68)

Stock SQLite runs a DELETE journal with a zero busy timeout, so two overlapping write transactions collided instantly with `database is locked` and surfaced as 500/503. Every SQLite connection now sets `journal_mode=WAL`, `synchronous=NORMAL` and a 5s `busy_timeout` — readers proceed during writes and writers queue instead of erroring. The timeout is deliberately short: it's waited on inside a request, so a 30s wait would pin a worker for 30s and turn one slow write into a pile-up.

WAL persists in the database file, so existing deployments upgrade themselves on first connect.

`create_all` never touches a table that already exists, so the `api_key_id` index added to `requests_log` would never reach a deployment that upgraded. It's now created by hand on boot (`packages/db/schema.py`).

### 4. `budget_limit_cents` was never enforced (#72)

The column existed and was loaded into `KeyContext`, but nothing ever checked it — a leaked key meant unbounded spend on the operator's upstream accounts.

A plain read-then-compare check races: twenty requests arriving together read the same spend total and all pass, so the cap only holds under sequential traffic. Instead, each request reserves its worst-case cost as a row in a new `budget_holds` table, inserted by a single `INSERT..SELECT` whose `WHERE` clause is the cap check — the writer lock makes the second caller see the first one's reservation. The hold is dropped once the real cost is in `requests_log`, and anything abandoned mid-flight expires on a 15-minute TTL so it can't block the key forever.

The reservation is priced from the model catalog, so `"auto"` resolves first and reserves against a real model, and an unpriceable model reserves nothing (its logged cost is 0 too).

`budget_period` is also gone: nothing ever set it to anything but `"monthly"`, so it only pretended to be configurable. The cap is monthly, full stop.

---

## Tests

652 pass locally. New test files:

- `tests/integration/test_observability.py` — unhandled 500 and auth-503 logging
- `tests/integration/test_keys_workspace_scoping.py` — workspace scoping + restriction inheritance
- `tests/unit/test_sqlite_engine_pragmas.py` — WAL, busy timeout, concurrent writers
- `tests/unit/test_runtime_indexes.py` — the index lands on an upgraded database
- `tests/integration/test_budget_enforcement.py` — 429 before upstream, no cap set, and twenty parallel claims against a 1-cent cap (run on real threads — twenty coroutines on one loop just queue, and the race never shows)

---

## Note on CI

`ruff check .` **already fails on `main`** before this branch, from an import-order error in `tests/unit/test_startup_guards.py:131`. That file isn't touched here, so the red CI isn't from these changes.